### PR TITLE
Settings page with theme preference

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-fs": "^2.5.1",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-store": "^2",
         "@uiw/react-codemirror": "^4.25.9",
         "github-markdown-css": "^5.9.0",
         "highlight.js": "^11.11.1",
@@ -323,6 +324,8 @@
     "@tauri-apps/plugin-fs": ["@tauri-apps/plugin-fs@2.5.1", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.4", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ=="],
+
+    "@tauri-apps/plugin-store": ["@tauri-apps/plugin-store@2.4.3", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-9LWPj9yMphRi9czEtUv87XHbl1b6xgd9EXpPrUnq6nG7+nbtoF84d4Kwz9xhAv/Hf30sr58pq7EOlyI936y8qw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-store": "^2",
     "@uiw/react-codemirror": "^4.25.9",
     "github-markdown-css": "^5.9.0",
     "highlight.js": "^11.11.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2025,6 +2025,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-store",
 ]
 
 [[package]]
@@ -3694,6 +3695,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-store"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c72dda16786eb4a3f903e43a17b64d8d78dc0f00fe2aa4b757c28f617a8630b"
+dependencies = [
+ "dunce",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3908,7 +3925,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-store = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 notify = "8"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:event:default",
     "opener:default",
-    "dialog:default"
+    "dialog:default",
+    "store:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -150,9 +150,15 @@ fn build_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
         ..Default::default()
     };
 
+    let app_settings = MenuItemBuilder::with_id("app_settings", "Settings\u{2026}")
+        .accelerator("CmdOrCtrl+,")
+        .build(app)?;
+
     // Slot 0 — macOS treats this as the application menu and substitutes the app name.
     let app_sub = SubmenuBuilder::new(app, "Margin")
         .item(&PredefinedMenuItem::about(app, None, Some(about_md))?)
+        .separator()
+        .item(&app_settings)
         .separator()
         .item(&PredefinedMenuItem::services(app, None)?)
         .separator()
