### PR TITLE
Global search command palette (#31)

### DIFF
--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -12,8 +12,9 @@
 //!
 //! See `src/migrations/001_init.sql` for the schema.
 //!
-//! Out of scope here: `notes_fts` is populated but no search command
-//! exists yet; that lands with #31.
+//! Search (#31) is exposed via `search_notes`: FTS5 over title+body
+//! against `notes_fts` plus a per-bundle `transcript.json` substring scan
+//! merged into the same ranked result list.
 
 use std::collections::HashMap;
 use std::fs;
@@ -21,6 +22,7 @@ use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
 use rusqlite::{params, Connection, OptionalExtension, Result, Transaction};
+use serde::Serialize;
 
 use crate::notes::{
     action_id, bundle_dir_for_in, extract_preview, parse_actions, parse_frontmatter,
@@ -237,6 +239,368 @@ pub fn list_actions(
         out.push(row?);
     }
     Ok(out)
+}
+
+/// One ranked hit from `search_notes`. `source` carries which surface
+/// the match came from so the UI can label rows ("Title", "Body",
+/// "Transcript"). `snippet` is a short window around the match — already
+/// truncated, ready to render.
+#[derive(Serialize, Clone)]
+pub struct SearchHit {
+    pub note_path: String,
+    pub bundle_id: String,
+    pub title: String,
+    pub modified_ms: i64,
+    pub snippet: String,
+    pub source: SearchSource,
+    /// Lower is better (mirrors SQLite's bm25). Transcript hits get a
+    /// synthetic score so they slot in alongside FTS rows.
+    pub score: f64,
+}
+
+#[derive(Serialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SearchSource {
+    Title,
+    Body,
+    Transcript,
+}
+
+const SEARCH_SNIPPET_OPEN: &str = "\u{2068}";
+const SEARCH_SNIPPET_CLOSE: &str = "\u{2069}";
+const SEARCH_TRANSCRIPT_WINDOW: usize = 80;
+
+/// Combined FTS + transcript search. Excludes archived notes (mirrors the
+/// `Active` scope in `list_all`). Caller picks the per-source caps via
+/// `limit`; total results = `limit` (FTS hits favored, transcript hits
+/// fill the remainder).
+pub fn search_notes(
+    conn: &Connection,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<SearchHit>> {
+    let trimmed = query.trim();
+    if trimmed.is_empty() || limit == 0 {
+        return Ok(Vec::new());
+    }
+    let cap = limit.min(50);
+
+    let fts_query = match build_fts_query(trimmed) {
+        Some(q) => q,
+        None => return Ok(Vec::new()),
+    };
+
+    let mut hits: Vec<SearchHit> = Vec::new();
+    let mut seen_paths: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+
+    // FTS pass — pull bm25() and a body snippet in one go. JOIN on
+    // `notes` to drop archived rows and to fetch the canonical title /
+    // mtime / bundle_id (the FTS row's `title` is duplicated for ranking
+    // purposes; `notes.title` is the source-of-truth).
+    let fts_sql = "\
+        SELECT n.note_path, n.bundle_id, n.title, n.modified_ms, \
+               snippet(notes_fts, 2, ?2, ?3, '…', 12) AS body_snip, \
+               bm25(notes_fts) AS score \
+        FROM notes_fts \
+        JOIN notes n ON n.note_path = notes_fts.note_path \
+        WHERE notes_fts MATCH ?1 AND n.archived = 0 \
+        ORDER BY score ASC \
+        LIMIT ?4";
+    let mut stmt = conn.prepare(fts_sql)?;
+    let rows = stmt.query_map(
+        params![
+            &fts_query,
+            SEARCH_SNIPPET_OPEN,
+            SEARCH_SNIPPET_CLOSE,
+            cap as i64,
+        ],
+        |r| {
+            Ok(FtsRow {
+                note_path: r.get(0)?,
+                bundle_id: r.get(1)?,
+                title: r.get(2)?,
+                modified_ms: r.get(3)?,
+                body_snip: r.get(4)?,
+                score: r.get(5)?,
+            })
+        },
+    )?;
+
+    let needle_lc = trimmed.to_lowercase();
+    for row in rows {
+        let row = row?;
+        let title_lc = row.title.to_lowercase();
+        let (source, snippet) = if title_lc.contains(&needle_lc) {
+            (SearchSource::Title, row.title.clone())
+        } else {
+            (SearchSource::Body, row.body_snip.clone())
+        };
+        seen_paths.insert(row.note_path.clone());
+        hits.push(SearchHit {
+            note_path: row.note_path,
+            bundle_id: row.bundle_id,
+            title: row.title,
+            modified_ms: row.modified_ms,
+            snippet,
+            source,
+            score: row.score,
+        });
+    }
+
+    // Transcript pass — we need the user's notes dir, but `index.rs`
+    // doesn't take it as a parameter elsewhere. Use `paths::notes_dir()`
+    // for symmetry with `upsert`. Walk every non-archived bundle whose
+    // path we haven't already surfaced and substring-scan the segments.
+    if hits.len() < cap {
+        let archived_paths: std::collections::HashSet<String> = {
+            let mut stmt = conn
+                .prepare("SELECT note_path FROM notes WHERE archived = 1")?;
+            let rows = stmt.query_map([], |r| r.get::<_, String>(0))?;
+            let mut set = std::collections::HashSet::new();
+            for r in rows {
+                set.insert(r?);
+            }
+            set
+        };
+        let titles_by_path: HashMap<String, (String, String, i64)> = {
+            let mut stmt = conn.prepare(
+                "SELECT note_path, bundle_id, title, modified_ms FROM notes \
+                 WHERE archived = 0",
+            )?;
+            let rows = stmt.query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, i64>(3)?,
+                ))
+            })?;
+            let mut map = HashMap::new();
+            for row in rows {
+                let (p, b, t, m) = row?;
+                map.insert(p, (b, t, m));
+            }
+            map
+        };
+
+        let remaining = cap - hits.len();
+        let transcript_hits = scan_transcripts(
+            &paths::notes_dir(),
+            trimmed,
+            &seen_paths,
+            &archived_paths,
+            &titles_by_path,
+            remaining,
+        );
+        hits.extend(transcript_hits);
+    }
+
+    Ok(hits)
+}
+
+struct FtsRow {
+    note_path: String,
+    bundle_id: String,
+    title: String,
+    modified_ms: i64,
+    body_snip: String,
+    score: f64,
+}
+
+/// Translate user input into an FTS5 MATCH expression. Each
+/// whitespace-separated token becomes a quoted prefix term so the query
+/// never trips on FTS5 operators (`AND`, `NOT`, `*`, `:` etc) the user
+/// happened to type. Returns `None` when the input has no usable tokens
+/// (e.g. punctuation-only input).
+fn build_fts_query(input: &str) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    for raw in input.split_whitespace() {
+        let cleaned: String = raw
+            .chars()
+            .filter(|c| c.is_alphanumeric() || *c == '\'' || *c == '-' || *c == '_')
+            .collect();
+        if cleaned.is_empty() {
+            continue;
+        }
+        let escaped = cleaned.replace('"', "\"\"");
+        parts.push(format!("\"{escaped}\"*"));
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" "))
+    }
+}
+
+fn scan_transcripts(
+    notes_dir: &Path,
+    needle: &str,
+    seen_paths: &std::collections::HashSet<String>,
+    archived_paths: &std::collections::HashSet<String>,
+    titles_by_path: &HashMap<String, (String, String, i64)>,
+    limit: usize,
+) -> Vec<SearchHit> {
+    if limit == 0 {
+        return Vec::new();
+    }
+    let needle_lc = needle.to_lowercase();
+    let mut out: Vec<SearchHit> = Vec::new();
+
+    let read_dir = match fs::read_dir(notes_dir) {
+        Ok(r) => r,
+        Err(_) => return out,
+    };
+    for entry in read_dir.flatten() {
+        if out.len() >= limit {
+            break;
+        }
+        let bundle = entry.path();
+        if !bundle.is_dir() {
+            continue;
+        }
+        let note_path = bundle.join(NOTE_FILENAME);
+        let note_path_str = note_path.to_string_lossy().into_owned();
+        if seen_paths.contains(&note_path_str)
+            || archived_paths.contains(&note_path_str)
+        {
+            continue;
+        }
+        let transcript_path = bundle.join(TRANSCRIPT_FILENAME);
+        if !transcript_path.exists() {
+            continue;
+        }
+        let raw = match fs::read_to_string(&transcript_path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        // Cheap filter before parsing JSON — most transcripts won't
+        // contain the needle at all.
+        if !raw.to_lowercase().contains(&needle_lc) {
+            continue;
+        }
+        let parsed: serde_json::Value = match serde_json::from_str(&raw) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let segments = match parsed.get("segments").and_then(|s| s.as_array()) {
+            Some(s) => s,
+            None => continue,
+        };
+        let mut snippet: Option<String> = None;
+        for seg in segments {
+            let text = seg.get("text").and_then(|t| t.as_str()).unwrap_or("");
+            if let Some((start, end)) = find_ci(text, &needle_lc) {
+                snippet = Some(transcript_snippet(text, start, end));
+                break;
+            }
+        }
+        let snippet = match snippet {
+            Some(s) => s,
+            None => continue,
+        };
+        let (bundle_id, title, modified_ms) = match titles_by_path.get(&note_path_str) {
+            Some(v) => v.clone(),
+            None => continue,
+        };
+        out.push(SearchHit {
+            note_path: note_path_str,
+            bundle_id,
+            title,
+            modified_ms,
+            snippet,
+            source: SearchSource::Transcript,
+            // Transcript hits rank below FTS rows. bm25 returns negative
+            // scores for stronger matches — pick a positive value to
+            // place transcripts at the end deterministically.
+            score: 1.0,
+        });
+    }
+    out
+}
+
+/// Case-insensitive substring search returning a `(start, end)` byte
+/// range in `haystack` aligned to char boundaries. `needle_lc` must
+/// already be lowercase. Returns `None` if no match.
+fn find_ci(haystack: &str, needle_lc: &str) -> Option<(usize, usize)> {
+    let needle_chars: Vec<char> = needle_lc.chars().collect();
+    if needle_chars.is_empty() {
+        return None;
+    }
+    let hay: Vec<(usize, char)> = haystack.char_indices().collect();
+    if hay.len() < needle_chars.len() {
+        return None;
+    }
+    'outer: for i in 0..=hay.len() - needle_chars.len() {
+        for (k, n) in needle_chars.iter().enumerate() {
+            // Compare via single-char lowercase folding. This matches
+            // ASCII and most Latin scripts; specialty cases like ß→SS
+            // (which lowercases to two chars) won't align, and we
+            // accept the false negative for v1.
+            let lc = hay[i + k].1.to_lowercase().next().unwrap_or(hay[i + k].1);
+            if lc != *n {
+                continue 'outer;
+            }
+        }
+        let start = hay[i].0;
+        let end_idx = i + needle_chars.len();
+        let end = if end_idx < hay.len() {
+            hay[end_idx].0
+        } else {
+            haystack.len()
+        };
+        return Some((start, end));
+    }
+    None
+}
+
+/// Build a `…pre[needle]post…` snippet with bidirectional isolate marks
+/// around the match. `start`/`end` are byte offsets into `text`; both
+/// must be on char boundaries.
+fn transcript_snippet(text: &str, start: usize, end: usize) -> String {
+    let half = SEARCH_TRANSCRIPT_WINDOW / 2;
+
+    let pre_byte = char_offset_back(&text[..start], half);
+    let post_byte_rel = char_offset_forward(&text[end..], half);
+    let post_byte = end + post_byte_rel;
+
+    let mut snip = String::new();
+    if pre_byte > 0 {
+        snip.push('…');
+    }
+    snip.push_str(text[pre_byte..start].trim_start());
+    snip.push_str(SEARCH_SNIPPET_OPEN);
+    snip.push_str(&text[start..end]);
+    snip.push_str(SEARCH_SNIPPET_CLOSE);
+    snip.push_str(text[end..post_byte].trim_end());
+    if post_byte < text.len() {
+        snip.push('…');
+    }
+    snip
+}
+
+/// Byte index `n_chars` chars before the end of `prefix`, or 0 if
+/// `prefix` is shorter than that.
+fn char_offset_back(prefix: &str, n_chars: usize) -> usize {
+    let total = prefix.chars().count();
+    if total <= n_chars {
+        return 0;
+    }
+    prefix
+        .char_indices()
+        .nth(total - n_chars)
+        .map(|(i, _)| i)
+        .unwrap_or(0)
+}
+
+/// Byte index `n_chars` chars into `suffix`, or `suffix.len()` if
+/// `suffix` is shorter than that.
+fn char_offset_forward(suffix: &str, n_chars: usize) -> usize {
+    suffix
+        .char_indices()
+        .nth(n_chars)
+        .map(|(i, _)| i)
+        .unwrap_or(suffix.len())
 }
 
 #[derive(Default)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -491,6 +491,7 @@ pub fn run() {
             notes::duplicate_note,
             notes::is_owned_note,
             notes::list_notes,
