### PR TITLE
AI ask palette with tool use (#31 follow-up)

### DIFF
--- a/src-tauri/src/ask.rs
+++ b/src-tauri/src/ask.rs
@@ -1,0 +1,1035 @@
+//! AI-powered Q&A over the user's notes (#31 follow-up).
+//!
+//! The search palette can escalate a query to "Ask" mode (Cmd+Enter). We
+//! retrieve top-N candidate notes via the existing FTS index, build a
+//! prompt with labeled excerpts, and stream Anthropic's response back to
+//! the frontend as `ai-stream` events. The model is instructed to cite
+//! sources via `[N]` markers; the frontend renders those as clickable
+//! chips that open the underlying note.
+//!
+//! Tool use: the model can mid-stream invoke `read_note(n)` and
+//! `read_transcript(n)` to pull the full body or transcript of a
+//! directory entry beyond what we preloaded. We stream-parse SSE,
+//! accumulate input_json across deltas per content block, dispatch each
+//! tool call, append the result to messages[], and re-POST. Outer loop
+//! iterates until the model returns a non-tool stop_reason or we hit
+//! `MAX_TOOL_ITERATIONS`.
+//!
+//! Streaming: SSE events are forwarded to the frontend as `Delta` for
+//! text and `ToolUseStart`/`ToolUseDone` for tool calls. Errors at any
+//! stage emit a single `Error` event with a user-facing message.
+
+use std::path::PathBuf;
+
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::{index::DirectoryEntry, keychain};
+
+const ENDPOINT: &str = "https://api.anthropic.com/v1/messages";
+const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const MAX_TOKENS: u32 = 2048;
+
+/// Top-K retrieved notes whose full body is loaded into the prompt.
+const RETRIEVAL_K: usize = 12;
+/// Cap on the "all notes directory" entries (title + date + preview).
+/// Plenty for personal use; if a user has more, the directory becomes
+/// recency-biased — deep matches still surface via retrieval.
+const DIRECTORY_CAP: usize = 200;
+/// Per-retrieved-note full-body excerpt cap (characters). Keeps the
+/// "deep" section of the prompt bounded.
+const PER_NOTE_BODY_CAP: usize = 2000;
+/// Per-team-member profile excerpt cap (characters).
+const PER_PROFILE_CAP: usize = 1500;
+/// Per-directory-entry preview cap (characters). The DB already stores
+/// a short preview; this is a safety belt.
+const PER_PREVIEW_CAP: usize = 200;
+/// Per-transcript tool call cap (characters). Transcripts can be tens
+/// of thousands of words; we truncate to keep token budget bounded.
+const TRANSCRIPT_CHARS_CAP: usize = 3000;
+/// Max tool-use round-trips per turn before we force the model to
+/// answer with what it has. Guards against runaway tool loops.
+const MAX_TOOL_ITERATIONS: u32 = 6;
+
+/// Emitted on the unified `ai-stream` channel. The frontend filters by
+/// `turn_id` so a stale stream that arrives after the user navigates
+/// away can't corrupt the active conversation.
+///
+/// Event ordering: one `Sources` first, then any number of `Delta` /
+/// `ToolUseStart` / `ToolUseDone` interleaved (in the order the model
+/// emits text vs tool calls), then one terminal `Done` or `Error`.
+#[derive(Serialize, Clone)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum StreamEvent {
+    Sources {
+        turn_id: String,
+        sources: Vec<AskSource>,
+    },
+    Delta {
+        turn_id: String,
+        text: String,
+    },
+    /// The model has issued a tool call. Carries enough info for the UI
+    /// to render an inline pill ("Reading [3] 'All-hands April'…").
+    ToolUseStart {
+        turn_id: String,
+        tool_id: String,
+        name: String,
+        target_n: u32,
+        target_title: String,
+    },
+    /// The tool call resolved. `ok=false` on out-of-range / I/O errors;
+    /// the model still gets the error text and can recover next turn.
+    ToolUseDone {
+        turn_id: String,
+        tool_id: String,
+        ok: bool,
+    },
+    Done {
+        turn_id: String,
+    },
+    Error {
+        turn_id: String,
+        message: String,
+    },
+}
+
+/// One source the model can cite as `[N]`. Indexes the full notes
+/// directory (not just the retrieved set) so the model's allowed
+/// citation surface matches what's actually in its prompt. The UI
+/// renders chips only for `[N]`s the model actually emits in its
+/// answer — passing the whole directory keeps the mapping consistent
+/// without flooding the chip strip.
+#[derive(Serialize, Clone)]
+pub struct AskSource {
+    pub index: u32,
+    pub note_path: String,
+    pub bundle_id: String,
+    pub title: String,
+    pub modified_ms: i64,
+}
+
+/// One past turn in the conversation, threaded back to the model.
+/// Frontend only ever stores text content; we wrap it in a single
+/// text content block when composing the API request.
+#[derive(Deserialize, Clone)]
+pub struct ChatTurn {
+    pub role: String,
+    pub content: String,
+}
+
+const SYSTEM_PROMPT: &str = "You are answering questions about the user's personal notes (meeting \
+notes, hand-typed notes, transcripts) and their team profiles.
+
+The user's message contains three sections:
+
+1. **Notes directory** — every non-archived note, labeled `[1]`, `[2]`, etc., with title, date, and \
+a short preview. This is the master index; you may cite *any* `[N]` from this directory.
+
+2. **Top candidates** — a subset of the directory whose full bodies have been loaded for deep \
+context. The same `[N]` labels apply — these are the same notes, just expanded. When citing details \
+that came from a body, cite the directory `[N]`.
+
+3. **Team profiles** — short bios for each colleague: display name, aliases, role, profile text. \
+Use these to interpret references to people in the notes (e.g. \"Heike\" maps to a known team \
+member). You may cite directly attributable claims from a profile by the person's name in prose; \
+profiles aren't `[N]`-citable — only notes are.
+
+You also have two tools for digging deeper into the directory:
+- **`read_note(n)`** — returns the full markdown body of directory entry `[n]`. Use when a preview \
+hints at relevance but you need the body to answer.
+- **`read_transcript(n)`** — returns the meeting transcript text for `[n]`, if it has audio. Use \
+when the question is likely about something said in a meeting but not captured in the typed body.
+
+Use tools sparingly — most questions can be answered from the directory + top candidates already in \
+context. Don't speculate; call a tool if you genuinely need the content. Up to 6 tool calls per \
+question; after that you must answer with what you have.
+
+Rules:
+- Answer in natural prose. Be specific and concise — 1-4 short paragraphs unless the question asks \
+for a list.
+- Cite sources inline with `[N]` immediately after each claim that came from a note. Multiple \
+citations: `[1][3]`. Never make up citation numbers — only use directory labels you actually \
+received.
+- For \"when did we first…\" questions, identify the *earliest* dated note that matches and cite it.
+- If neither the notes nor the profiles contain the answer, say so clearly. Don't speculate.
+- Don't pad with caveats or restate the question. Open with the answer.
+- Don't echo note titles back as a heading; cite them inline.";
+
+/// Public entry point — the Tauri command lives in lib.rs and forwards
+/// here. The frontend generates `turn_id` so the assistant message can
+/// be tagged with it *before* the first `ai-stream` event arrives,
+/// avoiding a race where `Sources` got emitted before the listener
+/// could associate it with a message.
+pub async fn start(
+    app: AppHandle,
+    turn_id: String,
+    query: String,
+    history: Vec<ChatTurn>,
+    model: Option<String>,
+) -> Result<(), String> {
+    let key = keychain::read_anthropic_api_key().map_err(|_| {
+        "Anthropic API key not configured — open Settings → AI to add one".to_string()
+    })?;
+
+    // Pull the all-notes directory + retrieval set + team roster in
+    // one lock. Profile.md content is read off-lock below.
+    let conn_state = app.state::<std::sync::Mutex<rusqlite::Connection>>();
+    let (directory, retrieved_paths, team) = {
+        let c = conn_state.lock().map_err(|e| e.to_string())?;
+        let directory = crate::index::list_directory(&c, DIRECTORY_CAP)
+            .map_err(|e| e.to_string())?;
+        let hits = crate::index::retrieve_for_ask(&c, &query, RETRIEVAL_K)
+            .map_err(|e| e.to_string())?;
+        let retrieved_paths: std::collections::HashSet<String> =
+            hits.iter().map(|h| h.note_path.clone()).collect();
+        let team = crate::team::list_team_members_raw(&c).unwrap_or_default();
+        (directory, retrieved_paths, team)
+    };
+
+    // Build the citation surface: every directory entry gets a 1-based
+    // [N] label.
+    let mut sources: Vec<AskSource> = Vec::with_capacity(directory.len());
+    for (i, e) in directory.iter().enumerate() {
+        sources.push(AskSource {
+            index: (i + 1) as u32,
+            note_path: e.note_path.clone(),
+            bundle_id: e.bundle_id.clone(),
+            title: e.title.clone(),
+            modified_ms: e.modified_ms,
+        });
+    }
+
+    // Emit sources before the first token. UI renders chips only for
+    // [N]s that appear in the streamed answer.
+    let _ = app.emit(
+        "ai-stream",
+        StreamEvent::Sources {
+            turn_id: turn_id.clone(),
+            sources: sources.clone(),
+        },
+    );
+
+    if directory.is_empty() && team.is_empty() && history.is_empty() {
+        // No notes at all and no team members configured — the model
+        // can only refuse. Short-circuit.
+        let app_for_emit = app.clone();
+        let tid = turn_id.clone();
+        tauri::async_runtime::spawn(async move {
+            let _ = app_for_emit.emit(
+                "ai-stream",
+                StreamEvent::Delta {
+                    turn_id: tid.clone(),
+                    text: "There are no notes or team profiles to search yet."
+                        .to_string(),
+                },
+            );
+            let _ = app_for_emit.emit("ai-stream", StreamEvent::Done { turn_id: tid });
+        });
+        return Ok(());
+    }
+
+    // Read profile.md contents off-lock (small file IO, no need to
+    // hold the SQLite mutex). Failure on any one profile degrades to
+    // an empty excerpt — the model still has the display_name + aliases.
+    let mut profile_excerpts: Vec<(crate::team::TeamMember, String)> =
+        Vec::with_capacity(team.len());
+    for m in team {
+        let body = match tokio::fs::read_to_string(&m.profile_md_path).await {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!(
+                    "[ask] read profile {} failed: {e}",
+                    m.profile_md_path
+                );
+                String::new()
+            }
+        };
+        let excerpt = truncate_chars(body.trim(), PER_PROFILE_CAP);
+        profile_excerpts.push((m, excerpt));
+    }
+
+    let user_message = format_user_message(
+        &query,
+        &directory,
+        &retrieved_paths,
+        &profile_excerpts,
+    );
+
+    // Compose `messages[]`: prior history first, then this turn's user
+    // message. History rows arrive as plain strings — wrap each in a
+    // single text content block. Anything other than user/assistant is
+    // dropped so a bad payload can't poison the request.
+    let mut messages: Vec<ApiMessage> = Vec::with_capacity(history.len() + 1);
+    for h in history {
+        if h.role == "user" || h.role == "assistant" {
+            messages.push(ApiMessage {
+                role: h.role,
+                content: vec![ContentBlock::Text { text: h.content }],
+            });
+        }
+    }
+    messages.push(ApiMessage {
+        role: "user".to_string(),
+        content: vec![ContentBlock::Text {
+            text: user_message,
+        }],
+    });
+
+    let model = model.as_deref().unwrap_or(DEFAULT_MODEL).to_string();
+
+    // Spawn the network + tool-use loop. Errors emit an `error` event
+    // and exit; success emits deltas + a final `done` event.
+    let app_bg = app.clone();
+    let turn_id_bg = turn_id.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(msg) = run_loop(
+            &app_bg,
+            &turn_id_bg,
+            &key,
+            &model,
+            messages,
+            &directory,
+        )
+        .await
+        {
+            let _ = app_bg.emit(
+                "ai-stream",
+                StreamEvent::Error {
+                    turn_id: turn_id_bg.clone(),
+                    message: msg,
+                },
+            );
+        }
+    });
+
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct CacheControl {
+    #[serde(rename = "type")]
+    kind: &'static str,
+}
+
+#[derive(Serialize)]
+struct SystemBlock {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    text: &'static str,
+    cache_control: CacheControl,
+}
+
+/// One content block in a request `messages[]` content array. Mirrors
+/// Anthropic's content block schema for assistant `text` / `tool_use`
+/// and user `tool_result` blocks. The `type` discriminator is emitted
+/// via serde.
+#[derive(Serialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ContentBlock {
+    Text {
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+        #[serde(skip_serializing_if = "is_false")]
+        is_error: bool,
+    },
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+#[derive(Serialize, Clone)]
+struct ApiMessage {
+    role: String,
+    content: Vec<ContentBlock>,
+}
+
+#[derive(Serialize)]
+struct ApiRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    stream: bool,
+    system: Vec<SystemBlock>,
+    messages: &'a [ApiMessage],
+    /// Tool definitions. Empty/None on the final non-tool-allowed call
+    /// after we hit the iteration cap.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<&'a serde_json::Value>,
+}
+
+/// Outer loop driving multiple POSTs against /v1/messages until the
+/// model returns a non-tool stop_reason or we hit the iteration cap.
+async fn run_loop(
+    app: &AppHandle,
+    turn_id: &str,
+    api_key: &str,
+    model: &str,
+    mut messages: Vec<ApiMessage>,
+    directory: &[DirectoryEntry],
+) -> Result<(), String> {
+    let tools = tool_definitions();
+
+    for _ in 0..MAX_TOOL_ITERATIONS {
+        let body = ApiRequest {
+            model,
+            max_tokens: MAX_TOKENS,
+            stream: true,
+            system: vec![SystemBlock {
+                kind: "text",
+                text: SYSTEM_PROMPT,
+                cache_control: CacheControl { kind: "ephemeral" },
+            }],
+            messages: &messages,
+            tools: Some(&tools),
+        };
+
+        let pass = stream_pass(app, turn_id, api_key, &body).await?;
+
+        if pass.pending_tool_calls.is_empty() {
+            // No tool calls — the model is done with this turn.
+            let _ = app.emit(
+                "ai-stream",
+                StreamEvent::Done {
+                    turn_id: turn_id.to_string(),
+                },
+            );
+            return Ok(());
+        }
+
+        // Append the assistant's full response (text + tool_use blocks)
+        // and run each tool, accumulating tool_result blocks for the
+        // next user message.
+        messages.push(ApiMessage {
+            role: "assistant".to_string(),
+            content: pass.assistant_blocks,
+        });
+
+        let mut result_blocks: Vec<ContentBlock> = Vec::with_capacity(pass.pending_tool_calls.len());
+        for tc in pass.pending_tool_calls {
+            let target_n = tc
+                .input
+                .get("n")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32;
+            let target_title = directory
+                .get(target_n.saturating_sub(1) as usize)
+                .map(|e| e.title.clone())
+                .unwrap_or_default();
+
+            let _ = app.emit(
+                "ai-stream",
+                StreamEvent::ToolUseStart {
+                    turn_id: turn_id.to_string(),
+                    tool_id: tc.id.clone(),
+                    name: tc.name.clone(),
+                    target_n,
+                    target_title: target_title.clone(),
+                },
+            );
+
+            let result = dispatch_tool(&tc.name, &tc.input, directory);
+
+            let _ = app.emit(
+                "ai-stream",
+                StreamEvent::ToolUseDone {
+                    turn_id: turn_id.to_string(),
+                    tool_id: tc.id.clone(),
+                    ok: !result.is_error,
+                },
+            );
+
+            result_blocks.push(ContentBlock::ToolResult {
+                tool_use_id: tc.id,
+                content: result.content,
+                is_error: result.is_error,
+            });
+        }
+        messages.push(ApiMessage {
+            role: "user".to_string(),
+            content: result_blocks,
+        });
+    }
+
+    // Hit the cap. Force the model to answer with what it has by
+    // re-POSTing without tools available.
+    let final_body = ApiRequest {
+        model,
+        max_tokens: MAX_TOKENS,
+        stream: true,
+        system: vec![SystemBlock {
+            kind: "text",
+            text: SYSTEM_PROMPT,
+            cache_control: CacheControl { kind: "ephemeral" },
+        }],
+        messages: &messages,
+        tools: None,
+    };
+    let _ = stream_pass(app, turn_id, api_key, &final_body).await?;
+    let _ = app.emit(
+        "ai-stream",
+        StreamEvent::Done {
+            turn_id: turn_id.to_string(),
+        },
+    );
+    Ok(())
+}
+
+/// Static tool definitions. Built once and reused across iterations.
+/// Both tools key off the 1-based directory index `n` so the model
+/// can reference any source it sees in the prompt.
+fn tool_definitions() -> serde_json::Value {
+    serde_json::json!([
+        {
+            "name": "read_note",
+            "description": "Read the full markdown body of a note by its directory index [N]. Use when a directory entry's title or preview suggests it might answer the question and you need its body to be sure. Returns the body or a not-found error.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "n": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "The 1-based [N] label from the Notes directory section."
+                    }
+                },
+                "required": ["n"]
+            }
+        },
+        {
+            "name": "read_transcript",
+            "description": "Read the meeting transcript text for a note by its directory index [N]. Use when the question is likely answered by something said in a meeting (rather than captured in the typed body). Returns the transcript text or a 'no transcript' notice if the note has no audio.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "n": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "The 1-based [N] label from the Notes directory section."
+                    }
+                },
+                "required": ["n"]
+            }
+        }
+    ])
+}
+
+/// Result of one streaming round-trip.
+struct PassResult {
+    assistant_blocks: Vec<ContentBlock>,
+    pending_tool_calls: Vec<PendingToolCall>,
+}
+
+struct PendingToolCall {
+    id: String,
+    name: String,
+    input: serde_json::Value,
+}
+
+/// Per-content-block scratchpad while the model streams. Anthropic
+/// emits `content_block_start` then any number of deltas then
+/// `content_block_stop` per block, identified by `index`.
+enum BlockState {
+    Text {
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        json_buf: String,
+    },
+}
+
+async fn stream_pass(
+    app: &AppHandle,
+    turn_id: &str,
+    api_key: &str,
+    body: &ApiRequest<'_>,
+) -> Result<PassResult, String> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(ENDPOINT)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", ANTHROPIC_VERSION)
+        .header("content-type", "application/json")
+        .header("accept", "text/event-stream")
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| format!("network: {e}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let raw = resp.text().await.unwrap_or_default();
+        let msg = match status.as_u16() {
+            401 => format!("Invalid Anthropic API key — check Settings → AI ({raw})"),
+            429 => "Rate limited by Anthropic — try again shortly".to_string(),
+            _ => format!("Anthropic returned {status}: {raw}"),
+        };
+        return Err(msg);
+    }
+
+    let mut stream = resp.bytes_stream();
+    let mut buf = String::new();
+    let mut blocks: std::collections::BTreeMap<u64, BlockState> =
+        std::collections::BTreeMap::new();
+
+    while let Some(chunk) = stream.next().await {
+        let bytes = chunk.map_err(|e| format!("stream chunk: {e}"))?;
+        let s = std::str::from_utf8(&bytes).map_err(|e| format!("stream utf8: {e}"))?;
+        buf.push_str(s);
+
+        while let Some(boundary) = find_event_boundary(&buf) {
+            let event_block: String = buf.drain(..boundary).collect();
+            // Drop the trailing `\n\n` (or `\r\n\r\n`) the boundary
+            // marker pointed at.
+            buf.drain(..buf.len().min(2));
+
+            let payload = match data_payload(&event_block) {
+                Some(p) => p,
+                None => continue,
+            };
+            if payload == "[DONE]" {
+                continue;
+            }
+            let parsed: serde_json::Value = match serde_json::from_str(&payload) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("[ask] sse parse error ({e}); payload: {payload}");
+                    continue;
+                }
+            };
+            let kind = parsed.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+            match kind {
+                "content_block_start" => {
+                    let index = parsed
+                        .get("index")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    let cb = parsed.get("content_block");
+                    let cb_type = cb
+                        .and_then(|c| c.get("type"))
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("");
+                    if cb_type == "text" {
+                        blocks.insert(index, BlockState::Text { text: String::new() });
+                    } else if cb_type == "tool_use" {
+                        let id = cb
+                            .and_then(|c| c.get("id"))
+                            .and_then(|t| t.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let name = cb
+                            .and_then(|c| c.get("name"))
+                            .and_then(|t| t.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        blocks.insert(
+                            index,
+                            BlockState::ToolUse {
+                                id,
+                                name,
+                                json_buf: String::new(),
+                            },
+                        );
+                    }
+                }
+                "content_block_delta" => {
+                    let index = parsed
+                        .get("index")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    let delta = parsed.get("delta");
+                    let dtype = delta
+                        .and_then(|d| d.get("type"))
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("");
+                    if dtype == "text_delta" {
+                        let text = delta
+                            .and_then(|d| d.get("text"))
+                            .and_then(|t| t.as_str())
+                            .unwrap_or("");
+                        if !text.is_empty() {
+                            if let Some(BlockState::Text { text: t }) =
+                                blocks.get_mut(&index)
+                            {
+                                t.push_str(text);
+                            }
+                            let _ = app.emit(
+                                "ai-stream",
+                                StreamEvent::Delta {
+                                    turn_id: turn_id.to_string(),
+                                    text: text.to_string(),
+                                },
+                            );
+                        }
+                    } else if dtype == "input_json_delta" {
+                        let pj = delta
+                            .and_then(|d| d.get("partial_json"))
+                            .and_then(|t| t.as_str())
+                            .unwrap_or("");
+                        if let Some(BlockState::ToolUse { json_buf, .. }) =
+                            blocks.get_mut(&index)
+                        {
+                            json_buf.push_str(pj);
+                        }
+                    }
+                }
+                "content_block_stop" => {
+                    // Block boundaries are tracked by `blocks`; nothing
+                    // to do here. The accumulated state finalizes once
+                    // the stream ends.
+                }
+                "message_delta" => {
+                    // Carries stop_reason on the final delta. We don't
+                    // need to act on it here — pending_tool_calls being
+                    // non-empty is what drives the outer loop's next
+                    // iteration.
+                }
+                "message_stop" => {
+                    // End of this pass; further chunks (if any) won't
+                    // contain new events. The stream will close naturally.
+                }
+                "error" => {
+                    let msg = parsed
+                        .get("error")
+                        .and_then(|e| e.get("message"))
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("Anthropic streaming error")
+                        .to_string();
+                    return Err(msg);
+                }
+                _ => {} // message_start, ping, etc.
+            }
+        }
+    }
+
+    // Finalize: walk blocks in index order, build assistant_blocks +
+    // pending_tool_calls in the order the model emitted them. This
+    // ordering matters — Anthropic requires assistant tool_use blocks
+    // to be paired with user tool_result blocks in the same sequence.
+    let mut assistant_blocks: Vec<ContentBlock> = Vec::new();
+    let mut pending_tool_calls: Vec<PendingToolCall> = Vec::new();
+    for (_, state) in blocks {
+        match state {
+            BlockState::Text { text } => {
+                if !text.is_empty() {
+                    assistant_blocks.push(ContentBlock::Text { text });
+                }
+            }
+            BlockState::ToolUse { id, name, json_buf } => {
+                let input: serde_json::Value = if json_buf.trim().is_empty() {
+                    serde_json::json!({})
+                } else {
+                    serde_json::from_str(&json_buf).unwrap_or_else(|_| {
+                        serde_json::json!({})
+                    })
+                };
+                assistant_blocks.push(ContentBlock::ToolUse {
+                    id: id.clone(),
+                    name: name.clone(),
+                    input: input.clone(),
+                });
+                pending_tool_calls.push(PendingToolCall { id, name, input });
+            }
+        }
+    }
+
+    Ok(PassResult {
+        assistant_blocks,
+        pending_tool_calls,
+    })
+}
+
+/// Find the first `\n\n` (or `\r\n\r\n`) that ends an SSE event block.
+/// Returns the byte index of the start of the blank-line terminator.
+fn find_event_boundary(s: &str) -> Option<usize> {
+    if let Some(i) = s.find("\r\n\r\n") {
+        return Some(i);
+    }
+    s.find("\n\n")
+}
+
+/// Extract the SSE `data:` line(s) from one event block. Multi-line
+/// data is concatenated with `\n` per the SSE spec, but Anthropic's
+/// stream uses single-line `data:` payloads in practice.
+fn data_payload(block: &str) -> Option<String> {
+    let mut out: Option<String> = None;
+    for line in block.lines() {
+        if let Some(rest) = line.strip_prefix("data:") {
+            let trimmed = rest.trim_start();
+            match &mut out {
+                Some(acc) => {
+                    acc.push('\n');
+                    acc.push_str(trimmed);
+                }
+                None => out = Some(trimmed.to_string()),
+            }
+        }
+    }
+    out
+}
+
+struct ToolResult {
+    content: String,
+    is_error: bool,
+}
+
+/// Resolve a tool call. Both tools key off the directory index `n`.
+/// Errors (out-of-range, missing files, parse failures) become
+/// `is_error: true` results so the model sees them and can recover
+/// rather than the whole turn aborting.
+fn dispatch_tool(
+    name: &str,
+    input: &serde_json::Value,
+    directory: &[DirectoryEntry],
+) -> ToolResult {
+    let n = match input.get("n").and_then(|v| v.as_u64()) {
+        Some(v) if v >= 1 => v as usize,
+        _ => {
+            return ToolResult {
+                content: "Tool input missing or invalid required field 'n' (must be a 1-based directory index).".to_string(),
+                is_error: true,
+            };
+        }
+    };
+    if n > directory.len() {
+        return ToolResult {
+            content: format!(
+                "[{n}] is out of range. Notes directory has {len} entries — valid range is [1]..[{len}].",
+                n = n,
+                len = directory.len()
+            ),
+            is_error: true,
+        };
+    }
+    let entry = &directory[n - 1];
+
+    match name {
+        "read_note" => {
+            let body = read_note_body(&PathBuf::from(&entry.note_path));
+            let content = if body.is_empty() {
+                format!("[{n}] '{title}' is empty.", n = n, title = entry.title.trim())
+            } else {
+                format!(
+                    "# [{n}] {title}\n\n{body}",
+                    n = n,
+                    title = entry.title.trim(),
+                    body = body
+                )
+            };
+            ToolResult {
+                content,
+                is_error: false,
+            }
+        }
+        "read_transcript" => {
+            let bundle_dir = match PathBuf::from(&entry.note_path).parent() {
+                Some(p) => p.to_path_buf(),
+                None => {
+                    return ToolResult {
+                        content: format!("[{n}] '{}' has no resolvable bundle directory.", entry.title.trim()),
+                        is_error: true,
+                    };
+                }
+            };
+            let transcript_path = bundle_dir.join(crate::notes::TRANSCRIPT_FILENAME);
+            if !transcript_path.exists() {
+                return ToolResult {
+                    content: format!(
+                        "No transcript available for [{n}] '{title}' — this note has no audio recording.",
+                        n = n,
+                        title = entry.title.trim()
+                    ),
+                    is_error: false,
+                };
+            }
+            let raw = match std::fs::read_to_string(&transcript_path) {
+                Ok(s) => s,
+                Err(e) => {
+                    return ToolResult {
+                        content: format!("Failed to read transcript for [{n}]: {e}"),
+                        is_error: true,
+                    };
+                }
+            };
+            let parsed: serde_json::Value = match serde_json::from_str(&raw) {
+                Ok(v) => v,
+                Err(e) => {
+                    return ToolResult {
+                        content: format!("Transcript JSON for [{n}] is malformed: {e}"),
+                        is_error: true,
+                    };
+                }
+            };
+            let mut text = String::new();
+            if let Some(segs) = parsed.get("segments").and_then(|s| s.as_array()) {
+                for seg in segs {
+                    if let Some(t) = seg.get("text").and_then(|t| t.as_str()) {
+                        let trimmed = t.trim();
+                        if trimmed.is_empty() {
+                            continue;
+                        }
+                        if !text.is_empty() {
+                            text.push(' ');
+                        }
+                        text.push_str(trimmed);
+                    }
+                }
+            }
+            let truncated = truncate_chars(&text, TRANSCRIPT_CHARS_CAP);
+            ToolResult {
+                content: format!(
+                    "# Transcript for [{n}] {title}\n\n{body}",
+                    n = n,
+                    title = entry.title.trim(),
+                    body = truncated
+                ),
+                is_error: false,
+            }
+        }
+        _ => ToolResult {
+            content: format!("Unknown tool: {name}. Available tools: read_note, read_transcript."),
+            is_error: true,
+        },
+    }
+}
+
+fn read_note_body(note_path: &std::path::Path) -> String {
+    let raw = match std::fs::read_to_string(note_path) {
+        Ok(s) => s,
+        Err(_) => return String::new(),
+    };
+    let (_yaml, body) = crate::notes::split_frontmatter(&raw);
+    truncate_chars(body.trim(), PER_NOTE_BODY_CAP)
+}
+
+fn truncate_chars(s: &str, cap: usize) -> String {
+    let mut out = s.to_string();
+    if out.chars().count() > cap {
+        let cutoff = out
+            .char_indices()
+            .nth(cap)
+            .map(|(i, _)| i)
+            .unwrap_or(out.len());
+        out.truncate(cutoff);
+        out.push('…');
+    }
+    out
+}
+
+fn format_user_message(
+    query: &str,
+    directory: &[DirectoryEntry],
+    retrieved_paths: &std::collections::HashSet<String>,
+    profiles: &[(crate::team::TeamMember, String)],
+) -> String {
+    let mut s = String::new();
+
+    s.push_str("# Notes directory\n\n");
+    if directory.is_empty() {
+        s.push_str("_(no notes yet)_\n\n");
+    } else {
+        for (i, e) in directory.iter().enumerate() {
+            let n = i + 1;
+            let date = format_date(e.modified_ms);
+            let preview = preview_one_line(&e.preview);
+            let _ = std::fmt::Write::write_fmt(
+                &mut s,
+                format_args!("[{n}] {title} ({date}) — {preview}\n",
+                    title = e.title.trim(),
+                    date = date,
+                    preview = preview),
+            );
+        }
+        s.push('\n');
+    }
+
+    s.push_str("# Top candidates (full body)\n\n");
+    let mut deep_count = 0usize;
+    for (i, e) in directory.iter().enumerate() {
+        if !retrieved_paths.contains(&e.note_path) {
+            continue;
+        }
+        deep_count += 1;
+        let n = i + 1;
+        let date = format_date(e.modified_ms);
+        let body = read_note_body(&PathBuf::from(&e.note_path));
+        let _ = std::fmt::Write::write_fmt(
+            &mut s,
+            format_args!(
+                "[{n}] {title} ({date})\n{body}\n\n---\n\n",
+                title = e.title.trim(),
+                date = date,
+                body = body.trim()
+            ),
+        );
+    }
+    if deep_count == 0 {
+        s.push_str(
+            "_(no notes matched the keywords; reason from the directory previews above, or call read_note/read_transcript on a likely entry)_\n\n",
+        );
+    }
+
+    if !profiles.is_empty() {
+        s.push_str("# Team profiles\n\n");
+        for (m, excerpt) in profiles {
+            let aliases = if m.aliases.is_empty() {
+                String::new()
+            } else {
+                format!(" (aliases: {})", m.aliases.join(", "))
+            };
+            let role = if m.role.is_empty() {
+                String::new()
+            } else {
+                format!(" — {}", m.role)
+            };
+            let body = if excerpt.is_empty() {
+                "_(profile is empty)_".to_string()
+            } else {
+                excerpt.clone()
+            };
+            let _ = std::fmt::Write::write_fmt(
+                &mut s,
+                format_args!(
+                    "## {name}{role}{aliases}\n\n{body}\n\n",
+                    name = m.display_name,
+                    role = role,
+                    aliases = aliases,
+                    body = body
+                ),
+            );
+        }
+    }
+
+    s.push_str("# Question\n\n");
+    s.push_str(query.trim());
+    s
+}
+
+fn preview_one_line(preview: &str) -> String {
+    let collapsed: String = preview
+        .chars()
+        .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
+        .collect();
+    truncate_chars(collapsed.trim(), PER_PREVIEW_CAP)
+}
+
+fn format_date(modified_ms: i64) -> String {
+    use chrono::{DateTime, Utc};
+    let secs = modified_ms / 1000;
+    let nsec = ((modified_ms % 1000) * 1_000_000) as u32;
+    DateTime::<Utc>::from_timestamp(secs, nsec)
+        .map(|dt| dt.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "unknown date".to_string())
+}

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -408,6 +408,349 @@ struct FtsRow {
     score: f64,
 }
 