@@ -230,6 +236,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_store::Builder::default().build())
         .menu(build_menu)
         .on_menu_event(handle_menu_event)
         .setup(|app| {

--- a/src/App.css
+++ b/src/App.css
@@ -25,6 +25,87 @@
   --tab-active-border: #30363d;
 }
 
+/* highlight.js github-dark — applied only when our root is in dark mode.
+   Overrides the github (light) theme that's imported globally. */
+[data-theme="dark"] .markdown-body pre,
+[data-theme="dark"] .hljs {
+  background: #161b22;
+  color: #c9d1d9;
+}
+[data-theme="dark"] .hljs-doctag,
+[data-theme="dark"] .hljs-keyword,
+[data-theme="dark"] .hljs-meta .hljs-keyword,
+[data-theme="dark"] .hljs-template-tag,
+[data-theme="dark"] .hljs-template-variable,
+[data-theme="dark"] .hljs-type,
+[data-theme="dark"] .hljs-variable.language_ {
+  color: #ff7b72;
+}
+[data-theme="dark"] .hljs-title,
+[data-theme="dark"] .hljs-title.class_,
+[data-theme="dark"] .hljs-title.class_.inherited__,
+[data-theme="dark"] .hljs-title.function_ {
+  color: #d2a8ff;
+}
+[data-theme="dark"] .hljs-attr,
+[data-theme="dark"] .hljs-attribute,
+[data-theme="dark"] .hljs-literal,
+[data-theme="dark"] .hljs-meta,
+[data-theme="dark"] .hljs-number,
+[data-theme="dark"] .hljs-operator,
+[data-theme="dark"] .hljs-variable,
+[data-theme="dark"] .hljs-selector-attr,
+[data-theme="dark"] .hljs-selector-class,
+[data-theme="dark"] .hljs-selector-id {
+  color: #79c0ff;
+}
+[data-theme="dark"] .hljs-regexp,
+[data-theme="dark"] .hljs-string,
+[data-theme="dark"] .hljs-meta .hljs-string {
+  color: #a5d6ff;
+}
+[data-theme="dark"] .hljs-built_in,
+[data-theme="dark"] .hljs-symbol {
+  color: #ffa657;
+}
+[data-theme="dark"] .hljs-comment,
+[data-theme="dark"] .hljs-code,
+[data-theme="dark"] .hljs-formula {
+  color: #8b949e;
+}
+[data-theme="dark"] .hljs-name,
+[data-theme="dark"] .hljs-quote,
+[data-theme="dark"] .hljs-selector-tag,
+[data-theme="dark"] .hljs-selector-pseudo {
+  color: #7ee787;
+}
+[data-theme="dark"] .hljs-subst {
+  color: #c9d1d9;
+}
+[data-theme="dark"] .hljs-section {
+  color: #1f6feb;
+  font-weight: bold;
+}
+[data-theme="dark"] .hljs-bullet {
+  color: #f2cc60;
+}
+[data-theme="dark"] .hljs-emphasis {
+  color: #c9d1d9;
+  font-style: italic;
+}
+[data-theme="dark"] .hljs-strong {
+  color: #c9d1d9;
+  font-weight: bold;
+}
+[data-theme="dark"] .hljs-addition {
+  color: #aff5b4;
+  background-color: #033a16;
+}
+[data-theme="dark"] .hljs-deletion {
+  color: #ffdcd7;
+  background-color: #67060c;
+}
+
 * {
   box-sizing: border-box;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -201,6 +201,131 @@ body {
   color-scheme: dark;
 }
 
+.settings {
+  height: 100%;
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  overflow: hidden;
+}
+
+.settings-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 16px 8px;
+  border-right: 1px solid var(--border-muted);
+  background: var(--bg-muted);
+  overflow-y: auto;
+}
+
+.settings-nav-item {
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--fg-muted);
+  text-align: left;
+  cursor: pointer;
+}
+
+.settings-nav-item:hover {
+  background: var(--bg);
+  color: var(--fg);
+}
+
+.settings-nav-item.active {
+  background: var(--bg);
+  border-color: var(--border);
+  color: var(--fg);
+  font-weight: 500;
+}
+
+.settings-content {
+  overflow-y: auto;
+  padding: 32px 40px;
+}
+
+.settings-section {
+  max-width: 640px;
+}
+
+.settings-section h2 {
+  margin: 0 0 24px;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.settings-row {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 16px;
+  align-items: start;
+  padding: 12px 0;
+  border-top: 1px solid var(--border-muted);
+}
+
+.settings-row:first-of-type {
+  border-top: none;
+}
+
+.settings-row-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--fg);
+  padding-top: 4px;
+}
+
+.settings-radio-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-radio {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  cursor: pointer;
+  padding: 6px 8px;
+  border-radius: 6px;
+}
+
+.settings-radio:hover {
+  background: var(--bg-muted);
+}
+
+.settings-radio input[type="radio"] {
+  margin: 3px 0 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.settings-radio-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.settings-radio-label {
+  font-size: 13px;
+  color: var(--fg);
+}
+
+.settings-radio-hint {
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+
+.settings-placeholder {
+  font-size: 13px;
+  color: var(--fg-muted);
+  font-style: italic;
+}
+
 .statusbar {
   display: flex;
   align-items: center;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { Editor } from "./Editor";
 import { Preview } from "./Preview";
+import { Settings } from "./Settings";
 import {
   getInitialFile,
   pickFileToOpen,
@@ -12,9 +13,14 @@ import {
   watchFile,
   writeFile,
 } from "./file";
+import { loadSettings, saveSetting, type Theme } from "./settingsStore";
 import "./App.css";
 
-type Mode = "edit" | "preview";
+type Mode = "edit" | "preview" | "settings";
+
+function systemTheme(): "light" | "dark" {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
 
 const WELCOME = `# Welcome to Margin
 
@@ -51,9 +57,10 @@ export default function App() {
   const [tabSize, setTabSize] = useState<number>(2);
   const [useTabs, setUseTabs] = useState<boolean>(false);
   const [softWrap, setSoftWrap] = useState<boolean>(true);
-  const [theme, setTheme] = useState<"light" | "dark">(() =>
-    window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light",
-  );
+  const [themePreference, setThemePreference] = useState<Theme>("system");
+  const [systemAppearance, setSystemAppearance] = useState<"light" | "dark">(systemTheme);
+  const theme: "light" | "dark" =
+    themePreference === "system" ? systemAppearance : themePreference;
 
   const [externalChange, setExternalChange] = useState<{ path: string } | null>(null);
   const [externallyDeleted, setExternallyDeleted] = useState<boolean>(false);
@@ -160,6 +167,9 @@ export default function App() {
         case "view_preview":
           setMode("preview");
           break;
+        case "app_settings":
+          setMode("settings");
+          break;
       }
     });
     return () => {
@@ -221,12 +231,27 @@ export default function App() {
     }
   }, [externalChange]);
 
-  // Track system theme changes
+  // Track system theme changes (always — used when preference is "system")
   useEffect(() => {
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    const handler = (e: MediaQueryListEvent) => setTheme(e.matches ? "dark" : "light");
+    const handler = (e: MediaQueryListEvent) =>
+      setSystemAppearance(e.matches ? "dark" : "light");
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  // Hydrate persisted settings on mount
+  useEffect(() => {
+    loadSettings()
+      .then((s) => setThemePreference(s.theme))
+      .catch((err) => console.error("loadSettings failed:", err));
+  }, []);
+
+  const onThemeChange = useCallback((next: Theme) => {
+    setThemePreference(next);
+    void saveSetting("theme", next).catch((err) =>
+      console.error("saveSetting(theme) failed:", err),
+    );
   }, []);
 
   // Reflect document title
@@ -254,6 +279,14 @@ export default function App() {
             onClick={() => setMode("preview")}
           >
             Preview
+          </button>
+          <button
+            role="tab"
+            aria-selected={mode === "settings"}
+            className={"tab " + (mode === "settings" ? "active" : "")}
+            onClick={() => setMode("settings")}
+          >
+            Settings
           </button>
         </div>
 
@@ -322,7 +355,7 @@ export default function App() {
       )}
 
       <main className="pane">
-        {mode === "edit" ? (
+        {mode === "edit" && (
           <Editor
             value={content}
             onChange={setContent}
@@ -331,8 +364,10 @@ export default function App() {
             softWrap={softWrap}
             theme={theme}
           />
-        ) : (
-          <Preview source={content} theme={theme} />
+        )}
+        {mode === "preview" && <Preview source={content} theme={theme} />}
+        {mode === "settings" && (
+          <Settings theme={themePreference} onThemeChange={onThemeChange} />
         )}
       </main>
 

--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import type { Theme } from "./settingsStore";
+
+type Section = "appearance" | "editor" | "shortcuts";
+
+type SettingsProps = {
+  theme: Theme;
+  onThemeChange: (theme: Theme) => void;
+};
+
+const SECTIONS: { id: Section; label: string }[] = [
+  { id: "appearance", label: "Appearance" },
+  { id: "editor", label: "Editor" },
+  { id: "shortcuts", label: "Shortcuts" },
+];
+
+const THEME_OPTIONS: { value: Theme; label: string; hint: string }[] = [
+  { value: "system", label: "System", hint: "Match the macOS appearance" },
+  { value: "light", label: "Light", hint: "Always use the light theme" },
+  { value: "dark", label: "Dark", hint: "Always use the dark theme" },
+];
+
+export function Settings({ theme, onThemeChange }: SettingsProps) {
+  const [active, setActive] = useState<Section>("appearance");
+
+  return (
+    <div className="settings">
+      <nav className="settings-nav" aria-label="Settings sections">
+        {SECTIONS.map((s) => (
+          <button
+            key={s.id}
+            className={"settings-nav-item " + (active === s.id ? "active" : "")}
+            onClick={() => setActive(s.id)}
+            aria-current={active === s.id ? "page" : undefined}
+          >
+            {s.label}
+          </button>
+        ))}
+      </nav>
+
+      <div className="settings-content">
+        {active === "appearance" && (
+          <section className="settings-section">
+            <h2>Appearance</h2>
+
+            <div className="settings-row">
+              <div className="settings-row-label">Theme</div>
+              <div className="settings-radio-group" role="radiogroup" aria-label="Theme">
+                {THEME_OPTIONS.map((opt) => (
+                  <label key={opt.value} className="settings-radio">
+                    <input
+                      type="radio"
+                      name="theme"
+                      value={opt.value}
+                      checked={theme === opt.value}
+                      onChange={() => onThemeChange(opt.value)}
+                    />
+                    <span className="settings-radio-text">
+                      <span className="settings-radio-label">{opt.label}</span>
+                      <span className="settings-radio-hint">{opt.hint}</span>
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </section>
+        )}
+
+        {active === "editor" && (
+          <section className="settings-section">
+            <h2>Editor</h2>
+            <p className="settings-placeholder">Editor preferences coming soon.</p>
+          </section>
+        )}
+
+        {active === "shortcuts" && (
+          <section className="settings-section">
+            <h2>Shortcuts</h2>
+            <p className="settings-placeholder">Keyboard shortcut customization coming soon.</p>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/settingsStore.ts
+++ b/src/settingsStore.ts
@@ -1,0 +1,43 @@
+import { LazyStore } from "@tauri-apps/plugin-store";
+
+export type Theme = "system" | "light" | "dark";
+
+export type AppSettings = {
+  theme: Theme;
+};
+
+export const DEFAULT_SETTINGS: AppSettings = {
+  theme: "system",
+};
+
+const STORE_FILE = "settings.json";
+
+let store: LazyStore | null = null;
+
+function getStore(): LazyStore {
+  if (!store) {
+    store = new LazyStore(STORE_FILE);
+  }
+  return store;
+}
+
+function isTheme(value: unknown): value is Theme {
+  return value === "system" || value === "light" || value === "dark";
+}
+
+export async function loadSettings(): Promise<AppSettings> {
+  const s = getStore();
+  const theme = await s.get<Theme>("theme");
+  return {
+    theme: isTheme(theme) ? theme : DEFAULT_SETTINGS.theme,
+  };
+}
+
+export async function saveSetting<K extends keyof AppSettings>(
+  key: K,
+  value: AppSettings[K],
+): Promise<void> {
+  const s = getStore();
+  await s.set(key, value);
+  await s.save();
+}


### PR DESCRIPTION
## Summary
Two commits on this branch:

1. **a68f7be** (your commit) — Settings page with theme preference (System / Light / Dark), persisted via `tauri-plugin-store`. Adds a new menu item to open Settings.
2. **fff7938** (rebase fix) — Apply github-dark highlight.js colors when `data-theme=dark`. The preview was importing only the light hljs theme, so code blocks rendered light-on-light in dark mode. Code-block bg uses `#161b22` (canvas-subtle) for visual contrast against the page bg.

Rebased cleanly onto current main (one trivial conflict in App.tsx around the system-theme effect, resolved keeping both the watcher block and the more descriptive comment).

## Test plan
- [ ] Settings page opens via menu; theme switching is immediate
- [ ] Theme persists across app restart
- [ ] Code blocks look right in both light and dark
- [ ] Existing features (⌘O/S/E/P, file watcher banner, drag) still work