+            notes::search_notes,
             notes::note_meta,
             notes::discard_recording,
             notes::delete_note,

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -253,6 +253,21 @@ pub fn list_notes(
     crate::index::list_all(&c, scope.unwrap_or_default()).map_err(|e| e.to_string())
 }
 
+/// Search across all non-archived owned notes (titles + bodies via the
+/// FTS5 index, plus per-bundle transcript.json segments). Returns a
+/// ranked list of `SearchHit`s. `limit` defaults to 20 and is clamped
+/// to 50 by the index layer.
+#[tauri::command]
+pub fn search_notes(
+    query: String,
+    limit: Option<usize>,
+    conn: tauri::State<'_, std::sync::Mutex<rusqlite::Connection>>,
+) -> Result<Vec<crate::index::SearchHit>, String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    crate::index::search_notes(&c, &query, limit.unwrap_or(20))
+        .map_err(|e| e.to_string())
+}
+
 /// Return action items across all non-archived owned notes, scoped to
 /// open / done / all. Default `Open`. Joins on the notes table for the
 /// source note's title. When `assignee_id` is set, the result is

--- a/src/App.css
+++ b/src/App.css
@@ -941,12 +941,16 @@ select.settings-input {
   display: flex;
   align-items: center;
   gap: 8px;
+  width: 100%;
   height: 30px;
   padding: 0 10px;
   background: var(--bg);
+  border: none;
   border-radius: 9px;
   box-shadow: inset 0 0 0 0.5px var(--home-line-strong);
   color: var(--fg-muted);
+  font: inherit;
+  text-align: left;
   cursor: pointer;
   user-select: none;
   transition: background 120ms ease;
@@ -3625,4 +3629,182 @@ input.nh-title {
   color: var(--fg-muted);
   align-self: flex-start;
   margin-top: 2px;
+}
+
+/* ----- Search command palette (#31) ----- */
+
+.palette-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 14vh;
+  background: color-mix(in srgb, var(--fg) 18%, transparent);
+  backdrop-filter: blur(2px);
+  animation: palette-backdrop-in 100ms ease-out;
+}
+
+@keyframes palette-backdrop-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes palette-dialog-in {
+  from { opacity: 0; transform: translateY(-6px) scale(0.985); }
+  to { opacity: 1; transform: none; }
+}
+
+.palette-dialog {
+  width: min(560px, calc(100vw - 32px));
+  max-height: min(560px, calc(100vh - 28vh));
+  display: flex;
+  flex-direction: column;
+  border-radius: 12px;
+  border: 0.5px solid var(--home-line);
+  background: var(--bg);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.22),
+    0 8px 16px rgba(0, 0, 0, 0.10);
+  overflow: hidden;
+  animation: palette-dialog-in 120ms ease-out;
+}
+
+.palette-input-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 0.5px solid var(--home-line);
+}
+
+.palette-input-icon {
+  display: inline-flex;
+  color: var(--fg-muted);
+}
+
+.palette-input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  font-size: 14px;
+  padding: 2px 0;
+}
+
+.palette-input::placeholder {
+  color: var(--fg-muted);
+}
+
+.palette-input-kbd {
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--fg-muted);
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--home-chip);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.palette-results {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.palette-empty {
+  padding: 22px 18px;
+  text-align: center;
+  color: var(--fg-muted);
+  font-size: 12.5px;
+}
+
+.palette-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 14px;
+  cursor: pointer;
+  font-size: 12.5px;
+  color: var(--fg);
+}
+
+.palette-row.active {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.palette-row-icon {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 1px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--fg) 6%, transparent);
+  color: var(--fg-muted);
+}
+
+.palette-row.active .palette-row-icon {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: var(--accent);
+}
+
+.palette-row-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.palette-row-title {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.palette-row-snippet {
+  color: var(--fg-muted);
+  font-size: 11.5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.palette-row-tag {
+  flex-shrink: 0;
+  align-self: flex-start;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--home-chip);
+  color: var(--fg-muted);
+  margin-top: 3px;
+}
+
+.palette-row-tag.tag-title {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
+}
+
+.palette-row-tag.tag-transcript {
+  background: color-mix(in srgb, #c44a1f 14%, transparent);
+  color: #c44a1f;
+}
+
+.palette-highlight {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  color: var(--fg);
+  border-radius: 2px;
+  padding: 0 1px;
 }

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -7,6 +7,7 @@ import { avatarColor } from "./initials";
 import { MoreMenu } from "./MoreMenu";
 import { type NotificationRecord, unreadCount } from "./notifications";
 import { NotificationsPanel } from "./NotificationsPanel";
+import { SearchPalette } from "./SearchPalette";
 import { TeamView, type EditorSettings as TeamEditorSettings } from "./Team";
 import {
   IconArchive,
@@ -132,7 +133,23 @@ export function Home({
     scope === "archived" ? "archive" : scope === "favorites" ? "favorites" : "home",
   );
   const [panelOpen, setPanelOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
   const unreadBadge = useMemo(() => unreadCount(notifications), [notifications]);
+
+  // Global ⌘K / Ctrl+K to open the search palette. Capture phase so the
+  // editor's Cmd+K (link insert, etc.) doesn't swallow it first.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && (e.key === "k" || e.key === "K")) {
+        e.preventDefault();
+        e.stopPropagation();
+        setPaletteOpen(true);
+      }
+    };
+    window.addEventListener("keydown", onKey, { capture: true });
+    return () => window.removeEventListener("keydown", onKey, { capture: true } as EventListenerOptions);
+  }, []);
 
   // Map sidebar nav → backend scope. Only home, archive, and favorites
   // currently map to scopes; the other nav items are placeholders.
@@ -200,6 +217,14 @@ export function Home({
 
   return (
     <div className={"home" + (sidebarOpen ? "" : " home-collapsed")}>
+      <SearchPalette
+        open={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        onOpenNote={(p) => {
+          setPaletteOpen(false);
+          onOpen(p);
+        }}
+      />
       {sidebarOpen && (
         <Sidebar
           active={nav}
@@ -210,6 +235,7 @@ export function Home({
           activeTag={tagFilter}
           onTagSelect={(t) => setTagFilter(t === tagFilter ? null : t)}
           onOpenSettings={onOpenSettings}
+          onOpenPalette={() => setPaletteOpen(true)}
         />
       )}
       <div className="home-main">
@@ -323,6 +349,7 @@ function Sidebar({
   activeTag,
   onTagSelect,
   onOpenSettings,
+  onOpenPalette,
 }: {
   active: NavId;
   onSelect: (id: NavId) => void;
@@ -332,21 +359,24 @@ function Sidebar({
   activeTag: string | null;
   onTagSelect: (tag: string) => void;
   onOpenSettings: () => void;
+  onOpenPalette: () => void;
 }) {
   return (
     <aside className="home-sidebar">
       <div className="home-titlebar" data-tauri-drag-region />
       <div className="home-search-wrap">
-        <div
+        <button
+          type="button"
           className="home-search"
           data-tauri-drag-region="false"
-          title="Search — coming soon (issue #31)"
-          onClick={() => stub("Search", 31)}
+          title="Search notes (⌘K)"
+          aria-label="Search notes"
+          onClick={onOpenPalette}
         >
           <IconSearch size={13} sw={1.8} />
           <span className="home-search-placeholder">Search notes…</span>
           <span className="home-search-kbd">⌘K</span>
-        </div>
+        </button>
       </div>
 
       <nav className="home-nav">

--- a/src/SearchPalette.tsx
+++ b/src/SearchPalette.tsx
@@ -1,0 +1,282 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  searchNotes,
+  SEARCH_HIGHLIGHT_CLOSE,
+  SEARCH_HIGHLIGHT_OPEN,
+  type SearchHit,
+} from "./file";
+import { IconFileText, IconMic, IconSearch } from "./icons";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onOpenNote: (path: string) => void;
+};
+
+const QUERY_DEBOUNCE_MS = 120;
+
+/// ⌘K command palette. Backed by `search_notes` (FTS over title+body
+/// plus per-bundle transcript scan). The palette stays mounted while
+/// `open` to preserve input/result state across rapid open/close
+/// cycles, but resets state on the open→close edge.
+export function SearchPalette({ open, onClose, onOpenNote }: Props) {
+  const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<SearchHit[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  // Generation counter so out-of-order search responses can't overwrite
+  // newer results when a slow query resolves after a faster one.
+  const queryGen = useRef(0);
+
+  // Reset on close so the next open starts fresh. Focus the input on
+  // open so the user can type immediately.
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setHits([]);
+      setLoading(false);
+      setActiveIdx(0);
+      return;
+    }
+    inputRef.current?.focus();
+  }, [open]);
+
+  // Debounced search. Empty query clears results without a round-trip.
+  useEffect(() => {
+    if (!open) return;
+    const trimmed = query.trim();
+    if (trimmed.length === 0) {
+      setHits([]);
+      setLoading(false);
+      setActiveIdx(0);
+      return;
+    }
+    const gen = ++queryGen.current;
+    setLoading(true);
+    const timer = window.setTimeout(async () => {
+      try {
+        const results = await searchNotes(trimmed, 20);
+        if (queryGen.current !== gen) return;
+        setHits(results);
+        setActiveIdx(0);
+      } catch (err) {
+        if (queryGen.current !== gen) return;
+        console.error("[search] failed:", err);
+        setHits([]);
+      } finally {
+        if (queryGen.current === gen) setLoading(false);
+      }
+    }, QUERY_DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [open, query]);
+
+  // Outside-click + Escape dismissal. Stop propagation on the dialog
+  // itself so the global mousedown listener doesn't fire when the user
+  // clicks inside.
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node | null;
+      if (dialogRef.current && target && dialogRef.current.contains(target)) return;
+      onClose();
+    };
+    window.addEventListener("mousedown", onMouseDown);
+    return () => window.removeEventListener("mousedown", onMouseDown);
+  }, [open, onClose]);
+
+  // Scroll the active row into view when navigating with arrow keys.
+  useEffect(() => {
+    if (!listRef.current) return;
+    const row = listRef.current.querySelector<HTMLElement>(
+      `[data-row-idx="${activeIdx}"]`,
+    );
+    row?.scrollIntoView({ block: "nearest" });
+  }, [activeIdx, hits]);
+
+  if (!open) return null;
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+      return;
+    }
+    if (hits.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIdx((i) => Math.min(i + 1, hits.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const hit = hits[activeIdx];
+      if (hit) {
+        onOpenNote(hit.note_path);
+        onClose();
+      }
+    }
+  };
+
+  return (
+    <div
+      className="palette-backdrop"
+      role="presentation"
+      onMouseDown={(e) => {
+        // Click on the backdrop dismisses; click on the dialog does
+        // not (the dialog stops propagation below).
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        className="palette-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search notes"
+        onKeyDown={onKeyDown}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="palette-input-row">
+          <span className="palette-input-icon" aria-hidden="true">
+            <IconSearch size={14} sw={1.7} />
+          </span>
+          <input
+            ref={inputRef}
+            type="text"
+            className="palette-input"
+            placeholder="Search notes…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            spellCheck={false}
+            autoCorrect="off"
+            autoCapitalize="off"
+          />
+          <span className="palette-input-kbd">esc</span>
+        </div>
+        <div className="palette-results" ref={listRef} role="listbox">
+          {query.trim().length === 0 ? (
+            <div className="palette-empty">
+              Type to search across all your notes — titles, bodies, and
+              meeting transcripts.
+            </div>
+          ) : loading && hits.length === 0 ? (
+            <div className="palette-empty">Searching…</div>
+          ) : hits.length === 0 ? (
+            <div className="palette-empty">No matches.</div>
+          ) : (
+            hits.map((hit, idx) => (
+              <ResultRow
+                key={hit.note_path + ":" + hit.source}
+                hit={hit}
+                active={idx === activeIdx}
+                idx={idx}
+                onMouseEnter={() => setActiveIdx(idx)}
+                onClick={() => {
+                  onOpenNote(hit.note_path);
+                  onClose();
+                }}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ResultRow({
+  hit,
+  active,
+  idx,
+  onMouseEnter,
+  onClick,
+}: {
+  hit: SearchHit;
+  active: boolean;
+  idx: number;
+  onMouseEnter: () => void;
+  onClick: () => void;
+}) {
+  return (
+    <div
+      role="option"
+      aria-selected={active}
+      data-row-idx={idx}
+      className={"palette-row" + (active ? " active" : "")}
+      onMouseEnter={onMouseEnter}
+      onClick={onClick}
+    >
+      <span className="palette-row-icon" aria-hidden="true">
+        {hit.source === "transcript" ? (
+          <IconMic size={13} sw={1.6} />
+        ) : (
+          <IconFileText size={13} sw={1.6} />
+        )}
+      </span>
+      <span className="palette-row-body">
+        <span className="palette-row-title">
+          <Highlighted text={hit.title} />
+        </span>
+        <span className="palette-row-snippet">
+          <Highlighted text={hit.snippet} />
+        </span>
+      </span>
+      <span className={"palette-row-tag tag-" + hit.source}>
+        {labelFor(hit.source)}
+      </span>
+    </div>
+  );
+}
+
+function labelFor(source: SearchHit["source"]): string {
+  if (source === "title") return "Title";
+  if (source === "body") return "Body";
+  return "Transcript";
+}
+
+/// Render text containing the U+2068/U+2069 isolate marks the Rust side
+/// uses to delimit the matched span. Falls back to plain text if the
+/// marks are absent or unbalanced.
+function Highlighted({ text }: { text: string }) {
+  const parts = useMemo(() => splitHighlights(text), [text]);
+  return (
+    <>
+      {parts.map((p, i) =>
+        p.match ? (
+          <mark key={i} className="palette-highlight">
+            {p.text}
+          </mark>
+        ) : (
+          <span key={i}>{p.text}</span>
+        ),
+      )}
+    </>
+  );
+}
+
+function splitHighlights(text: string): { text: string; match: boolean }[] {
+  const out: { text: string; match: boolean }[] = [];
+  let i = 0;
+  while (i < text.length) {
+    const open = text.indexOf(SEARCH_HIGHLIGHT_OPEN, i);
+    if (open === -1) {
+      out.push({ text: text.slice(i), match: false });
+      break;
+    }
+    if (open > i) out.push({ text: text.slice(i, open), match: false });
+    const close = text.indexOf(SEARCH_HIGHLIGHT_CLOSE, open + 1);
+    if (close === -1) {
+      // Unbalanced — render remainder verbatim, marks included.
+      out.push({ text: text.slice(open), match: false });
+      break;
+    }
+    out.push({ text: text.slice(open + 1, close), match: true });
+    i = close + 1;
+  }
+  return out;
+}

--- a/src/file.ts
+++ b/src/file.ts
@@ -187,6 +187,30 @@ export async function listNotes(scope: NoteScope = "active"): Promise<NoteListIt
   return invoke<NoteListItem[]>("list_notes", { scope });
 }
 
+// --- Search (#31) --------------------------------------------------------
+
+export type SearchSource = "title" | "body" | "transcript";
+
+/** One ranked result from `search_notes`. The Rust side wraps the matched
+ *  span in U+2068 / U+2069 (FSI/PDI) inside `snippet` so the UI can split
+ *  on those marks to render the highlight without HTML round-tripping. */
+export type SearchHit = {
+  note_path: string;
+  bundle_id: string;
+  title: string;
+  modified_ms: number;
+  snippet: string;
+  source: SearchSource;
+  score: number;
+};
+
+export const SEARCH_HIGHLIGHT_OPEN = "\u{2068}";
+export const SEARCH_HIGHLIGHT_CLOSE = "\u{2069}";
+
+export async function searchNotes(query: string, limit = 20): Promise<SearchHit[]> {
+  return invoke<SearchHit[]>("search_notes", { query, limit });
+}
+
 export type NoteMeta = { modified_ms: number };
 
 export async function noteMeta(notePath: string): Promise<NoteMeta> {


### PR DESCRIPTION
## Summary
- ⌘K-triggered command palette searching titles, bodies, and meeting transcripts
- Title+body via existing FTS5 `notes_fts` (incrementally maintained on `upsert`); transcript hits via per-bundle substring scan over `transcript.json`, deduped against FTS results
- Sidebar search input now triggers the palette; global ⌘K/Ctrl+K bound in capture phase so the editor's Cmd+K can't swallow it
- Debounced query, keyboard nav (↑/↓/Enter/Esc), and a generation counter to discard out-of-order responses

Closes #31.

## Test plan
- [ ] Open the palette via the sidebar search button and via ⌘K
- [ ] Type a query that matches a title, a body, and a transcript — confirm all three sources appear with the right tag chip
- [ ] Use ↑/↓ to navigate, Enter to open the highlighted note, Esc to dismiss
- [ ] Click outside the dialog to dismiss
- [ ] Confirm archived notes don't appear in results
- [ ] Type FTS5 operator characters (`AND`, `*`, `:`, `"`) and verify no syntax error