+/// One entry in the "all non-archived notes" directory the AI ask
+/// command builds for citation. Lighter than `SearchHit` — just enough
+/// to render a chip and ground the model on what exists.
+#[derive(Serialize, Clone)]
+pub struct DirectoryEntry {
+    pub note_path: String,
+    pub bundle_id: String,
+    pub title: String,
+    pub modified_ms: i64,
+    pub preview: String,
+}
+
+/// All non-archived notes, newest-first, capped at `limit`. Used as the
+/// "Notes directory" section of the AI ask prompt — every entry gets a
+/// `[N]` label the model can cite even when its body wasn't deep-loaded
+/// into the retrieved set.
+pub fn list_directory(conn: &Connection, limit: usize) -> Result<Vec<DirectoryEntry>> {
+    let mut stmt = conn.prepare(
+        "SELECT note_path, bundle_id, title, modified_ms, preview \
+         FROM notes WHERE archived = 0 \
+         ORDER BY modified_ms DESC LIMIT ?1",
+    )?;
+    let rows = stmt.query_map(params![limit as i64], |r| {
+        Ok(DirectoryEntry {
+            note_path: r.get(0)?,
+            bundle_id: r.get(1)?,
+            title: r.get(2)?,
+            modified_ms: r.get(3)?,
+            preview: r.get(4)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// AI-question retrieval: stopword-filtered OR query over title+body
+/// (and a per-token transcript scan to fill remaining slots). Used by
+/// the Ask palette where the input is a full natural-language question
+/// rather than a narrowing keyword filter — strict AND semantics from
+/// the lexical search would reject most candidates because question
+/// words like "what", "did", "is" rarely co-occur with topic terms in
+/// the same note.
+///
+/// Falls back to the most-recently-modified non-archived notes when no
+/// content tokens remain (e.g. user asked "what's new?") so the model
+/// always has something to reason over.
+pub fn retrieve_for_ask(
+    conn: &Connection,
+    query: &str,
+    limit: usize,
+) -> Result<Vec<SearchHit>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    let cap = limit.min(50);
+    let tokens = content_tokens(query);
+
+    if tokens.is_empty() {
+        return recent_notes(conn, cap);
+    }
+
+    // OR'd FTS query — bm25 ranks docs with more matching terms higher
+    // automatically, so OR + bm25 ≈ best-effort topic recall.
+    let fts_query = tokens
+        .iter()
+        .map(|t| format!("\"{}\"*", t.replace('"', "\"\"")))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+
+    let mut hits: Vec<SearchHit> = Vec::new();
+    let mut seen_paths: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+
+    let fts_sql = "\
+        SELECT n.note_path, n.bundle_id, n.title, n.modified_ms, \
+               snippet(notes_fts, 2, ?2, ?3, '…', 16) AS body_snip, \
+               bm25(notes_fts) AS score \
+        FROM notes_fts \
+        JOIN notes n ON n.note_path = notes_fts.note_path \
+        WHERE notes_fts MATCH ?1 AND n.archived = 0 \
+        ORDER BY score ASC \
+        LIMIT ?4";
+    let mut stmt = conn.prepare(fts_sql)?;
+    let rows = stmt.query_map(
+        params![
+            &fts_query,
+            SEARCH_SNIPPET_OPEN,
+            SEARCH_SNIPPET_CLOSE,
+            cap as i64,
+        ],
+        |r| {
+            Ok(FtsRow {
+                note_path: r.get(0)?,
+                bundle_id: r.get(1)?,
+                title: r.get(2)?,
+                modified_ms: r.get(3)?,
+                body_snip: r.get(4)?,
+                score: r.get(5)?,
+            })
+        },
+    )?;
+    for row in rows {
+        let row = row?;
+        seen_paths.insert(row.note_path.clone());
+        let source = if tokens
+            .iter()
+            .any(|t| row.title.to_lowercase().contains(t.as_str()))
+        {
+            SearchSource::Title
+        } else {
+            SearchSource::Body
+        };
+        let snippet = if matches!(source, SearchSource::Title) {
+            row.title.clone()
+        } else {
+            row.body_snip.clone()
+        };
+        hits.push(SearchHit {
+            note_path: row.note_path,
+            bundle_id: row.bundle_id,
+            title: row.title,
+            modified_ms: row.modified_ms,
+            snippet,
+            source,
+            score: row.score,
+        });
+    }
+
+    // Transcript pass — for ask retrieval we want any note whose
+    // transcript contains *any* meaningful token, not just the full
+    // query string. Cheap pre-filter: lowercased substring match per
+    // token before JSON parse.
+    if hits.len() < cap {
+        let archived_paths: std::collections::HashSet<String> = {
+            let mut stmt = conn
+                .prepare("SELECT note_path FROM notes WHERE archived = 1")?;
+            let rows = stmt.query_map([], |r| r.get::<_, String>(0))?;
+            let mut set = std::collections::HashSet::new();
+            for r in rows {
+                set.insert(r?);
+            }
+            set
+        };
+        let titles_by_path: HashMap<String, (String, String, i64)> = {
+            let mut stmt = conn.prepare(
+                "SELECT note_path, bundle_id, title, modified_ms FROM notes \
+                 WHERE archived = 0",
+            )?;
+            let rows = stmt.query_map([], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, i64>(3)?,
+                ))
+            })?;
+            let mut map = HashMap::new();
+            for row in rows {
+                let (p, b, t, m) = row?;
+                map.insert(p, (b, t, m));
+            }
+            map
+        };
+
+        let remaining = cap - hits.len();
+        let transcript_hits = scan_transcripts_any_token(
+            &paths::notes_dir(),
+            &tokens,
+            &seen_paths,
+            &archived_paths,
+            &titles_by_path,
+            remaining,
+        );
+        hits.extend(transcript_hits);
+    }
+
+    // Last-resort fallback: if even OR retrieval found nothing, hand
+    // the model the most-recent notes so it can at least confirm
+    // there's nothing relevant rather than refusing on empty context.
+    if hits.is_empty() {
+        return recent_notes(conn, cap);
+    }
+
+    Ok(hits)
+}
+
+/// Tokenize input the way the FTS tokenizer does, then drop stopwords
+/// and very short tokens. Output is lowercased for consistent
+/// case-insensitive matching downstream.
+fn content_tokens(input: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for raw in input.split(|c: char| !c.is_alphanumeric() && c != '\'' && c != '-') {
+        let lc = raw.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase();
+        if lc.chars().count() < 3 {
+            continue;
+        }
+        if STOPWORDS.contains(&lc.as_str()) {
+            continue;
+        }
+        if !out.iter().any(|t| t == &lc) {
+            out.push(lc);
+        }
+    }
+    out
+}
+
+/// English stopwords — common question words, auxiliaries, and
+/// determiners that almost never carry topical signal. Trimmed to
+/// avoid removing too much.
+const STOPWORDS: &[&str] = &[
+    "the", "and", "for", "are", "but", "not", "you", "all", "any", "can",
+    "had", "has", "have", "her", "his", "him", "she", "they", "this", "that",
+    "these", "those", "with", "from", "your", "yours", "ours", "their",
+    "theirs", "what", "when", "where", "who", "whom", "why", "how", "which",
+    "was", "were", "been", "being", "did", "does", "doing", "done", "would",
+    "could", "should", "shall", "will", "may", "might", "must", "into",
+    "about", "over", "under", "than", "then", "there", "here", "them",
+    "some", "such", "very", "just", "also", "only", "more", "most", "much",
+    "many", "few", "again", "still", "yet", "now", "before", "after",
+    "between", "during", "while", "because", "though", "although", "even",
+    "ever", "never", "always", "often", "sometimes", "really",
+];
+
+fn recent_notes(conn: &Connection, limit: usize) -> Result<Vec<SearchHit>> {
+    let mut stmt = conn.prepare(
+        "SELECT note_path, bundle_id, title, modified_ms, preview \
+         FROM notes WHERE archived = 0 \
+         ORDER BY modified_ms DESC LIMIT ?1",
+    )?;
+    let rows = stmt.query_map(params![limit as i64], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            r.get::<_, String>(2)?,
+            r.get::<_, i64>(3)?,
+            r.get::<_, String>(4)?,
+        ))
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        let (note_path, bundle_id, title, modified_ms, preview) = row?;
+        out.push(SearchHit {
+            note_path,
+            bundle_id,
+            title,
+            modified_ms,
+            snippet: preview,
+            source: SearchSource::Body,
+            score: 999.0,
+        });
+    }
+    Ok(out)
+}
+
+fn scan_transcripts_any_token(
+    notes_dir: &Path,
+    tokens: &[String],
+    seen_paths: &std::collections::HashSet<String>,
+    archived_paths: &std::collections::HashSet<String>,
+    titles_by_path: &HashMap<String, (String, String, i64)>,
+    limit: usize,
+) -> Vec<SearchHit> {
+    if limit == 0 || tokens.is_empty() {
+        return Vec::new();
+    }
+    let mut out: Vec<SearchHit> = Vec::new();
+    let read_dir = match fs::read_dir(notes_dir) {
+        Ok(r) => r,
+        Err(_) => return out,
+    };
+    for entry in read_dir.flatten() {
+        if out.len() >= limit {
+            break;
+        }
+        let bundle = entry.path();
+        if !bundle.is_dir() {
+            continue;
+        }
+        let note_path = bundle.join(NOTE_FILENAME);
+        let note_path_str = note_path.to_string_lossy().into_owned();
+        if seen_paths.contains(&note_path_str)
+            || archived_paths.contains(&note_path_str)
+        {
+            continue;
+        }
+        let transcript_path = bundle.join(TRANSCRIPT_FILENAME);
+        if !transcript_path.exists() {
+            continue;
+        }
+        let raw = match fs::read_to_string(&transcript_path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let raw_lc = raw.to_lowercase();
+        // Match any token (OR). First-token-wins for the snippet.
+        let mut snippet: Option<String> = None;
+        for tok in tokens {
+            if raw_lc.contains(tok.as_str()) {
+                let parsed: serde_json::Value =
+                    match serde_json::from_str(&raw) {
+                        Ok(v) => v,
+                        Err(_) => continue,
+                    };
+                let segments = match parsed.get("segments").and_then(|s| s.as_array()) {
+                    Some(s) => s,
+                    None => continue,
+                };
+                for seg in segments {
+                    let text = seg.get("text").and_then(|t| t.as_str()).unwrap_or("");
+                    if let Some((start, end)) = find_ci(text, tok) {
+                        snippet = Some(transcript_snippet(text, start, end));
+                        break;
+                    }
+                }
+                if snippet.is_some() {
+                    break;
+                }
+            }
+        }
+        let snippet = match snippet {
+            Some(s) => s,
+            None => continue,
+        };
+        let (bundle_id, title, modified_ms) = match titles_by_path.get(&note_path_str) {
+            Some(v) => v.clone(),
+            None => continue,
+        };
+        out.push(SearchHit {
+            note_path: note_path_str,
+            bundle_id,
+            title,
+            modified_ms,
+            snippet,
+            source: SearchSource::Transcript,
+            score: 1.0,
+        });
+    }
+    out
+}
+
 /// Translate user input into an FTS5 MATCH expression. Each
 /// whitespace-separated token becomes a quoted prefix term so the query
 /// never trips on FTS5 operators (`AND`, `NOT`, `*`, `:` etc) the user

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod ask;
 mod audio;
 mod chunker;
 mod dates;
@@ -81,6 +82,23 @@ async fn start_meeting_recording(
     let path = r.note_path.to_string_lossy().into_owned();
     s.recording = Some(r);
     Ok(path)
+}
+
+/// Kick off an AI Q&A turn over the user's notes (#31 follow-up).
+/// Retrieves candidate notes via FTS, streams Anthropic's response back
+/// as `ai-stream` events keyed by `turn_id`. The frontend generates the
+/// `turn_id` so it can tag the in-flight assistant message *before*
+/// the first event lands — otherwise the listener races the invoke
+/// response and loses the `Sources` event.
+#[tauri::command]
+async fn ask_notes_start(
+    app: AppHandle,
+    turn_id: String,
+    query: String,
+    history: Vec<ask::ChatTurn>,
+    model: Option<String>,
+) -> Result<(), String> {
+    ask::start(app, turn_id, query, history, model).await
 }
 
 #[tauri::command]
@@ -482,6 +500,7 @@ pub fn run() {
             keychain::has_anthropic_api_key,
             start_meeting_recording,
             stop_meeting_recording,
+            ask_notes_start,
             transcribe::transcribe,
             reconcile::reconcile_notes,
             notes::notes_dir,

--- a/src/App.css
+++ b/src/App.css
@@ -3808,3 +3808,342 @@ input.nh-title {
   border-radius: 2px;
   padding: 0 1px;
 }
+
+/* AI chat mode (#31 follow-up) */
+
+.palette-dialog.mode-chat {
+  max-height: min(640px, calc(100vh - 22vh));
+}
+
+.palette-send {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 6px;
+  background: var(--accent);
+  color: var(--bg);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: opacity 100ms ease;
+}
+.palette-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.palette-send:not(:disabled):hover {
+  filter: brightness(1.05);
+}
+
+.palette-conversation {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 14px 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.palette-msg {
+  display: flex;
+  flex-direction: column;
+}
+.palette-msg-user {
+  align-items: flex-end;
+}
+.palette-msg-assistant {
+  align-items: flex-start;
+}
+
+.palette-msg-bubble {
+  max-width: 90%;
+  padding: 8px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  line-height: 1.45;
+  word-wrap: break-word;
+}
+
+/* Markdown rendered inside the assistant bubble. Tightens margins so
+   prose feels chat-like rather than document-like. */
+.palette-md > :first-child { margin-top: 0; }
+.palette-md > :last-child { margin-bottom: 0; }
+.palette-md p {
+  margin: 0 0 8px 0;
+}
+.palette-md p:last-child { margin-bottom: 0; }
+.palette-md strong {
+  font-weight: 600;
+}
+.palette-md em {
+  font-style: italic;
+}
+.palette-md ul,
+.palette-md ol {
+  margin: 4px 0 8px 0;
+  padding-left: 22px;
+}
+.palette-md li {
+  margin: 2px 0;
+}
+.palette-md li > p {
+  margin: 0;
+}
+.palette-md code {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11.5px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--home-chip);
+  color: var(--fg);
+}
+.palette-md pre {
+  margin: 6px 0;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--home-chip);
+  overflow-x: auto;
+  font-size: 11.5px;
+}
+.palette-md pre code {
+  padding: 0;
+  background: none;
+  font-size: inherit;
+}
+.palette-md h1,
+.palette-md h2,
+.palette-md h3,
+.palette-md h4 {
+  margin: 8px 0 4px 0;
+  font-weight: 600;
+  line-height: 1.3;
+}
+.palette-md h1 { font-size: 15px; }
+.palette-md h2 { font-size: 14px; }
+.palette-md h3 { font-size: 13.5px; }
+.palette-md h4 { font-size: 13px; }
+.palette-md a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-thickness: 0.5px;
+  text-underline-offset: 2px;
+}
+.palette-md blockquote {
+  margin: 6px 0;
+  padding: 0 0 0 10px;
+  border-left: 2px solid var(--home-line-strong);
+  color: var(--fg-muted);
+}
+.palette-md hr {
+  margin: 10px 0;
+  border: none;
+  border-top: 0.5px solid var(--home-line);
+}
+
+.palette-msg-user .palette-msg-bubble {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--fg);
+  border: 0.5px solid color-mix(in srgb, var(--accent) 24%, transparent);
+}
+
+.palette-msg-assistant .palette-msg-bubble {
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
+  color: var(--fg);
+  border: 0.5px solid var(--home-line);
+}
+
+.palette-msg-error {
+  background: color-mix(in srgb, #c44a1f 12%, transparent) !important;
+  border-color: color-mix(in srgb, #c44a1f 30%, transparent) !important;
+  color: #c44a1f;
+}
+
+.palette-msg-typing {
+  display: inline-flex;
+  gap: 4px;
+  padding: 2px 0;
+}
+.palette-msg-typing span {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--fg-muted);
+  animation: palette-typing 1s infinite ease-in-out;
+}
+.palette-msg-typing span:nth-child(2) {
+  animation-delay: 0.16s;
+}
+.palette-msg-typing span:nth-child(3) {
+  animation-delay: 0.32s;
+}
+@keyframes palette-typing {
+  0%, 60%, 100% { opacity: 0.3; transform: translateY(0); }
+  30% { opacity: 1; transform: translateY(-2px); }
+}
+
+.palette-cite {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 16px;
+  padding: 0 4px;
+  margin: 0 2px;
+  border: 0.5px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+  font-size: 10.5px;
+  font-weight: 600;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  line-height: 1;
+  cursor: pointer;
+  vertical-align: baseline;
+  transition: background 80ms ease;
+}
+.palette-cite:hover {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.palette-sources {
+  margin-top: 8px;
+  width: 100%;
+}
+.palette-sources-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin-bottom: 6px;
+}
+.palette-sources-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.palette-source-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 240px;
+  padding: 4px 8px 4px 4px;
+  border: 0.5px solid var(--home-line);
+  border-radius: 14px;
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 11.5px;
+  cursor: pointer;
+  transition: background 80ms ease, border-color 80ms ease;
+}
+.palette-source-chip:hover {
+  background: var(--home-card-hover);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+.palette-source-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 10.5px;
+  flex-shrink: 0;
+}
+.palette-source-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.palette-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 6px 14px;
+  border-top: 0.5px solid var(--home-line);
+  font-size: 10.5px;
+  color: var(--fg-muted);
+}
+.palette-footer kbd {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--home-chip);
+  color: var(--fg-muted);
+}
+
+/* Tool-use pills inline in assistant message bubble. The model
+   emits these mid-stream when invoking read_note / read_transcript;
+   each pill is clickable to jump to the underlying note. */
+.palette-tool-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin: 4px 0;
+  padding: 3px 8px 3px 6px;
+  border: 0.5px solid var(--home-line);
+  border-radius: 12px;
+  background: var(--bg);
+  color: var(--fg-muted);
+  font-size: 11.5px;
+  font-style: italic;
+  font-family: inherit;
+  cursor: pointer;
+  vertical-align: baseline;
+  transition: background 80ms ease, border-color 80ms ease;
+}
+.palette-tool-pill:hover {
+  background: var(--home-card-hover);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.palette-tool-pill.status-running {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 24%, transparent);
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+}
+.palette-tool-pill.status-running .palette-tool-icon {
+  animation: palette-tool-spin 1.4s linear infinite;
+}
+.palette-tool-pill.status-ok {
+  color: var(--fg-muted);
+}
+.palette-tool-pill.status-ok .palette-tool-icon {
+  color: #1a8a3a;
+}
+.palette-tool-pill.status-error {
+  color: #c44a1f;
+  border-color: color-mix(in srgb, #c44a1f 24%, transparent);
+  background: color-mix(in srgb, #c44a1f 6%, transparent);
+}
+
+.palette-tool-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.palette-tool-target {
+  font-style: normal;
+  font-weight: 600;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11px;
+}
+
+@keyframes palette-tool-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/src/SearchPalette.tsx
+++ b/src/SearchPalette.tsx
@@ -1,12 +1,25 @@
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
+  type AiStreamEvent,
+  type AskSource,
+  askNotesStart,
+  type MessagePart,
   searchNotes,
   SEARCH_HIGHLIGHT_CLOSE,
   SEARCH_HIGHLIGHT_OPEN,
   type SearchHit,
 } from "./file";
-import { IconFileText, IconMic, IconSearch } from "./icons";
+import { render as renderMarkdown } from "./markdown";
+import {
+  IconArrowRight,
+  IconCheck,
+  IconFileText,
+  IconMic,
+  IconSearch,
+  IconSparkle,
+} from "./icons";
 
 type Props = {
   open: boolean;
@@ -16,28 +29,69 @@ type Props = {
 
 const QUERY_DEBOUNCE_MS = 120;
 
-/// ⌘K command palette. Backed by `search_notes` (FTS over title+body
-/// plus per-bundle transcript scan). The palette stays mounted while
-/// `open` to preserve input/result state across rapid open/close
-/// cycles, but resets state on the open→close edge.
+type ChatMessage = {
+  id: string;
+  role: "user" | "assistant";
+  /** Ordered list of parts. User messages always have a single text
+   *  part (the user can't trigger tools directly). Assistant messages
+   *  interleave text deltas and tool-use markers in the order the
+   *  model emitted them. */
+  parts: MessagePart[];
+  /** Assistant-only — populated by the `sources` event before any
+   *  `delta` arrives so chips can render alongside the streaming text. */
+  sources?: AskSource[];
+  status: "streaming" | "done" | "error";
+  error?: string;
+  /** The turn_id returned by `ask_notes_start`; used to filter the
+   *  Tauri `ai-stream` channel to events for this message. Only set on
+   *  assistant messages. */
+  turnId?: string;
+};
+
+/// Concatenate all text parts of a message, ignoring tool parts. Used
+/// for citation parsing (regex over the whole prose) and for shipping
+/// history back to the backend (which only stores plain text content).
+function joinText(parts: MessagePart[]): string {
+  let out = "";
+  for (const p of parts) {
+    if (p.kind === "text") out += p.value;
+  }
+  return out;
+}
+
+/// Search palette + AI Q&A surface (#31).
+///
+/// Two modes share the same dialog:
+///   - "search": debounced lexical search via `search_notes`. Plain Enter
+///     opens the active row.
+///   - "chat":  conversation thread streamed from `ask_notes_start`.
+///     Plain Enter submits the next turn.
+///
+/// Cmd+Enter from search escalates to chat (sends the current input as
+/// the first user turn). Esc closes and resets everything.
 export function SearchPalette({ open, onClose, onOpenNote }: Props) {
+  const [mode, setMode] = useState<"search" | "chat">("search");
   const [query, setQuery] = useState("");
   const [hits, setHits] = useState<SearchHit[]>([]);
   const [loading, setLoading] = useState(false);
   const [activeIdx, setActiveIdx] = useState(0);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+
   const inputRef = useRef<HTMLInputElement | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
-  const listRef = useRef<HTMLDivElement | null>(null);
-  // Generation counter so out-of-order search responses can't overwrite
-  // newer results when a slow query resolves after a faster one.
+  const resultsRef = useRef<HTMLDivElement | null>(null);
+  const conversationRef = useRef<HTMLDivElement | null>(null);
+  // Generation counter for the search debounce — out-of-order responses
+  // from a slower keystroke must not overwrite a newer one's results.
   const queryGen = useRef(0);
 
-  // Reset on close so the next open starts fresh. Focus the input on
-  // open so the user can type immediately.
+  // Reset everything on close. Focus the input on open.
   useEffect(() => {
     if (!open) {
+      setMode("search");
       setQuery("");
       setHits([]);
+      setMessages([]);
       setLoading(false);
       setActiveIdx(0);
       return;
@@ -45,9 +99,9 @@ export function SearchPalette({ open, onClose, onOpenNote }: Props) {
     inputRef.current?.focus();
   }, [open]);
 
-  // Debounced search. Empty query clears results without a round-trip.
+  // Lexical search debounce — only runs in search mode.
   useEffect(() => {
-    if (!open) return;
+    if (!open || mode !== "search") return;
     const trimmed = query.trim();
     if (trimmed.length === 0) {
       setHits([]);
@@ -72,11 +126,10 @@ export function SearchPalette({ open, onClose, onOpenNote }: Props) {
       }
     }, QUERY_DEBOUNCE_MS);
     return () => window.clearTimeout(timer);
-  }, [open, query]);
+  }, [open, mode, query]);
 
-  // Outside-click + Escape dismissal. Stop propagation on the dialog
-  // itself so the global mousedown listener doesn't fire when the user
-  // clicks inside.
+  // Outside-click dismissal. Click *on* the dialog does not bubble here
+  // because the dialog stops propagation in its onMouseDown.
   useEffect(() => {
     if (!open) return;
     const onMouseDown = (e: MouseEvent) => {
@@ -88,16 +141,153 @@ export function SearchPalette({ open, onClose, onOpenNote }: Props) {
     return () => window.removeEventListener("mousedown", onMouseDown);
   }, [open, onClose]);
 
-  // Scroll the active row into view when navigating with arrow keys.
+  // Scroll the active search row into view when navigating with arrows.
   useEffect(() => {
-    if (!listRef.current) return;
-    const row = listRef.current.querySelector<HTMLElement>(
+    if (mode !== "search") return;
+    if (!resultsRef.current) return;
+    const row = resultsRef.current.querySelector<HTMLElement>(
       `[data-row-idx="${activeIdx}"]`,
     );
     row?.scrollIntoView({ block: "nearest" });
-  }, [activeIdx, hits]);
+  }, [activeIdx, hits, mode]);
+
+  // Auto-scroll the conversation as new tokens arrive.
+  useEffect(() => {
+    if (mode !== "chat") return;
+    if (!conversationRef.current) return;
+    conversationRef.current.scrollTop = conversationRef.current.scrollHeight;
+  }, [mode, messages]);
+
+  // Tauri `ai-stream` subscription. Active only while open and in chat
+  // mode (search-only sessions don't need the listener). Cleanup
+  // unsubscribes; the listener filters on turn_id so events from a
+  // closed palette can't mutate state for a fresh open.
+  useEffect(() => {
+    if (!open || mode !== "chat") return;
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+    (async () => {
+      const fn = await listen<AiStreamEvent>("ai-stream", (event) => {
+        const ev = event.payload;
+        setMessages((prev) =>
+          prev.map((m) => {
+            if (m.role !== "assistant" || m.turnId !== ev.turn_id) return m;
+            if (ev.kind === "sources") {
+              return { ...m, sources: ev.sources };
+            }
+            if (ev.kind === "delta") {
+              // Append to the trailing text part if there is one,
+              // otherwise push a new text part. Crucial for ordering:
+              // a tool pill in the middle of streaming text must not
+              // get its trailing text appended onto its `value`.
+              const last = m.parts[m.parts.length - 1];
+              if (last && last.kind === "text") {
+                const updated: MessagePart[] = [...m.parts];
+                updated[updated.length - 1] = {
+                  kind: "text",
+                  value: last.value + ev.text,
+                };
+                return { ...m, parts: updated };
+              }
+              return {
+                ...m,
+                parts: [...m.parts, { kind: "text", value: ev.text }],
+              };
+            }
+            if (ev.kind === "tool_use_start") {
+              return {
+                ...m,
+                parts: [
+                  ...m.parts,
+                  {
+                    kind: "tool",
+                    toolId: ev.tool_id,
+                    name: ev.name,
+                    targetN: ev.target_n,
+                    targetTitle: ev.target_title,
+                    status: "running",
+                  },
+                ],
+              };
+            }
+            if (ev.kind === "tool_use_done") {
+              const updated: MessagePart[] = m.parts.map((p) =>
+                p.kind === "tool" && p.toolId === ev.tool_id
+                  ? { ...p, status: ev.ok ? "ok" : "error" }
+                  : p,
+              );
+              return { ...m, parts: updated };
+            }
+            if (ev.kind === "done") {
+              return { ...m, status: "done" };
+            }
+            if (ev.kind === "error") {
+              return { ...m, status: "error", error: ev.message };
+            }
+            return m;
+          }),
+        );
+      });
+      if (cancelled) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, [open, mode]);
 
   if (!open) return null;
+
+  const isAnyStreaming = messages.some(
+    (m) => m.role === "assistant" && m.status === "streaming",
+  );
+
+  const submitChatTurn = async (text: string) => {
+    const trimmed = text.trim();
+    if (trimmed.length === 0 || isAnyStreaming) return;
+    const userMsg: ChatMessage = {
+      id: cryptoId(),
+      role: "user",
+      parts: [{ kind: "text", value: trimmed }],
+      status: "done",
+    };
+    // Generate turn_id up-front so it lands on the message before the
+    // backend's `Sources` event can arrive at the listener.
+    const turnId = cryptoId();
+    const assistantMsg: ChatMessage = {
+      id: cryptoId(),
+      role: "assistant",
+      parts: [],
+      status: "streaming",
+      turnId,
+    };
+    // History: every prior message at the moment of submit, in send
+    // order. Tool parts are dropped — the model only sees prose
+    // history. Backend stores history as plain {role, content} strings.
+    const history = messages.map((m) => ({
+      role: m.role,
+      content: joinText(m.parts),
+    }));
+    setMessages((prev) => [...prev, userMsg, assistantMsg]);
+    setQuery("");
+    setMode("chat");
+    try {
+      await askNotesStart(turnId, trimmed, history);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantMsg.id
+            ? { ...m, status: "error", error: message }
+            : m,
+        ),
+      );
+    }
+  };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Escape") {
@@ -105,87 +295,385 @@ export function SearchPalette({ open, onClose, onOpenNote }: Props) {
       onClose();
       return;
     }
-    if (hits.length === 0) return;
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-      setActiveIdx((i) => Math.min(i + 1, hits.length - 1));
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      setActiveIdx((i) => Math.max(i - 1, 0));
-    } else if (e.key === "Enter") {
-      e.preventDefault();
-      const hit = hits[activeIdx];
-      if (hit) {
-        onOpenNote(hit.note_path);
-        onClose();
+    if (mode === "search") {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        // Escalate to AI ask.
+        e.preventDefault();
+        if (query.trim().length > 0) submitChatTurn(query);
+        return;
+      }
+      if (hits.length === 0) return;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setActiveIdx((i) => Math.min(i + 1, hits.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setActiveIdx((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const hit = hits[activeIdx];
+        if (hit) {
+          onOpenNote(hit.note_path);
+          onClose();
+        }
+      }
+    } else {
+      // chat mode — Enter sends a follow-up turn.
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        if (query.trim().length > 0) submitChatTurn(query);
       }
     }
   };
+
+  const placeholder =
+    mode === "chat"
+      ? isAnyStreaming
+        ? "Waiting for answer…"
+        : "Ask a follow-up…"
+      : "Search notes — ⌘↵ to ask AI";
 
   return (
     <div
       className="palette-backdrop"
       role="presentation"
       onMouseDown={(e) => {
-        // Click on the backdrop dismisses; click on the dialog does
-        // not (the dialog stops propagation below).
         if (e.target === e.currentTarget) onClose();
       }}
     >
       <div
         ref={dialogRef}
-        className="palette-dialog"
+        className={"palette-dialog" + (mode === "chat" ? " mode-chat" : " mode-search")}
         role="dialog"
         aria-modal="true"
-        aria-label="Search notes"
+        aria-label={mode === "chat" ? "Ask AI about your notes" : "Search notes"}
         onKeyDown={onKeyDown}
         onMouseDown={(e) => e.stopPropagation()}
       >
         <div className="palette-input-row">
           <span className="palette-input-icon" aria-hidden="true">
-            <IconSearch size={14} sw={1.7} />
+            {mode === "chat" ? (
+              <IconSparkle size={14} sw={1.7} />
+            ) : (
+              <IconSearch size={14} sw={1.7} />
+            )}
           </span>
           <input
             ref={inputRef}
             type="text"
             className="palette-input"
-            placeholder="Search notes…"
+            placeholder={placeholder}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
+            disabled={mode === "chat" && isAnyStreaming}
             spellCheck={false}
             autoCorrect="off"
             autoCapitalize="off"
           />
-          <span className="palette-input-kbd">esc</span>
-        </div>
-        <div className="palette-results" ref={listRef} role="listbox">
-          {query.trim().length === 0 ? (
-            <div className="palette-empty">
-              Type to search across all your notes — titles, bodies, and
-              meeting transcripts.
-            </div>
-          ) : loading && hits.length === 0 ? (
-            <div className="palette-empty">Searching…</div>
-          ) : hits.length === 0 ? (
-            <div className="palette-empty">No matches.</div>
+          {mode === "chat" ? (
+            <button
+              type="button"
+              className="palette-send"
+              aria-label="Send message"
+              disabled={query.trim().length === 0 || isAnyStreaming}
+              onClick={() => submitChatTurn(query)}
+            >
+              <IconArrowRight size={13} sw={1.7} />
+            </button>
           ) : (
-            hits.map((hit, idx) => (
-              <ResultRow
-                key={hit.note_path + ":" + hit.source}
-                hit={hit}
-                active={idx === activeIdx}
-                idx={idx}
-                onMouseEnter={() => setActiveIdx(idx)}
-                onClick={() => {
-                  onOpenNote(hit.note_path);
-                  onClose();
-                }}
-              />
-            ))
+            <span className="palette-input-kbd">esc</span>
+          )}
+        </div>
+
+        {mode === "search" ? (
+          <SearchResults
+            ref={resultsRef}
+            query={query}
+            hits={hits}
+            loading={loading}
+            activeIdx={activeIdx}
+            onHover={setActiveIdx}
+            onPick={(path) => {
+              onOpenNote(path);
+              onClose();
+            }}
+          />
+        ) : (
+          <Conversation
+            ref={conversationRef}
+            messages={messages}
+            onOpenNote={(path) => {
+              onOpenNote(path);
+              onClose();
+            }}
+          />
+        )}
+
+        <div className="palette-footer">
+          {mode === "chat" ? (
+            <span>
+              <kbd>↵</kbd> send · <kbd>esc</kbd> close
+            </span>
+          ) : (
+            <span>
+              <kbd>↵</kbd> open · <kbd>⌘↵</kbd> ask AI · <kbd>esc</kbd> close
+            </span>
           )}
         </div>
       </div>
     </div>
+  );
+}
+
+function SearchResults({
+  ref,
+  query,
+  hits,
+  loading,
+  activeIdx,
+  onHover,
+  onPick,
+}: {
+  ref: React.RefObject<HTMLDivElement | null>;
+  query: string;
+  hits: SearchHit[];
+  loading: boolean;
+  activeIdx: number;
+  onHover: (idx: number) => void;
+  onPick: (path: string) => void;
+}) {
+  return (
+    <div className="palette-results" ref={ref} role="listbox">
+      {query.trim().length === 0 ? (
+        <div className="palette-empty">
+          Type to search across all your notes — titles, bodies, and meeting
+          transcripts. Press <kbd>⌘↵</kbd> to ask AI instead.
+        </div>
+      ) : loading && hits.length === 0 ? (
+        <div className="palette-empty">Searching…</div>
+      ) : hits.length === 0 ? (
+        <div className="palette-empty">No matches.</div>
+      ) : (
+        hits.map((hit, idx) => (
+          <ResultRow
+            key={hit.note_path + ":" + hit.source}
+            hit={hit}
+            active={idx === activeIdx}
+            idx={idx}
+            onMouseEnter={() => onHover(idx)}
+            onClick={() => onPick(hit.note_path)}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+function Conversation({
+  ref,
+  messages,
+  onOpenNote,
+}: {
+  ref: React.RefObject<HTMLDivElement | null>;
+  messages: ChatMessage[];
+  onOpenNote: (path: string) => void;
+}) {
+  return (
+    <div className="palette-conversation" ref={ref}>
+      {messages.map((m) => (
+        <MessageBubble key={m.id} message={m} onOpenNote={onOpenNote} />
+      ))}
+    </div>
+  );
+}
+
+function MessageBubble({
+  message,
+  onOpenNote,
+}: {
+  message: ChatMessage;
+  onOpenNote: (path: string) => void;
+}) {
+  if (message.role === "user") {
+    return (
+      <div className="palette-msg palette-msg-user">
+        <div className="palette-msg-bubble">{joinText(message.parts)}</div>
+      </div>
+    );
+  }
+  // Assistant
+  if (message.status === "error") {
+    return (
+      <div className="palette-msg palette-msg-assistant">
+        <div className="palette-msg-bubble palette-msg-error">
+          {message.error || "Something went wrong."}
+        </div>
+      </div>
+    );
+  }
+  const sources = message.sources || [];
+  const fullText = joinText(message.parts);
+  // Render chips only for [N] markers the model actually cited across
+  // all text parts. The directory can be hundreds of entries — showing
+  // all of them would be a wall of chips.
+  const citedSources = useMemo(() => {
+    if (sources.length === 0) return [];
+    const cited = new Set<number>();
+    const re = /\[(\d{1,3})\]/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(fullText)) !== null) {
+      cited.add(Number(m[1]));
+    }
+    return sources.filter((s) => cited.has(s.index));
+  }, [sources, fullText]);
+
+  const isEmptyAndStreaming =
+    message.parts.length === 0 && message.status === "streaming";
+
+  return (
+    <div className="palette-msg palette-msg-assistant">
+      <div className="palette-msg-bubble">
+        {isEmptyAndStreaming ? (
+          <span className="palette-msg-typing">
+            <span></span>
+            <span></span>
+            <span></span>
+          </span>
+        ) : (
+          message.parts.map((part, i) =>
+            part.kind === "text" ? (
+              <CitedText
+                key={i}
+                text={part.value}
+                sources={sources}
+                onOpenNote={onOpenNote}
+              />
+            ) : (
+              <ToolPill
+                key={i}
+                part={part}
+                onOpen={() => {
+                  // Resolve the directory entry by [N] and open the
+                  // note. Lets the user follow the model's reasoning
+                  // trail.
+                  const src = sources.find((s) => s.index === part.targetN);
+                  if (src) onOpenNote(src.note_path);
+                }}
+              />
+            ),
+          )
+        )}
+      </div>
+      {citedSources.length > 0 && (
+        <div className="palette-sources">
+          <div className="palette-sources-label">Sources</div>
+          <div className="palette-sources-list">
+            {citedSources.map((s) => (
+              <button
+                key={s.note_path}
+                type="button"
+                className="palette-source-chip"
+                title={s.title}
+                onClick={() => onOpenNote(s.note_path)}
+              >
+                <span className="palette-source-num">{s.index}</span>
+                <span className="palette-source-title">{s.title}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ToolPill({
+  part,
+  onOpen,
+}: {
+  part: Extract<MessagePart, { kind: "tool" }>;
+  onOpen: () => void;
+}) {
+  const verb = part.name === "read_transcript" ? "Reading transcript" : "Reading";
+  const titleAttr = `${part.name}([${part.targetN}] ${part.targetTitle})`;
+  return (
+    <button
+      type="button"
+      className={`palette-tool-pill status-${part.status}`}
+      title={titleAttr}
+      onClick={onOpen}
+    >
+      <span className="palette-tool-icon" aria-hidden="true">
+        {part.status === "ok" ? (
+          <IconCheck size={11} sw={2} />
+        ) : part.status === "error" ? (
+          "✗"
+        ) : (
+          <IconSearch size={11} sw={1.7} />
+        )}
+      </span>
+      <span className="palette-tool-text">
+        {verb} <span className="palette-tool-target">[{part.targetN}]</span>
+        {part.targetTitle ? ` "${part.targetTitle}"` : ""}
+        {part.status === "running" ? "…" : ""}
+      </span>
+    </button>
+  );
+}
+
+/// Render assistant text as Markdown with `[N]` markers swapped for
+/// clickable chips that link to the corresponding source note.
+///
+/// Approach: replace each `[N]` in the source with a sentinel `<button>`
+/// element BEFORE markdown rendering, so markdown-it sees the inline
+/// HTML and passes it through untouched. The button carries the
+/// citation number in `data-cite-n`; click handling is delegated on the
+/// wrapping div so React doesn't have to mount one handler per chip.
+///
+/// Streaming partial markdown (incomplete `**bold` etc.) is fine —
+/// markdown-it just renders the partial state literally until the
+/// closing pair arrives in a later delta.
+function CitedText({
+  text,
+  sources,
+  onOpenNote,
+}: {
+  text: string;
+  sources: AskSource[];
+  onOpenNote: (path: string) => void;
+}) {
+  const sourceByIndex = useMemo(() => {
+    const m = new Map<number, AskSource>();
+    for (const s of sources) m.set(s.index, s);
+    return m;
+  }, [sources]);
+
+  const html = useMemo(() => {
+    const withCitations = text.replace(/\[(\d{1,3})\]/g, (full, n) => {
+      const num = Number(n);
+      // Hallucinated citation number — leave the marker as plain text
+      // rather than emitting a dead chip.
+      if (!sourceByIndex.has(num)) return full;
+      return `<button type="button" class="palette-cite" data-cite-n="${num}">${num}</button>`;
+    });
+    return renderMarkdown(withCitations);
+  }, [text, sourceByIndex]);
+
+  const onClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    const cite = target.closest<HTMLElement>(".palette-cite[data-cite-n]");
+    if (!cite) return;
+    const n = Number(cite.getAttribute("data-cite-n"));
+    const source = sourceByIndex.get(n);
+    if (source) onOpenNote(source.note_path);
+  };
+
+  return (
+    <div
+      className="palette-md"
+      onClick={onClick}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
   );
 }
 
@@ -226,9 +714,7 @@ function ResultRow({
           <Highlighted text={hit.snippet} />
         </span>
       </span>
-      <span className={"palette-row-tag tag-" + hit.source}>
-        {labelFor(hit.source)}
-      </span>
+      <span className={"palette-row-tag tag-" + hit.source}>{labelFor(hit.source)}</span>
     </div>
   );
 }
@@ -239,9 +725,6 @@ function labelFor(source: SearchHit["source"]): string {
   return "Transcript";
 }
 
-/// Render text containing the U+2068/U+2069 isolate marks the Rust side
-/// uses to delimit the matched span. Falls back to plain text if the
-/// marks are absent or unbalanced.
 function Highlighted({ text }: { text: string }) {
   const parts = useMemo(() => splitHighlights(text), [text]);
   return (
@@ -271,7 +754,6 @@ function splitHighlights(text: string): { text: string; match: boolean }[] {
     if (open > i) out.push({ text: text.slice(i, open), match: false });
     const close = text.indexOf(SEARCH_HIGHLIGHT_CLOSE, open + 1);
     if (close === -1) {
-      // Unbalanced — render remainder verbatim, marks included.
       out.push({ text: text.slice(open), match: false });
       break;
     }
@@ -279,4 +761,12 @@ function splitHighlights(text: string): { text: string; match: boolean }[] {
     i = close + 1;
   }
   return out;
+}
+
+function cryptoId(): string {
+  // crypto.randomUUID is available in modern browsers + Tauri webview.
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -211,6 +211,70 @@ export async function searchNotes(query: string, limit = 20): Promise<SearchHit[
   return invoke<SearchHit[]>("search_notes", { query, limit });
 }
 
+// --- AI Q&A (#31 follow-up) ---------------------------------------------
+
+export type AskSource = {
+  /** 1-based label the model is told to cite as `[N]`. */
+  index: number;
+  note_path: string;
+  bundle_id: string;
+  title: string;
+  modified_ms: number;
+};
+
+export type ChatTurn = {
+  role: "user" | "assistant";
+  content: string;
+};
+
+/** Discriminated union pushed by the Rust side on the `ai-stream` Tauri
+ *  event channel. Order: `sources` (once), then any number of `delta` /
+ *  `tool_use_start` / `tool_use_done` interleaved (in the order the
+ *  model emits text vs tool calls), then a terminal `done` or `error`.
+ *  Filter by `turn_id` to ignore stale turns. */
+export type AiStreamEvent =
+  | { kind: "sources"; turn_id: string; sources: AskSource[] }
+  | { kind: "delta"; turn_id: string; text: string }
+  | {
+      kind: "tool_use_start";
+      turn_id: string;
+      tool_id: string;
+      name: string;
+      target_n: number;
+      target_title: string;
+    }
+  | { kind: "tool_use_done"; turn_id: string; tool_id: string; ok: boolean }
+  | { kind: "done"; turn_id: string }
+  | { kind: "error"; turn_id: string; message: string };
+
+/** One ordered piece of an assistant message. The Rust side only emits
+ *  text deltas + tool-use markers; the UI builds this list in arrival
+ *  order so tool pills land at their position in the prose. */
+export type MessagePart =
+  | { kind: "text"; value: string }
+  | {
+      kind: "tool";
+      toolId: string;
+      name: string;
+      targetN: number;
+      targetTitle: string;
+      status: "running" | "ok" | "error";
+    };
+
+/** Caller generates `turnId` (UUID) so the in-flight assistant message
+ *  can be tagged with it before the first `ai-stream` event arrives —
+ *  the backend's `Sources` emit can fire before invoke's promise
+ *  resolves, and the listener needs the tag to associate the event
+ *  with the right message. */
+export async function askNotesStart(
+  turnId: string,
+  query: string,
+  history: ChatTurn[] = [],
+  model?: string,
+): Promise<void> {
+  return invoke<void>("ask_notes_start", { turnId, query, history, model });
+}
+
 export type NoteMeta = { modified_ms: number };
 
 export async function noteMeta(notePath: string): Promise<NoteMeta> {


### PR DESCRIPTION
## Summary
- ⌘↵ from the palette escalates to AI Q&A — conversation thread, streamed answer, citations to source notes
- Prompt = 200-entry notes directory (title + preview) + full bodies of top-12 retrieval + every team profile
- Stopword-filtered OR retrieval (lexical AND broke recall on natural-language questions)
- Tool use: model can mid-stream call `read_note(n)` / `read_transcript(n)` to deep-load any directory entry; rendered as inline pills with click-through
- Markdown rendering in chat bubbles (bold, lists, code, headers) via existing markdown-it instance; `[N]` citations survive as clickable chips
- Outer loop caps at 6 tool round-trips per turn before forcing final answer

Successor to #54 (this is the reopened #55 — the original was auto-closed when its base branch was deleted as part of #54's merge).

## Test plan
- [ ] ⌘K → type a question → ⌘↵ — palette flips to chat, streams answer
- [ ] Citations `[N]` render as clickable chips and the cited-sources strip appears below the answer
- [ ] Ask a transcript-only question — verify a `Reading transcript [N]…` pill appears mid-stream
- [ ] Ask about a note whose body wasn't preloaded (in directory but not top-12) — verify a `Reading [N]…` pill
- [ ] Click a tool pill — opens the referenced note
- [ ] Click a citation chip / source chip — opens the referenced note
- [ ] Markdown formatting: `**bold**`, lists, inline `code`, headers all render correctly
- [ ] Follow-up turn after a tool-use turn — verify history threads correctly
- [ ] No Anthropic API key configured — verify clean error message
- [ ] Question with no relevant notes — model should answer "no info" without burning tool calls