### PR TITLE
Voice mode for AI search (#57)

### DIFF
--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -235,7 +235,10 @@ fn run_mic_thread(
     Ok(())
 }
 
-fn build_stream(
+/// Reusable across `audio.rs` (meeting capture) and `voice.rs` (voice
+/// query capture). Exposed at crate scope so a sibling module doesn't
+/// have to duplicate the four sample-format match arms.
+pub(crate) fn build_stream(
     device: &cpal::Device,
     cfg: &cpal::StreamConfig,
     fmt: cpal::SampleFormat,
@@ -291,7 +294,7 @@ fn build_stream(
     }
 }
 
-fn downmix(interleaved: &[f32], channels: usize) -> Vec<f32> {
+pub(crate) fn downmix(interleaved: &[f32], channels: usize) -> Vec<f32> {
     if channels == 1 {
         interleaved.to_vec()
     } else {
@@ -303,14 +306,14 @@ fn downmix(interleaved: &[f32], channels: usize) -> Vec<f32> {
 }
 
 /// Buffers mono samples at the source rate and emits 16 kHz mono chunks.
-struct MonoResampler {
+pub(crate) struct MonoResampler {
     resampler: Option<FastFixedIn<f32>>,
     chunk: usize,
     leftover: Vec<f32>,
 }
 
 impl MonoResampler {
-    fn new(src_rate: u32, _channels: usize) -> Result<Self, String> {
+    pub(crate) fn new(src_rate: u32, _channels: usize) -> Result<Self, String> {
         let resampler = if src_rate == TARGET_SAMPLE_RATE {
             None
         } else {
@@ -332,7 +335,7 @@ impl MonoResampler {
         })
     }
 
-    fn process(&mut self, mono: Vec<f32>) -> Result<Vec<Vec<f32>>, String> {
+    pub(crate) fn process(&mut self, mono: Vec<f32>) -> Result<Vec<Vec<f32>>, String> {
         self.leftover.extend_from_slice(&mono);
         let mut out_chunks = Vec::new();
         while self.leftover.len() >= self.chunk {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod sharing;
 mod sysaudio;
 mod team;
 mod transcribe;
+mod voice;
 
 use notify::{RecommendedWatcher, RecursiveMode};
 use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, RecommendedCache};
@@ -29,6 +30,10 @@ use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
 
 struct AudioState {
     recording: Option<audio::Recording>,
+}
+
+struct VoiceState {
+    recording: Option<voice::VoiceRecording>,
 }
 
 /// Start recording into a Margin note bundle. The note_path must be an owned
@@ -109,6 +114,109 @@ fn stop_meeting_recording(state: State<'_, Mutex<AudioState>>) -> Result<String,
     };
     let path = r.stop()?;
     Ok(path.to_string_lossy().into_owned())
+}
+
+/// Voice query result reported back to the frontend after stop. The
+/// `status` discriminator drives the palette UI: "ok" populates the
+/// input with `text`, "silent" shows "Didn't catch that", "error"
+/// shows the error message and stays in voice mode.
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "snake_case")]
+struct VoiceTranscript {
+    status: VoiceStatus,
+    text: String,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "snake_case")]
+enum VoiceStatus {
+    Ok,
+    Silent,
+    Error,
+}
+
+/// Peak amplitude floor below which we treat a recording as silence
+/// and skip the (~1-2s) Whisper inference. Tuned low because the cpal
+/// stream takes ~50-200ms to start delivering frames after `play()` —
+/// short voice queries can capture only a few hundred ms of real audio
+/// after that warm-up, so we err on the side of running Whisper rather
+/// than dropping a real attempt. Whisper's own silence handling
+/// catches the truly empty case.
+const VOICE_SILENCE_THRESHOLD: f32 = 0.01;
+
+/// Start mic capture for a one-shot voice query (#57). Errors out if a
+/// meeting recording is already running — sharing the input device
+/// across two recorders is technically possible but UX-confusing.
+#[tauri::command]
+fn start_voice_recording(
+    app: AppHandle,
+    voice_state: State<'_, Mutex<VoiceState>>,
+    audio_state: State<'_, Mutex<AudioState>>,
+) -> Result<(), String> {
+    {
+        let a = audio_state.lock().map_err(|e| e.to_string())?;
+        if a.recording.is_some() {
+            return Err("A meeting is recording — stop it first.".to_string());
+        }
+    }
+    let mut v = voice_state.lock().map_err(|e| e.to_string())?;
+    if v.recording.is_some() {
+        // Idempotent: already recording counts as success. Avoids races
+        // between the keyboard listener's autorepeat and the React
+        // state updater.
+        return Ok(());
+    }
+    let r = voice::start(app)?;
+    v.recording = Some(r);
+    Ok(())
+}
+
+/// Stop mic capture, finalize the temp WAV, run silence detection,
+/// transcribe via the existing Whisper helper if non-silent, and
+/// return the result. Always cleans up the temp WAV before returning.
+#[tauri::command]
+async fn stop_voice_recording(
+    app: AppHandle,
+    voice_state: State<'_, Mutex<VoiceState>>,
+    model: Option<String>,
+) -> Result<VoiceTranscript, String> {
+    let r = {
+        let mut v = voice_state.lock().map_err(|e| e.to_string())?;
+        v.recording.take().ok_or("not recording")?
+    };
+    let stop = r.stop()?;
+    let wav = stop.wav_path.clone();
+
+    if stop.max_amplitude < VOICE_SILENCE_THRESHOLD {
+        let _ = std::fs::remove_file(&wav);
+        return Ok(VoiceTranscript {
+            status: VoiceStatus::Silent,
+            text: String::new(),
+        });
+    }
+
+    let result = transcribe::transcribe_wav_to_transcript(
+        app,
+        wav.clone(),
+        model,
+        None,
+        None,
+    )
+    .await;
+
+    // Always clean up the temp WAV — voice queries are ephemeral.
+    let _ = std::fs::remove_file(&wav);
+
+    match result {
+        Ok(t) => Ok(VoiceTranscript {
+            status: VoiceStatus::Ok,
+            text: t.full_text.trim().to_string(),
+        }),
+        Err(e) => Ok(VoiceTranscript {
+            status: VoiceStatus::Error,
+            text: e,
+        }),
+    }
 }
 
 #[derive(Serialize, Clone)]
@@ -398,6 +506,7 @@ pub fn run() {
                 last_write: Mutex::new(None),
             });
             app.manage(Mutex::new(AudioState { recording: None }));
+            app.manage(Mutex::new(VoiceState { recording: None }));
 
             // Open the SQLite index, run migrations, and reconcile against
             // disk. Reconcile is fast on the happy path (a single
@@ -500,6 +609,8 @@ pub fn run() {
             keychain::has_anthropic_api_key,
             start_meeting_recording,
             stop_meeting_recording,
+            start_voice_recording,
+            stop_voice_recording,
             ask_notes_start,
             transcribe::transcribe,
             reconcile::reconcile_notes,

--- a/src-tauri/src/transcribe.rs
+++ b/src-tauri/src/transcribe.rs
@@ -119,13 +119,46 @@ async fn full_transcribe(
     glossary: Vec<String>,
     model: Option<String>,
 ) -> Result<Transcript, String> {
-    let path = PathBuf::from(audio_path);
+    let path = PathBuf::from(&audio_path);
+    let initial_prompt = build_initial_prompt(&glossary, None);
+    let transcript = transcribe_wav_to_transcript(
+        app,
+        path.clone(),
+        model,
+        initial_prompt,
+        Some("transcribe-progress"),
+    )
+    .await?;
+
+    // Sidecar JSON for re-summarization without re-transcribing.
+    let json_path = path.with_file_name(crate::notes::TRANSCRIPT_FILENAME);
+    std::fs::write(&json_path, serde_json::to_vec_pretty(&transcript).unwrap())
+        .map_err(|e| e.to_string())?;
+
+    Ok(transcript)
+}
+
+/// Run Whisper inference on a 16-bit PCM 16 kHz mono WAV (the format
+/// produced by `audio.rs` and `voice.rs`). Returns the full `Transcript`
+/// (segments, full_text, language, duration_ms). Does not write the
+/// sidecar JSON — caller decides whether to persist.
+///
+/// `progress_event`, when `Some`, names the Tauri event channel that
+/// receives 0-100 progress integers from whisper.cpp; pass `None` for
+/// silent inference (used by the voice-query path which doesn't want to
+/// pollute the meeting-transcribe progress UI).
+pub async fn transcribe_wav_to_transcript(
+    app: AppHandle,
+    audio_path: PathBuf,
+    model: Option<String>,
+    initial_prompt: Option<String>,
+    progress_event: Option<&'static str>,
+) -> Result<Transcript, String> {
     // Validate against the picker's allowlist; unknown values fall back to
     // the default rather than asking the OS to download an arbitrary URL.
     let model = resolve_model(model.as_deref());
     let model_path = ensure_model(&app, &model).await?;
     let app2 = app.clone();
-    let initial_prompt = build_initial_prompt(&glossary, None);
 
     tauri::async_runtime::spawn_blocking(move || -> Result<Transcript, String> {
         // Load Whisper model + state (Metal acceleration on Apple Silicon).
@@ -141,7 +174,7 @@ async fn full_transcribe(
         let mut state = ctx.create_state().map_err(|e| e.to_string())?;
 
         // Read 16-bit PCM 16 kHz mono WAV (per audio.rs spec).
-        let mut reader = hound::WavReader::open(&path).map_err(|e| e.to_string())?;
+        let mut reader = hound::WavReader::open(&audio_path).map_err(|e| e.to_string())?;
         let pcm_i16: Vec<i16> = reader.samples::<i16>().filter_map(|s| s.ok()).collect();
         let mut pcm_f32 = vec![0.0f32; pcm_i16.len()];
         whisper_rs::convert_integer_to_float_audio(&pcm_i16, &mut pcm_f32)
@@ -172,10 +205,12 @@ async fn full_transcribe(
             params.set_initial_prompt(p);
         }
 
-        let app3 = app2.clone();
-        params.set_progress_callback_safe(move |pct: i32| {
-            let _ = app3.emit("transcribe-progress", pct);
-        });
+        if let Some(event_name) = progress_event {
+            let app3 = app2.clone();
+            params.set_progress_callback_safe(move |pct: i32| {
+                let _ = app3.emit(event_name, pct);
+            });
+        }
 
         state.full(params, &pcm_f32).map_err(|e| e.to_string())?;
 
@@ -225,7 +260,7 @@ async fn full_transcribe(
         // stays compiled and reachable so #23 can re-enable it.
         let _ = (&mut segments, &app2);
 
-        let transcript = Transcript {
+        Ok(Transcript {
             segments,
             full_text,
             language,
@@ -233,14 +268,7 @@ async fn full_transcribe(
             num_speakers: None,
             reconciled_at: None,
             had_errors: false,
-        };
-
-        // Sidecar JSON for re-summarization without re-transcribing.
-        let json_path = path.with_file_name(crate::notes::TRANSCRIPT_FILENAME);
-        std::fs::write(&json_path, serde_json::to_vec_pretty(&transcript).unwrap())
-            .map_err(|e| e.to_string())?;
-
-        Ok(transcript)
+        })
     })
     .await
     .map_err(|e| e.to_string())?

--- a/src-tauri/src/voice.rs
+++ b/src-tauri/src/voice.rs
@@ -1,0 +1,168 @@
+//! Lightweight one-shot voice recording for the search palette (#57).
+//!
+//! Captures a short mic clip to a temporary 16-bit PCM 16 kHz mono WAV,
+//! emits `voice-level` events for the palette's level meter, and tracks
+//! peak amplitude so the caller can decide if the recording was silent.
+//!
+//! Why not reuse `audio::start()`? That path requires an owned-note
+//! bundle, spawns a streaming Whisper worker, and mounts system-audio
+//! capture — all wrong for a 5-second voice query. Voice mode collapses
+//! the meeting recorder's three-thread pipeline (mic + sysaudio + mixer)
+//! into a single thread that handles cpal capture, resampling, WAV
+//! writing, and level emission. Reuses the cpal helpers from `audio.rs`
+//! (`build_stream`, `downmix`, `MonoResampler`) via `pub(crate)`.
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
+use tauri::{AppHandle, Emitter};
+
+use crate::audio::{build_stream, downmix, MonoResampler};
+
+const TARGET_SAMPLE_RATE: u32 = 16_000;
+
+pub enum Cmd {
+    Stop,
+}
+
+pub struct VoiceRecording {
+    ctrl_tx: Sender<Cmd>,
+    join: std::thread::JoinHandle<Result<VoiceStopResult, String>>,
+}
+
+pub struct VoiceStopResult {
+    pub wav_path: PathBuf,
+    /// Peak |sample| over the full recording, post-downmix, on the
+    /// 0..1 f32 scale. Used by the caller to decide if the recording
+    /// was effectively silent before paying for Whisper inference.
+    pub max_amplitude: f32,
+}
+
+pub fn start(app: AppHandle) -> Result<VoiceRecording, String> {
+    let mut wav_path = std::env::temp_dir();
+    wav_path.push(format!("margin-voice-{}.wav", uuid::Uuid::new_v4()));
+
+    let (ctrl_tx, ctrl_rx) = unbounded::<Cmd>();
+    let voice_app = app.clone();
+    let join = std::thread::Builder::new()
+        .name("margin-voice".into())
+        .spawn(move || run_voice_thread(voice_app, wav_path, ctrl_rx))
+        .map_err(|e| e.to_string())?;
+
+    Ok(VoiceRecording { ctrl_tx, join })
+}
+
+impl VoiceRecording {
+    pub fn stop(self) -> Result<VoiceStopResult, String> {
+        let _ = self.ctrl_tx.send(Cmd::Stop);
+        match self.join.join() {
+            Ok(Ok(r)) => Ok(r),
+            Ok(Err(e)) => Err(e),
+            Err(_) => Err("voice thread panicked".to_string()),
+        }
+    }
+}
+
+fn run_voice_thread(
+    app: AppHandle,
+    wav_path: PathBuf,
+    ctrl_rx: Receiver<Cmd>,
+) -> Result<VoiceStopResult, String> {
+    let host = cpal::default_host();
+    let device = host
+        .default_input_device()
+        .ok_or_else(|| {
+            "No input device available — check microphone access in System Settings."
+                .to_string()
+        })?;
+    let cfg = device.default_input_config().map_err(|e| e.to_string())?;
+    let sample_rate: u32 = cfg.sample_rate().into();
+    let channels = cfg.channels() as usize;
+    let fmt = cfg.sample_format();
+    let stream_cfg: cpal::StreamConfig = cfg.into();
+
+    let device_name = device
+        .name()
+        .unwrap_or_else(|_| "<unknown>".to_string());
+    eprintln!(
+        "[voice] mic: {} | {} Hz | {} ch | {:?}",
+        device_name, sample_rate, channels, fmt
+    );
+
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate: TARGET_SAMPLE_RATE,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut wav = hound::WavWriter::create(&wav_path, spec).map_err(|e| e.to_string())?;
+
+    // cpal callbacks → raw frames. Bounded so a slow consumer can drop
+    // overflow rather than blocking the audio thread (matches audio.rs).
+    let (raw_tx, raw_rx) = bounded::<Vec<f32>>(64);
+    let stream = build_stream(&device, &stream_cfg, fmt, raw_tx)?;
+    stream.play().map_err(|e| e.to_string())?;
+
+    let mut shaper = MonoResampler::new(sample_rate, channels)?;
+    let mut last_emit = Instant::now();
+    let mut max_amplitude: f32 = 0.0;
+    let mut frame_count: u64 = 0;
+
+    loop {
+        crossbeam_channel::select! {
+            recv(raw_rx) -> msg => {
+                match msg {
+                    Ok(buf) => {
+                        let mono = downmix(&buf, channels);
+
+                        // Peak detector for silence detection. Run on
+                        // the pre-resample mono buffer so the threshold
+                        // doesn't drift with sample-rate conversion.
+                        frame_count += mono.len() as u64;
+                        for &s in &mono {
+                            let a = s.abs();
+                            if a > max_amplitude {
+                                max_amplitude = a;
+                            }
+                        }
+
+                        // ~30 Hz level meter, same shape as audio.rs's
+                        // `audio-level` event so LevelMeter.tsx can
+                        // consume it via its `eventName` prop.
+                        if last_emit.elapsed() >= Duration::from_millis(33) {
+                            let n = mono.len().max(1);
+                            let rms =
+                                (mono.iter().map(|s| s * s).sum::<f32>() / n as f32).sqrt();
+                            let _ = app.emit("voice-level", rms);
+                            last_emit = Instant::now();
+                        }
+
+                        for chunk in shaper.process(mono)? {
+                            for &s in &chunk {
+                                let i = (s.clamp(-1.0, 1.0) * 32767.0) as i16;
+                                wav.write_sample(i).map_err(|e| e.to_string())?;
+                            }
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            recv(ctrl_rx) -> _ => break,
+        }
+    }
+
+    drop(stream); // drop the !Send cpal::Stream on its owning thread
+    wav.finalize().map_err(|e| e.to_string())?;
+
+    eprintln!(
+        "[voice] stop: frames={frame_count} (~{ms}ms @ {sample_rate} Hz), max_amplitude={max_amplitude:.4}",
+        ms = frame_count * 1000 / sample_rate as u64,
+    );
+
+    Ok(VoiceStopResult {
+        wav_path,
+        max_amplitude,
+    })
+}

--- a/src/App.css
+++ b/src/App.css
@@ -4147,3 +4147,98 @@ input.nh-title {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+/* Voice mode (#57). Replaces the input row when active. */
+
+.palette-mic {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition: background 80ms ease, color 80ms ease;
+}
+.palette-mic:hover {
+  background: var(--home-card-hover);
+  color: var(--fg);
+}
+
+.palette-voice {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 22px 18px 18px;
+  border-bottom: 0.5px solid var(--home-line);
+}
+
+.palette-voice .level-meter {
+  /* Override the global `.level-meter` flex sizing — inside the
+     column-flex voice composer it'd otherwise grow to fill height. */
+  flex: 0 0 auto;
+  width: 100%;
+  max-width: none;
+  height: 10px;
+}
+
+.palette-voice-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--fg-muted);
+}
+
+.palette-voice-pulse {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #c44a1f;
+  animation: palette-voice-pulse 1.1s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+@keyframes palette-voice-pulse {
+  0%, 100% { opacity: 0.5; transform: scale(0.85); }
+  50%      { opacity: 1;   transform: scale(1.0);  }
+}
+
+.palette-voice-spinner {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1.5px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-top-color: var(--accent);
+  animation: palette-tool-spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+.palette-voice-didnt-catch {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: #c44a1f;
+  font-size: 12.5px;
+}
+
+.palette-voice-hint {
+  color: var(--fg-muted);
+  font-size: 11.5px;
+}
+
+.palette-voice-hint kbd {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 10.5px;
+  font-weight: 600;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--home-chip);
+  color: var(--fg-muted);
+  margin: 0 2px;
+}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -136,19 +136,70 @@ export function Home({
   const [paletteOpen, setPaletteOpen] = useState(false);
   const unreadBadge = useMemo(() => unreadCount(notifications), [notifications]);
 
-  // Global ⌘K / Ctrl+K to open the search palette. Capture phase so the
-  // editor's Cmd+K (link insert, etc.) doesn't swallow it first.
+  // Global keyboard shortcuts for the search palette:
+  //   ⌘K          — open palette in lexical search mode
+  //   Space hold  — open palette in voice mode; release to transcribe.
+  //                 Only fires when no editable element is focused, so
+  //                 typing in inputs / note editor still gets a space.
+  // Capture phase so the editor's Cmd+K (link insert, etc.) doesn't
+  // swallow it first.
   useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
+    let voiceArmed = false;
+
+    // True when the active element is something the user is likely
+    // typing into. Skips the space-hold trigger so normal typing isn't
+    // hijacked. CodeMirror's content area is contenteditable=true so
+    // it gets caught by the isContentEditable check.
+    const isEditable = (el: Element | null) => {
+      if (!el) return false;
+      const tag = el.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+      return (el as HTMLElement).isContentEditable === true;
+    };
+
+    const onDown = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
+      // ⌘K — existing palette open in search mode.
       if (mod && (e.key === "k" || e.key === "K")) {
         e.preventDefault();
         e.stopPropagation();
         setPaletteOpen(true);
+        return;
+      }
+      // Space hold — voice mode. Skip if any modifier is held (so
+      // ⌘+Space, ⌃+Space etc. continue to work for OS shortcuts) or
+      // if the user is currently typing.
+      if (
+        e.code === "Space" &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        !e.shiftKey
+      ) {
+        if (isEditable(document.activeElement)) return;
+        e.preventDefault();
+        e.stopPropagation();
+        if (voiceArmed || e.repeat) return; // ignore autorepeat
+        voiceArmed = true;
+        setPaletteOpen(true);
+        window.dispatchEvent(new CustomEvent("margin:voice-start"));
       }
     };
-    window.addEventListener("keydown", onKey, { capture: true });
-    return () => window.removeEventListener("keydown", onKey, { capture: true } as EventListenerOptions);
+
+    const onUp = (e: KeyboardEvent) => {
+      if (!voiceArmed) return;
+      if (e.code === "Space") {
+        voiceArmed = false;
+        window.dispatchEvent(new CustomEvent("margin:voice-stop"));
+      }
+    };
+
+    window.addEventListener("keydown", onDown, { capture: true });
+    window.addEventListener("keyup", onUp, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", onDown, { capture: true } as EventListenerOptions);
+      window.removeEventListener("keyup", onUp, { capture: true } as EventListenerOptions);
+    };
   }, []);
 
   // Map sidebar nav → backend scope. Only home, archive, and favorites

--- a/src/SearchPalette.tsx
+++ b/src/SearchPalette.tsx
@@ -10,7 +10,10 @@ import {
   SEARCH_HIGHLIGHT_CLOSE,
   SEARCH_HIGHLIGHT_OPEN,
   type SearchHit,
+  startVoiceRecording,
+  stopVoiceRecording,
 } from "./file";
+import { LevelMeter } from "./LevelMeter";
 import { render as renderMarkdown } from "./markdown";
 import {
   IconArrowRight,
@@ -69,6 +72,12 @@ function joinText(parts: MessagePart[]): string {
 ///
 /// Cmd+Enter from search escalates to chat (sends the current input as
 /// the first user turn). Esc closes and resets everything.
+type VoiceState =
+  | { kind: "off" }
+  | { kind: "recording" }
+  | { kind: "transcribing" }
+  | { kind: "didnt-catch"; message?: string };
+
 export function SearchPalette({ open, onClose, onOpenNote }: Props) {
   const [mode, setMode] = useState<"search" | "chat">("search");
   const [query, setQuery] = useState("");
@@ -76,6 +85,8 @@ export function SearchPalette({ open, onClose, onOpenNote }: Props) {
   const [loading, setLoading] = useState(false);
   const [activeIdx, setActiveIdx] = useState(0);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [voiceState, setVoiceState] = useState<VoiceState>({ kind: "off" });
+  const voiceModeActive = voiceState.kind !== "off";
 
   const inputRef = useRef<HTMLInputElement | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
@@ -94,6 +105,7 @@ export function SearchPalette({ open, onClose, onOpenNote }: Props) {
       setMessages([]);
       setLoading(false);
       setActiveIdx(0);
+      setVoiceState({ kind: "off" });
       return;
     }
     inputRef.current?.focus();
@@ -240,6 +252,90 @@ export function SearchPalette({ open, onClose, onOpenNote }: Props) {
     };
   }, [open, mode]);
 
+  // While voice is recording (from a button mousedown), watch for a
+  // window-level mouseup to end recording — the mic button itself
+  // unmounts as soon as state flips to "recording" (replaced by the
+  // VoiceComposer), so its own onMouseUp can't fire. The keyboard
+  // shortcut path emits margin:voice-stop directly so it doesn't need
+  // this listener.
+  useEffect(() => {
+    if (voiceState.kind !== "recording") return;
+    const onUp = () => void endVoice();
+    window.addEventListener("mouseup", onUp);
+    return () => window.removeEventListener("mouseup", onUp);
+    // endVoice closes over voiceState via React's state updater
+    // functions, so ESLint exhaustive-deps would flag it; safe to skip.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [voiceState.kind]);
+
+  const beginVoice = async () => {
+    // Idempotent: already-armed presses are no-ops.
+    if (voiceState.kind === "recording" || voiceState.kind === "transcribing") {
+      return;
+    }
+    setVoiceState({ kind: "recording" });
+    try {
+      await startVoiceRecording();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setVoiceState({ kind: "didnt-catch", message });
+    }
+  };
+
+  const endVoice = async () => {
+    if (voiceState.kind !== "recording") return;
+    setVoiceState({ kind: "transcribing" });
+    try {
+      const r = await stopVoiceRecording();
+      if (r.status === "silent") {
+        setVoiceState({ kind: "didnt-catch" });
+        return;
+      }
+      if (r.status === "error") {
+        setVoiceState({ kind: "didnt-catch", message: r.text });
+        return;
+      }
+      // Append rather than replace so a user who started typing then
+      // voiced the rest gets composite input. Trim avoids double spaces
+      // when the existing query already ends with whitespace.
+      setQuery((prev) => {
+        const sep = prev.length > 0 && !prev.endsWith(" ") ? " " : "";
+        return prev + sep + r.text;
+      });
+      setVoiceState({ kind: "off" });
+      // Defer focus: the input is being re-enabled, the focus call has
+      // to land after React applies the disabled=false update.
+      setTimeout(() => inputRef.current?.focus(), 0);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setVoiceState({ kind: "didnt-catch", message });
+    }
+  };
+
+  // CustomEvent bridge for Home.tsx's space-hold listener. Must be
+  // registered on MOUNT (not gated on `open`) because Home.tsx
+  // dispatches the event synchronously inside the keydown handler that
+  // also calls setPaletteOpen — if registration were gated on open,
+  // the listener wouldn't exist yet when the event fires.
+  //
+  // Refs let the listener always invoke the latest closure of
+  // beginVoice/endVoice (which read voiceState etc. directly) without
+  // re-registering on every render.
+  const beginVoiceRef = useRef(beginVoice);
+  const endVoiceRef = useRef(endVoice);
+  beginVoiceRef.current = beginVoice;
+  endVoiceRef.current = endVoice;
+  useEffect(() => {
+    const onStart = () => void beginVoiceRef.current();
+    const onStop = () => void endVoiceRef.current();
+    window.addEventListener("margin:voice-start", onStart);
+    window.addEventListener("margin:voice-stop", onStop);
+    return () => {
+      window.removeEventListener("margin:voice-start", onStart);
+      window.removeEventListener("margin:voice-stop", onStop);
+    };
+  }, []);
+
   if (!open) return null;
 
   const isAnyStreaming = messages.some(
@@ -292,6 +388,19 @@ export function SearchPalette({ open, onClose, onOpenNote }: Props) {
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Escape") {
       e.preventDefault();
+      // Esc in voice mode cancels back to the prior search/chat mode
+      // rather than closing the whole palette — gives the user a way
+      // to back out of a misfired ⇧⌘K.
+      if (voiceModeActive) {
+        if (voiceState.kind === "recording") {
+          // Best-effort: tell the backend to stop and discard the
+          // recording. We don't await — the UI returns to off
+          // immediately.
+          void stopVoiceRecording().catch(() => {});
+        }
+        setVoiceState({ kind: "off" });
+        return;
+      }
       onClose();
       return;
     }
@@ -350,42 +459,62 @@ export function SearchPalette({ open, onClose, onOpenNote }: Props) {
         onKeyDown={onKeyDown}
         onMouseDown={(e) => e.stopPropagation()}
       >
-        <div className="palette-input-row">
-          <span className="palette-input-icon" aria-hidden="true">
-            {mode === "chat" ? (
-              <IconSparkle size={14} sw={1.7} />
-            ) : (
-              <IconSearch size={14} sw={1.7} />
-            )}
-          </span>
-          <input
-            ref={inputRef}
-            type="text"
-            className="palette-input"
-            placeholder={placeholder}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            disabled={mode === "chat" && isAnyStreaming}
-            spellCheck={false}
-            autoCorrect="off"
-            autoCapitalize="off"
-          />
-          {mode === "chat" ? (
+        {voiceModeActive ? (
+          <VoiceComposer state={voiceState} />
+        ) : (
+          <div className="palette-input-row">
+            <span className="palette-input-icon" aria-hidden="true">
+              {mode === "chat" ? (
+                <IconSparkle size={14} sw={1.7} />
+              ) : (
+                <IconSearch size={14} sw={1.7} />
+              )}
+            </span>
+            <input
+              ref={inputRef}
+              type="text"
+              className="palette-input"
+              placeholder={placeholder}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              disabled={mode === "chat" && isAnyStreaming}
+              spellCheck={false}
+              autoCorrect="off"
+              autoCapitalize="off"
+            />
             <button
               type="button"
-              className="palette-send"
-              aria-label="Send message"
-              disabled={query.trim().length === 0 || isAnyStreaming}
-              onClick={() => submitChatTurn(query)}
+              className="palette-mic"
+              aria-label="Hold to record voice query"
+              title="Hold to record (or hold space)"
+              // Hold-to-record. mousedown/touchstart begin, the
+              // matching up/cancel events end. Pointer events would
+              // unify these but onMouseDown / onMouseUp work fine on
+              // both desktop platforms we ship to.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                void beginVoice();
+              }}
             >
-              <IconArrowRight size={13} sw={1.7} />
+              <IconMic size={13} sw={1.7} />
             </button>
-          ) : (
-            <span className="palette-input-kbd">esc</span>
-          )}
-        </div>
+            {mode === "chat" ? (
+              <button
+                type="button"
+                className="palette-send"
+                aria-label="Send message"
+                disabled={query.trim().length === 0 || isAnyStreaming}
+                onClick={() => submitChatTurn(query)}
+              >
+                <IconArrowRight size={13} sw={1.7} />
+              </button>
+            ) : (
+              <span className="palette-input-kbd">esc</span>
+            )}
+          </div>
+        )}
 
-        {mode === "search" ? (
+        {voiceModeActive ? null : mode === "search" ? (
           <SearchResults
             ref={resultsRef}
             query={query}
@@ -421,6 +550,37 @@ export function SearchPalette({ open, onClose, onOpenNote }: Props) {
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function VoiceComposer({ state }: { state: VoiceState }) {
+  const status = state.kind;
+  return (
+    <div className={`palette-voice palette-voice-${status}`}>
+      {status === "recording" && (
+        <>
+          <LevelMeter eventName="voice-level" ariaLabel="Voice input level" />
+          <div className="palette-voice-status">
+            <span className="palette-voice-pulse" aria-hidden="true" />
+            Listening — release space to transcribe
+          </div>
+        </>
+      )}
+      {status === "transcribing" && (
+        <div className="palette-voice-status">
+          <span className="palette-voice-spinner" aria-hidden="true" />
+          Transcribing…
+        </div>
+      )}
+      {status === "didnt-catch" && (
+        <div className="palette-voice-didnt-catch">
+          <div>{state.message ?? "Didn't catch that."}</div>
+          <div className="palette-voice-hint">
+            Hold <kbd>space</kbd> to try again, or press <kbd>esc</kbd> to cancel.
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -275,6 +275,24 @@ export async function askNotesStart(
   return invoke<void>("ask_notes_start", { turnId, query, history, model });
 }
 
+// --- Voice mode (#57) ----------------------------------------------------
+
+/** Result of a voice-query stop. `ok` carries the transcribed text;
+ *  `silent` means the recording was below the silence threshold (no
+ *  speech detected); `error` carries a user-facing message in `text`. */
+export type VoiceTranscript = {
+  status: "ok" | "silent" | "error";
+  text: string;
+};
+
+export async function startVoiceRecording(): Promise<void> {
+  return invoke<void>("start_voice_recording");
+}
+
+export async function stopVoiceRecording(model?: string): Promise<VoiceTranscript> {
+  return invoke<VoiceTranscript>("stop_voice_recording", { model });
+}
+
 export type NoteMeta = { modified_ms: number };
 
 export async function noteMeta(notePath: string): Promise<NoteMeta> {


### PR DESCRIPTION
## Summary
- Hold **space** (when no editable element is focused) → palette opens in voice mode, records, transcribes locally via the existing Whisper stack, drops the transcript into the input as editable text
- Mic button in the palette input row also enters voice mode (mousedown to start, window-level mouseup catches the release)
- Reuses the meeting transcription stack: shared cpal helpers (made `pub(crate)`), extracted `transcribe_wav_to_transcript` helper that both `transcribe()` and the voice path call
- New `voice.rs` is the lightweight one-shot recorder — single thread, temp WAV in `temp_dir`, peak-amplitude silence detection at 0.01
- Voice has its own state slot; refuses to start if a meeting is already recording

## How it triggers
- Capture-phase keydown on `Space` with no modifier keys
- Skips when `document.activeElement` is `INPUT` / `TEXTAREA` / `SELECT` / `contenteditable=true` so typing keeps producing a normal space
- Autorepeat dedup via a `voiceArmed` flag
- Window-scoped `margin:voice-start` / `margin:voice-stop` CustomEvents bridge the keyboard wiring in `Home.tsx` to the palette without prop-drilling. Listener registers on mount (not gated on palette open) — otherwise the synchronous dispatch races the palette mount

Closes #57.

## Test plan
- [ ] Hold space outside any input → palette opens in voice mode, level meter pulses, "Listening — release space to transcribe"
- [ ] Release space → "Transcribing…" → transcript drops into the input
- [ ] Press Enter (search) or ⌘↵ (AI ask) on the transcribed text — both work
- [ ] Hold space while typing in the palette input → space types normally, voice does NOT trigger
- [ ] Hold space while typing in the note editor (CodeMirror contenteditable) → space types normally
- [ ] Quick tap of space outside an input → "Didn't catch that" briefly, no crash
- [ ] Mic button in chat composer: mousedown → records, mouseup anywhere → ends
- [ ] Esc while recording → cancels, palette stays open in prior mode
- [ ] Start a meeting recording, then try space-hold → "A meeting is recording — stop it first" inline
- [ ] No mic permission → clear error message; granting permission and retrying works