### PR TITLE
Connector platform + OAuth (#59, #60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,38 @@ bun run tauri build
 
 Produces a `.dmg` and `.app` in `src-tauri/target/release/bundle/`.
 
+## OAuth client IDs
+
+Margin's connector platform supports Google and Microsoft (calendar, with email / chat etc. to follow). Each provider's client ID is read from an environment variable at build time — no secrets land in the source tree.
+
+To enable a provider, register a desktop OAuth app in its developer console and export the client ID before `cargo build` / `bun run tauri build` / `bun run tauri dev`:
+
+### Google
+
+1. [Google Cloud Console → APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)
+2. Create an **OAuth client ID** of type **Desktop**.
+3. Under "Authorized redirect URIs," add `http://127.0.0.1:8765` through `http://127.0.0.1:8784` (Margin's loopback range).
+4. Enable the **Google Calendar API** in APIs & Services → Library.
+5. Copy the client ID (the public string ending in `.apps.googleusercontent.com`).
+6. Export it:
+   ```sh
+   export MARGIN_GOOGLE_CLIENT_ID="123456789-abc.apps.googleusercontent.com"
+   ```
+
+### Microsoft
+
+1. [Azure App Registrations](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade) → **New registration**.
+2. Account type: **Personal Microsoft accounts only** (or include work/school as needed).
+3. Redirect URI type: **Public client/native (mobile & desktop)**, value `http://127.0.0.1:8765` (add the rest of the range too: `8766`..`8784`).
+4. API permissions → Microsoft Graph → **Calendars.Read**, **User.Read**, **offline_access**.
+5. Copy the **Application (client) ID** from Overview.
+6. Export it:
+   ```sh
+   export MARGIN_MICROSOFT_CLIENT_ID="00000000-0000-0000-0000-000000000000"
+   ```
+
+Without these env vars set, the corresponding provider simply doesn't appear in Settings → Connectors → Add. PKCE means no client secret is required.
+
 ## Shortcuts
 
 | Action     | Key            |

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2371,6 +2371,7 @@ name = "margin"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "chrono",
  "cpal",
  "crossbeam-channel",
@@ -2380,6 +2381,7 @@ dependencies = [
  "keyring",
  "notify",
  "notify-debouncer-full",
+ "oauth2",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -2400,6 +2402,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "unicode-normalization",
+ "url",
  "uuid",
  "whisper-rs",
  "whoami",
@@ -2642,6 +2645,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -3391,6 +3414,8 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -3400,8 +3425,18 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3419,6 +3454,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -3938,6 +3976,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2370,6 +2370,7 @@ dependencies = [
 name = "margin"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "cpal",
  "crossbeam-channel",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,9 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 whoami = "1"
 unicode-normalization = "0.1"
 async-trait = "0.1"
+oauth2 = { version = "5", default-features = false, features = ["reqwest", "rustls-tls"] }
+url = "2"
+base64 = "0.22"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = [
     "NSResponder",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ window-vibrancy = "0.6"
 rusqlite = { version = "0.32", features = ["bundled"] }
 whoami = "1"
 unicode-normalization = "0.1"
+async-trait = "0.1"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = [
     "NSResponder",

--- a/src-tauri/src/connectors/commands.rs
+++ b/src-tauri/src/connectors/commands.rs
@@ -1,0 +1,44 @@
+//! Tauri command handlers for the connector module. Only `list_connectors`
+//! ships in #59 — the add/remove flow lands with #60's OAuth work.
+
+use std::sync::Mutex;
+
+use rusqlite::Connection;
+
+use super::ConnectorInfo;
+
+#[tauri::command]
+pub fn list_connectors(
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<Vec<ConnectorInfo>, String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    let mut stmt = c
+        .prepare(
+            "SELECT c.id, c.kind, c.display_name, c.enabled, \
+                    s.last_sync_ms, s.last_success_ms, s.last_error, \
+                    COALESCE(s.next_due_ms, 0) AS next_due_ms \
+             FROM connectors c \
+             LEFT JOIN sync_status s ON s.connector_id = c.id \
+             ORDER BY c.kind, c.display_name",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |r| {
+            Ok(ConnectorInfo {
+                id: r.get(0)?,
+                kind: r.get(1)?,
+                display_name: r.get(2)?,
+                enabled: r.get::<_, i64>(3)? != 0,
+                last_sync_ms: r.get(4)?,
+                last_success_ms: r.get(5)?,
+                last_error: r.get(6)?,
+                next_due_ms: r.get(7)?,
+            })
+        })
+        .map_err(|e| e.to_string())?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row.map_err(|e| e.to_string())?);
+    }
+    Ok(out)
+}

--- a/src-tauri/src/connectors/commands.rs
+++ b/src-tauri/src/connectors/commands.rs
@@ -1,11 +1,15 @@
-//! Tauri command handlers for the connector module. Only `list_connectors`
-//! ships in #59 — the add/remove flow lands with #60's OAuth work.
+//! Tauri command handlers for the connector module.
 
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use rusqlite::Connection;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
 
+use super::oauth;
+use super::providers;
 use super::ConnectorInfo;
+use super::ConnectorRegistry;
 
 #[tauri::command]
 pub fn list_connectors(
@@ -41,4 +45,150 @@ pub fn list_connectors(
         out.push(row.map_err(|e| e.to_string())?);
     }
     Ok(out)
+}
+
+#[derive(Serialize, Clone)]
+pub struct OAuthProviderInfo {
+    pub kind: String,
+    pub display_name: String,
+}
+
+/// Returns the OAuth providers whose client_id is set at build time.
+/// Drives the "Add connector" picker — providers without a configured
+/// client_id are hidden so users don't see a button that can't work.
+#[tauri::command]
+pub fn list_oauth_providers() -> Vec<OAuthProviderInfo> {
+    providers::list_configured()
+        .into_iter()
+        .map(|p| OAuthProviderInfo {
+            kind: p.kind.to_string(),
+            display_name: p.display_name.to_string(),
+        })
+        .collect()
+}
+
+/// Run the OAuth flow for `kind`, persist tokens + DB row, and return
+/// the resulting `connector_id`.
+///
+/// Same `connector_id` repeats: the row is updated (tokens rotated)
+/// rather than duplicated. This is also the "Reconnect" path — the
+/// frontend can call this again with the same kind for an existing
+/// account; the user just re-authenticates and the new tokens replace
+/// the old ones.
+#[tauri::command]
+pub async fn start_oauth_connector(
+    app: AppHandle,
+    kind: String,
+    conn: tauri::State<'_, Mutex<Connection>>,
+    registry: tauri::State<'_, Arc<ConnectorRegistry>>,
+) -> Result<String, String> {
+    let provider = providers::lookup(&kind).ok_or_else(|| format!("unknown kind: {kind}"))?;
+
+    let result = oauth::run_authorization_flow(&app, &kind)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let connector_id = format!("{}:{}", kind, result.email);
+    let display_name = format!("{} ({})", provider.display_name, result.email);
+    let now_ms = current_unix_ms();
+
+    {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        c.execute(
+            "INSERT INTO connectors(id, kind, display_name, enabled, config_json, created_ms, updated_ms) \
+             VALUES (?1, ?2, ?3, 1, '{}', ?4, ?4) \
+             ON CONFLICT(id) DO UPDATE SET \
+                display_name = excluded.display_name, \
+                enabled = 1, \
+                updated_ms = excluded.updated_ms",
+            rusqlite::params![&connector_id, &kind, &display_name, now_ms],
+        )
+        .map_err(|e| e.to_string())?;
+
+        // Mark the connector due for an immediate sync the next time
+        // the runner ticks.
+        c.execute(
+            "INSERT INTO sync_status(connector_id, next_due_ms) \
+             VALUES (?1, 0) \
+             ON CONFLICT(connector_id) DO UPDATE SET \
+                next_due_ms = 0, \
+                last_error = NULL",
+            rusqlite::params![&connector_id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    // Re-instantiate connectors. If a factory for this kind is
+    // registered (#61, #63 onward), this picks the new row up; if
+    // not, the row is skipped and the runner logs "no factory" until
+    // a future build registers one.
+    {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        if let Err(e) = registry.rebuild_instances(&app, &c) {
+            eprintln!("[connectors] rebuild after OAuth flow failed: {e}");
+        }
+    }
+
+    let _ = app.emit(
+        "connector-status",
+        serde_json::json!({
+            "connector_id": connector_id,
+            "state": "added",
+            "message": null,
+        }),
+    );
+
+    Ok(connector_id)
+}
+
+/// Remove a connector's DB row + keychain tokens. Idempotent — calling
+/// twice is safe.
+#[tauri::command]
+pub async fn delete_connector(
+    app: AppHandle,
+    connector_id: String,
+    conn: tauri::State<'_, Mutex<Connection>>,
+    registry: tauri::State<'_, Arc<ConnectorRegistry>>,
+) -> Result<(), String> {
+    {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        // CASCADE on sync_status takes care of the status row.
+        c.execute(
+            "DELETE FROM connectors WHERE id = ?1",
+            rusqlite::params![&connector_id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    if let Err(e) = oauth::forget_tokens(&connector_id) {
+        // Log but don't fail — the DB row is gone, which is the
+        // source of truth. Orphan keychain entries are inert.
+        eprintln!("[connectors] forget_tokens failed for {connector_id}: {e}");
+    }
+
+    {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        if let Err(e) = registry.rebuild_instances(&app, &c) {
+            eprintln!("[connectors] rebuild after delete failed: {e}");
+        }
+    }
+
+    let _ = app.emit(
+        "connector-status",
+        serde_json::json!({
+            "connector_id": connector_id,
+            "state": "removed",
+            "message": null,
+        }),
+    );
+
+    Ok(())
+}
+
+fn current_unix_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
 }

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -1,0 +1,182 @@
+//! Connector platform foundation (#59).
+//!
+//! Pluggable architecture for external signal sources. A `Connector`
+//! is a self-contained unit that:
+//!   - Owns its own auth (OAuth tokens, API keys, etc. — see #60)
+//!   - Pulls signals from an external system into local SQLite tables
+//!     (calendar events for #61/#63, future: emails, chat messages, ...)
+//!   - Reports a polling cadence the `SyncRunner` respects
+//!   - Surfaces sync state via the unified `connector-status` Tauri event
+//!
+//! No real connector implementations live in this PR — those land in
+//! #61 (Google Calendar) and #63 (Microsoft Graph). The trait and
+//! supporting machinery here are the floor that those PRs (and any
+//! future signal source) plug into.
+//!
+//! `dead_code` is allowed module-wide because the trait + types
+//! exposed here are deliberately ahead of their first caller. Removing
+//! the allow once #61 lands and exercises this surface in earnest.
+
+#![allow(dead_code)]
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rusqlite::Connection;
+use serde::Serialize;
+
+pub mod commands;
+pub mod registry;
+pub mod runner;
+
+pub use registry::ConnectorRegistry;
+
+/// Implemented by every signal source. Required for `#[dyn Connector]`
+/// — the registry holds heterogeneous connectors as `Arc<dyn Connector>`.
+///
+/// `async_trait` is used here because native async-fn-in-trait
+/// (Rust 1.75+) doesn't compose cleanly with `dyn Trait` without extra
+/// adapter ceremony. The proc-macro overhead is one allocation per
+/// `sync()` call — negligible compared to the network I/O the call
+/// will dominate with anyway.
+#[async_trait::async_trait]
+pub trait Connector: Send + Sync {
+    /// Stable id used as the primary key in the `connectors` table and
+    /// in all event payloads. Convention: `<kind>:<account>` (e.g.
+    /// `google_calendar:tj@example.com`).
+    fn id(&self) -> &str;
+
+    /// Factory key that maps to a registered constructor in the
+    /// `ConnectorRegistry`. Multiple connectors can share a kind
+    /// (e.g. two Google accounts) but each instance has a unique `id`.
+    fn kind(&self) -> &str;
+
+    /// Human-readable label for the Settings UI.
+    fn display_name(&self) -> &str;
+
+    /// How often `sync` should run when the connector is enabled. The
+    /// `SyncRunner` ticks at a finer resolution and respects this as
+    /// the per-connector minimum gap between syncs.
+    fn poll_interval(&self) -> Duration;
+
+    /// Pull the latest state from the external system into local
+    /// storage. Should commit DB writes through `ctx.conn` directly —
+    /// callers don't write to the DB on the connector's behalf.
+    async fn sync(&self, ctx: SyncCtx<'_>) -> Result<SyncReport, ConnectorError>;
+}
+
+/// Per-sync context passed to `Connector::sync`. Borrows are tied to
+/// the runner's iteration so the connector can't squirrel them away.
+pub struct SyncCtx<'a> {
+    pub app: &'a tauri::AppHandle,
+    pub conn: &'a Mutex<Connection>,
+    /// Cooperative cancellation flag. Set true when the user disables
+    /// or removes the connector mid-sync. Connectors should poll this
+    /// at any natural break (between paginated requests, etc.) and
+    /// return `ConnectorError::Other("cancelled")` when set. v1
+    /// connectors can ignore this — runners give an in-flight sync
+    /// time to finish naturally before a subsequent disable takes
+    /// effect.
+    pub cancel: Arc<std::sync::atomic::AtomicBool>,
+}
+
+/// Counts the work done in a single sync. Used by the runner to
+/// produce the `synced` event payload and (later) to power "X new
+/// events today" UI affordances.
+#[derive(Debug, Default, Serialize, Clone)]
+pub struct SyncReport {
+    pub added: u64,
+    pub updated: u64,
+    pub removed: u64,
+    pub skipped: u64,
+}
+
+/// Failure modes the runner cares about. The variants drive both the
+/// stored `sync_status.last_error` text and downstream UI surfacing
+/// (e.g. `ReauthNeeded` becomes a "Reconnect" button in Settings once
+/// #60's add/remove UI lands).
+#[derive(Debug, Clone)]
+pub enum ConnectorError {
+    Network(String),
+    ReauthNeeded(String),
+    RateLimited { retry_after_ms: u64 },
+    Other(String),
+}
+
+impl std::fmt::Display for ConnectorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Network(m) => write!(f, "network: {m}"),
+            Self::ReauthNeeded(m) => write!(f, "reauth_needed: {m}"),
+            Self::RateLimited { retry_after_ms } => {
+                write!(f, "rate_limited: retry after {retry_after_ms}ms")
+            }
+            Self::Other(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+impl ConnectorError {
+    /// Tag used when persisting to `sync_status.last_error`. Settings
+    /// UI matches on this prefix to pick a UX treatment.
+    pub fn tag(&self) -> &'static str {
+        match self {
+            Self::Network(_) => "network",
+            Self::ReauthNeeded(_) => "reauth_needed",
+            Self::RateLimited { .. } => "rate_limited",
+            Self::Other(_) => "other",
+        }
+    }
+}
+
+/// Frontend-facing snapshot of one connector + its sync state. Joined
+/// from the `connectors` and `sync_status` tables in
+/// `commands::list_connectors`.
+#[derive(Serialize, Clone)]
+pub struct ConnectorInfo {
+    pub id: String,
+    pub kind: String,
+    pub display_name: String,
+    pub enabled: bool,
+    pub last_sync_ms: Option<i64>,
+    pub last_success_ms: Option<i64>,
+    pub last_error: Option<String>,
+    pub next_due_ms: i64,
+}
+
+/// Persisted row in the `connectors` table. Passed to factories via
+/// the registry so a connector instance can hydrate from its own
+/// per-kind config blob (which the factory parses; the registry treats
+/// it as opaque).
+#[derive(Debug, Clone)]
+pub struct ConnectorRow {
+    pub id: String,
+    pub kind: String,
+    pub display_name: String,
+    pub enabled: bool,
+    pub config_json: String,
+}
+
+/// Read all connector rows from the DB. Used by both the registry
+/// (to instantiate at boot) and the runner (to resolve `id` → `kind`
+/// when a previously-known instance has been removed mid-iteration).
+pub fn load_connector_rows(conn: &Connection) -> rusqlite::Result<Vec<ConnectorRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, kind, display_name, enabled, config_json FROM connectors \
+         ORDER BY kind, display_name",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok(ConnectorRow {
+            id: r.get(0)?,
+            kind: r.get(1)?,
+            display_name: r.get(2)?,
+            enabled: r.get::<_, i64>(3)? != 0,
+            config_json: r.get(4)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -26,6 +26,8 @@ use rusqlite::Connection;
 use serde::Serialize;
 
 pub mod commands;
+pub mod oauth;
+pub mod providers;
 pub mod registry;
 pub mod runner;
 

--- a/src-tauri/src/connectors/oauth.rs
+++ b/src-tauri/src/connectors/oauth.rs
@@ -1,0 +1,617 @@
+//! OAuth 2.0 (PKCE) flow runner + per-call refresh helper for cloud
+//! connectors (#60).
+//!
+//! Two public entry points:
+//!   - `run_authorization_flow(app, kind)` — opens the system browser,
+//!     listens on a localhost loopback for the redirect, exchanges the
+//!     code for tokens, persists them to the keychain. Returns the
+//!     user's email so the caller can construct a stable `connector_id`.
+//!   - `with_valid_token(app, connector_id, kind, f)` — reads tokens,
+//!     refreshes if expired or near-expired, hands a valid access token
+//!     to the closure, retries once on 401. The main API surface for
+//!     a `Connector::sync` implementation.
+//!
+//! PKCE replaces the client secret. Public clients (desktop apps)
+//! generate a verifier, send only the SHA-256 challenge to the auth
+//! server, and prove possession at code-exchange time. Means we ship
+//! the client_id in the binary safely.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use oauth2::basic::{BasicClient, BasicErrorResponseType, BasicTokenType};
+use oauth2::{
+    AuthUrl, AuthorizationCode, Client, ClientId, CsrfToken, EmptyExtraTokenFields,
+    EndpointNotSet, EndpointSet, PkceCodeChallenge, RedirectUrl, RefreshToken,
+    RequestTokenError, RevocationErrorResponseType, Scope, StandardErrorResponse,
+    StandardRevocableToken, StandardTokenIntrospectionResponse, StandardTokenResponse,
+    TokenResponse, TokenUrl,
+};
+use serde::Deserialize;
+use tauri::AppHandle;
+use tauri_plugin_opener::OpenerExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use super::providers::{self, OAuthProvider};
+use super::ConnectorError;
+use crate::keychain::{
+    delete_connector_tokens, read_connector_tokens, write_connector_tokens, ConnectorTokens,
+};
+
+/// First port we try for the OAuth redirect listener; we walk forward
+/// to the end of the range looking for one that's free. Both Google
+/// and Microsoft accept any localhost port for desktop apps as long
+/// as the URI is registered exactly. Register `8765..8784` once in
+/// each console.
+const REDIRECT_PORT_START: u16 = 8765;
+const REDIRECT_PORT_END: u16 = 8784;
+/// Hard timeout on the entire flow — opens browser, waits for the
+/// user's grant + redirect. 120s gives time for password / 2FA / app
+/// switcher confusion.
+const FLOW_TIMEOUT: Duration = Duration::from_secs(120);
+/// Refresh tokens proactively if they expire within this window.
+/// Avoids the case where a sync starts at T-30s and fails 5s in
+/// when the token expires mid-flight.
+const REFRESH_LEEWAY: Duration = Duration::from_secs(60);
+
+/// Ergonomic alias for the type-state-encoded fully-configured client.
+type ConfiguredClient = Client<
+    StandardErrorResponse<BasicErrorResponseType>,
+    StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
+    StandardTokenIntrospectionResponse<EmptyExtraTokenFields, BasicTokenType>,
+    StandardRevocableToken,
+    StandardErrorResponse<RevocationErrorResponseType>,
+    EndpointSet,    // auth_url
+    EndpointNotSet, // device_auth_url
+    EndpointNotSet, // introspection_url
+    EndpointNotSet, // revocation_url
+    EndpointSet,    // token_url
+>;
+
+#[derive(Debug, Clone)]
+pub struct AuthorizationResult {
+    /// User's email / UPN, extracted from the id_token. Used to
+    /// construct connector_id (`<kind>:<email>`).
+    pub email: String,
+    pub tokens: ConnectorTokens,
+}
+
+/// Drive the OAuth Authorization Code + PKCE flow end-to-end. After
+/// this returns, tokens have been persisted to the keychain at
+/// `connector::<kind>:<email>` — caller's responsibility is just to
+/// upsert the `connectors` table row.
+pub async fn run_authorization_flow(
+    app: &AppHandle,
+    kind: &str,
+) -> Result<AuthorizationResult, ConnectorError> {
+    let provider = providers::lookup(kind).ok_or_else(|| {
+        ConnectorError::Other(format!("unknown OAuth kind: {kind}"))
+    })?;
+    let client_id = provider.client_id.ok_or_else(|| {
+        ConnectorError::Other(format!(
+            "{} client ID not configured (set MARGIN_{}_CLIENT_ID at build time)",
+            provider.display_name,
+            provider.kind.to_uppercase().replace('_', "_")
+        ))
+    })?;
+
+    // Bind the loopback FIRST — we need the chosen port to build the
+    // redirect_uri before opening the browser.
+    let (listener, port) = bind_loopback().await?;
+    let redirect_uri = format!("http://127.0.0.1:{port}/oauth/callback");
+
+    let oauth_client = build_client(provider, client_id, &redirect_uri)?;
+    let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+
+    let mut auth_request = oauth_client.authorize_url(CsrfToken::new_random);
+    for scope in provider.scopes {
+        auth_request = auth_request.add_scope(Scope::new((*scope).to_string()));
+    }
+    let (auth_url, csrf_token) = auth_request
+        .set_pkce_challenge(pkce_challenge)
+        .url();
+
+    // Open in the system browser. Failure is recoverable — surface a
+    // message asking the user to copy the URL manually. Most users
+    // never see this path.
+    if let Err(e) = app.opener().open_url(auth_url.as_str(), None::<&str>) {
+        eprintln!("[oauth] open_url failed: {e}; flow continues — user can copy URL manually");
+    }
+
+    // Wait for the callback. The browser hits `/oauth/callback?code=...&state=...`
+    // (or `?error=...`). We accept exactly one connection and parse it.
+    let (code, returned_state) = tokio::time::timeout(FLOW_TIMEOUT, accept_callback(listener))
+        .await
+        .map_err(|_| ConnectorError::Other("OAuth flow timed out (120s)".to_string()))??;
+
+    if returned_state != *csrf_token.secret() {
+        return Err(ConnectorError::Other(
+            "OAuth state mismatch — possible CSRF; flow aborted".to_string(),
+        ));
+    }
+
+    // Exchange code for tokens.
+    let http_client = reqwest::Client::builder()
+        // Block redirects — token endpoint should never redirect.
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| ConnectorError::Network(format!("http client init: {e}")))?;
+
+    let token_result = oauth_client
+        .exchange_code(AuthorizationCode::new(code))
+        .set_pkce_verifier(pkce_verifier)
+        .request_async(&http_client)
+        .await
+        .map_err(map_token_error)?;
+
+    let tokens = token_response_to_stored(&token_result);
+
+    // Extract user identity from the id_token (or fall back to a
+    // /userinfo call if absent). For our two supported providers,
+    // id_token is always present when openid/User.Read scope is
+    // requested.
+    let email = extract_email(&token_result, provider, &tokens.access_token, &http_client)
+        .await
+        .ok_or_else(|| {
+            ConnectorError::Other(
+                "couldn't determine user email from OAuth response".to_string(),
+            )
+        })?;
+
+    let connector_id = format!("{}:{}", kind, email);
+    write_connector_tokens(&connector_id, &tokens).map_err(ConnectorError::Other)?;
+
+    Ok(AuthorizationResult { email, tokens })
+}
+
+/// Run an authenticated request with a guaranteed-fresh access token.
+///
+/// Refresh logic:
+/// - If `expires_at_ms - REFRESH_LEEWAY <= now`, refresh before
+///   calling the closure.
+/// - If the closure returns an error, we don't auto-retry — the
+///   connector decides retry semantics based on its own status code
+///   handling. (Adding 401-detection here would require a uniform
+///   error type; not worth the abstraction yet.)
+///
+/// On refresh failure with an `invalid_grant` response, surfaces
+/// `ConnectorError::ReauthNeeded` so the runner records the error
+/// and the UI can offer a "Reconnect" button.
+pub async fn with_valid_token<F, Fut, T>(
+    app: &AppHandle,
+    connector_id: &str,
+    kind: &str,
+    f: F,
+) -> Result<T, ConnectorError>
+where
+    F: FnOnce(String) -> Fut,
+    Fut: std::future::Future<Output = Result<T, ConnectorError>>,
+{
+    let _ = app; // kept on signature for future use (e.g. emit refresh-progress)
+    let mut tokens = read_connector_tokens(connector_id)
+        .map_err(ConnectorError::Other)?
+        .ok_or_else(|| {
+            ConnectorError::ReauthNeeded(format!(
+                "no stored tokens for connector {connector_id}"
+            ))
+        })?;
+
+    let now = current_unix_ms();
+    let expires_soon =
+        tokens.expires_at_ms - (REFRESH_LEEWAY.as_millis() as i64) <= now;
+    if expires_soon {
+        tokens = refresh_tokens(connector_id, kind, &tokens).await?;
+    }
+
+    f(tokens.access_token.clone()).await
+}
+
+async fn refresh_tokens(
+    connector_id: &str,
+    kind: &str,
+    current: &ConnectorTokens,
+) -> Result<ConnectorTokens, ConnectorError> {
+    let provider = providers::lookup(kind).ok_or_else(|| {
+        ConnectorError::Other(format!("unknown kind during refresh: {kind}"))
+    })?;
+    let client_id = provider.client_id.ok_or_else(|| {
+        ConnectorError::Other(format!("{} client ID not configured", provider.display_name))
+    })?;
+    let refresh_token_str = current.refresh_token.as_ref().ok_or_else(|| {
+        ConnectorError::ReauthNeeded(
+            "no refresh token stored — initial flow didn't return one".to_string(),
+        )
+    })?;
+
+    // Build a client without a redirect_uri — refresh doesn't use one.
+    // We still need it typed correctly; pass a placeholder that the
+    // request never references.
+    let oauth_client = build_client(provider, client_id, "http://127.0.0.1:0/unused")?;
+
+    let http_client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| ConnectorError::Network(format!("http client init: {e}")))?;
+
+    let result = oauth_client
+        .exchange_refresh_token(&RefreshToken::new(refresh_token_str.clone()))
+        .request_async(&http_client)
+        .await
+        .map_err(map_token_error)?;
+
+    let mut next = token_response_to_stored(&result);
+    // Some providers (Google) only return a refresh token on the
+    // initial exchange. Preserve the existing one if the refresh
+    // response didn't include a new one.
+    if next.refresh_token.is_none() {
+        next.refresh_token = current.refresh_token.clone();
+    }
+
+    write_connector_tokens(connector_id, &next).map_err(ConnectorError::Other)?;
+    Ok(next)
+}
+
+/// Remove tokens from the keychain. Called by `delete_connector`
+/// alongside the DB row deletion.
+pub fn forget_tokens(connector_id: &str) -> Result<(), String> {
+    delete_connector_tokens(connector_id)
+}
+
+// ----- Internal helpers --------------------------------------------------
+
+fn build_client(
+    provider: &OAuthProvider,
+    client_id: &str,
+    redirect_uri: &str,
+) -> Result<ConfiguredClient, ConnectorError> {
+    let auth_url = AuthUrl::new(provider.auth_url.to_string())
+        .map_err(|e| ConnectorError::Other(format!("bad auth_url for {}: {e}", provider.kind)))?;
+    let token_url = TokenUrl::new(provider.token_url.to_string())
+        .map_err(|e| ConnectorError::Other(format!("bad token_url for {}: {e}", provider.kind)))?;
+    let redirect_url = RedirectUrl::new(redirect_uri.to_string())
+        .map_err(|e| ConnectorError::Other(format!("bad redirect_uri: {e}")))?;
+
+    let client = BasicClient::new(ClientId::new(client_id.to_string()))
+        .set_auth_uri(auth_url)
+        .set_token_uri(token_url)
+        .set_redirect_uri(redirect_url);
+    Ok(client)
+}
+
+async fn bind_loopback() -> Result<(TcpListener, u16), ConnectorError> {
+    for port in REDIRECT_PORT_START..=REDIRECT_PORT_END {
+        match TcpListener::bind(("127.0.0.1", port)).await {
+            Ok(l) => return Ok((l, port)),
+            Err(_) => continue,
+        }
+    }
+    Err(ConnectorError::Other(format!(
+        "no free port in {}..={}",
+        REDIRECT_PORT_START, REDIRECT_PORT_END
+    )))
+}
+
+/// Accept exactly one TCP connection, parse the HTTP request line for
+/// `?code=...&state=...` (or `?error=...`), respond with a friendly
+/// HTML page, return the code + state.
+async fn accept_callback(
+    listener: TcpListener,
+) -> Result<(String, String), ConnectorError> {
+    let (mut stream, _peer) = listener
+        .accept()
+        .await
+        .map_err(|e| ConnectorError::Network(format!("accept callback: {e}")))?;
+
+    // Read until we have at least the request line + first newline.
+    // OAuth callbacks don't have request bodies, so we don't need to
+    // parse Content-Length.
+    let mut buf = vec![0u8; 4096];
+    let mut total = 0usize;
+    let request_line = loop {
+        let n = stream
+            .read(&mut buf[total..])
+            .await
+            .map_err(|e| ConnectorError::Network(format!("read callback: {e}")))?;
+        if n == 0 {
+            return Err(ConnectorError::Other(
+                "callback connection closed before request line".to_string(),
+            ));
+        }
+        total += n;
+        if let Some(idx) = buf[..total].iter().position(|&b| b == b'\n') {
+            let line = std::str::from_utf8(&buf[..idx])
+                .map_err(|e| ConnectorError::Other(format!("callback utf8: {e}")))?
+                .trim_end_matches('\r')
+                .to_string();
+            break line;
+        }
+        if total >= buf.len() {
+            return Err(ConnectorError::Other(
+                "callback request line too long".to_string(),
+            ));
+        }
+    };
+
+    // Send the success page back synchronously so the user's tab
+    // gets a friendly close-message before our task ends.
+    let body = "<html><body style=\"font-family:-apple-system,sans-serif;padding:32px;text-align:center;color:#333\">\
+        <h2>Connected to Margin</h2>\
+        <p>You can close this tab and return to the app.</p>\
+        </body></html>";
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    let _ = stream.write_all(response.as_bytes()).await;
+    let _ = stream.shutdown().await;
+
+    parse_callback_request_line(&request_line)
+}
+
+/// Parse the HTTP request line "GET /oauth/callback?code=...&state=... HTTP/1.1".
+fn parse_callback_request_line(line: &str) -> Result<(String, String), ConnectorError> {
+    let mut parts = line.split_whitespace();
+    let _method = parts
+        .next()
+        .ok_or_else(|| ConnectorError::Other("malformed callback request line".to_string()))?;
+    let path = parts
+        .next()
+        .ok_or_else(|| ConnectorError::Other("missing path on callback".to_string()))?;
+    let query = path.split_once('?').map(|(_, q)| q).unwrap_or("");
+
+    let mut code: Option<String> = None;
+    let mut state: Option<String> = None;
+    let mut error: Option<String> = None;
+    for pair in query.split('&') {
+        let (k, v) = match pair.split_once('=') {
+            Some(kv) => kv,
+            None => continue,
+        };
+        let v_decoded = url_decode(v);
+        match k {
+            "code" => code = Some(v_decoded),
+            "state" => state = Some(v_decoded),
+            "error" => error = Some(v_decoded),
+            _ => {}
+        }
+    }
+    if let Some(err) = error {
+        return Err(ConnectorError::Other(format!("OAuth provider returned error: {err}")));
+    }
+    let code = code.ok_or_else(|| {
+        ConnectorError::Other("no `code` in OAuth callback".to_string())
+    })?;
+    let state = state.ok_or_else(|| {
+        ConnectorError::Other("no `state` in OAuth callback".to_string())
+    })?;
+    Ok((code, state))
+}
+
+fn url_decode(s: &str) -> String {
+    // Minimal — just %XX and `+` → space. Sufficient for OAuth tokens
+    // and state strings, which are URL-safe base64 in practice anyway.
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'+' {
+            out.push(' ');
+            i += 1;
+        } else if b == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            match (hi, lo) {
+                (Some(h), Some(l)) => {
+                    out.push(((h * 16 + l) as u8) as char);
+                    i += 3;
+                }
+                _ => {
+                    out.push(b as char);
+                    i += 1;
+                }
+            }
+        } else {
+            out.push(b as char);
+            i += 1;
+        }
+    }
+    out
+}
+
+fn token_response_to_stored(
+    resp: &StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
+) -> ConnectorTokens {
+    let access_token = resp.access_token().secret().clone();
+    let refresh_token = resp.refresh_token().map(|r| r.secret().clone());
+    let expires_at_ms = current_unix_ms()
+        + resp
+            .expires_in()
+            .map(|d| d.as_millis() as i64)
+            // Conservative default if the provider didn't tell us.
+            .unwrap_or(60 * 60 * 1000);
+    let scope = resp
+        .scopes()
+        .map(|scopes| {
+            scopes
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .unwrap_or_default();
+    ConnectorTokens {
+        access_token,
+        refresh_token,
+        expires_at_ms,
+        scope,
+    }
+}
+
+/// Try to extract the user's email from the id_token first, falling
+/// back to a userinfo call. Both Google and Microsoft put a usable
+/// identifier somewhere — we don't care about the exact form, just
+/// that it's stable per user account.
+async fn extract_email(
+    resp: &StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
+    provider: &OAuthProvider,
+    access_token: &str,
+    http_client: &reqwest::Client,
+) -> Option<String> {
+    // The basic token response doesn't expose id_token directly, but
+    // it's serializable with extra fields. We re-deserialize the raw
+    // JSON to grab it. Quick + avoids a custom ExtraTokenFields type
+    // for a one-shot.
+    if let Ok(extra) = serde_json::to_value(resp) {
+        if let Some(id_token) = extra.get("id_token").and_then(|v| v.as_str()) {
+            if let Some(email) = email_from_id_token(id_token) {
+                return Some(email);
+            }
+        }
+    }
+
+    // Fallback: provider-specific userinfo endpoint.
+    let url = match provider.kind {
+        "google_calendar" => "https://openidconnect.googleapis.com/v1/userinfo",
+        "microsoft_graph" => "https://graph.microsoft.com/v1.0/me",
+        _ => return None,
+    };
+    let resp = http_client
+        .get(url)
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body: serde_json::Value = resp.json().await.ok()?;
+    body.get("email")
+        .or_else(|| body.get("mail"))
+        .or_else(|| body.get("userPrincipalName"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+fn email_from_id_token(id_token: &str) -> Option<String> {
+    // JWT: header.payload.signature, all base64url. We don't verify
+    // the signature — TLS to the provider's well-known token endpoint
+    // is the trust anchor here.
+    let payload_b64 = id_token.split('.').nth(1)?;
+    let payload_bytes = base64_url_decode(payload_b64)?;
+    let claims: IdTokenClaims = serde_json::from_slice(&payload_bytes).ok()?;
+    claims
+        .email
+        .or(claims.preferred_username)
+        .or(claims.upn)
+}
+
+#[derive(Deserialize)]
+struct IdTokenClaims {
+    email: Option<String>,
+    preferred_username: Option<String>,
+    upn: Option<String>,
+}
+
+fn base64_url_decode(s: &str) -> Option<Vec<u8>> {
+    use base64::Engine;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(s)
+        .ok()
+        .or_else(|| {
+            // Some providers use padded URL-safe encoding.
+            base64::engine::general_purpose::URL_SAFE.decode(s).ok()
+        })
+}
+
+fn map_token_error<E>(
+    e: RequestTokenError<E, StandardErrorResponse<BasicErrorResponseType>>,
+) -> ConnectorError
+where
+    E: std::error::Error + 'static,
+{
+    match e {
+        RequestTokenError::ServerResponse(resp) => match resp.error() {
+            BasicErrorResponseType::InvalidGrant => {
+                ConnectorError::ReauthNeeded("invalid_grant — token revoked".to_string())
+            }
+            other => ConnectorError::Other(format!(
+                "token endpoint returned {other:?}: {}",
+                resp.error_description().map(String::as_str).unwrap_or("")
+            )),
+        },
+        RequestTokenError::Request(err) => ConnectorError::Network(err.to_string()),
+        RequestTokenError::Parse(err, _) => {
+            ConnectorError::Other(format!("token response parse: {err}"))
+        }
+        RequestTokenError::Other(s) => ConnectorError::Other(s),
+    }
+}
+
+fn current_unix_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+// ----- Tests --------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_callback_extracts_code_and_state() {
+        let line = "GET /oauth/callback?code=4%2F0AeanS&state=abc123 HTTP/1.1";
+        let (code, state) = parse_callback_request_line(line).unwrap();
+        assert_eq!(code, "4/0AeanS");
+        assert_eq!(state, "abc123");
+    }
+
+    #[test]
+    fn parse_callback_propagates_provider_error() {
+        let line = "GET /oauth/callback?error=access_denied&state=xyz HTTP/1.1";
+        let err = parse_callback_request_line(line).unwrap_err();
+        assert!(matches!(err, ConnectorError::Other(ref m) if m.contains("access_denied")));
+    }
+
+    #[test]
+    fn url_decode_handles_percent_encoding() {
+        assert_eq!(url_decode("hello%20world"), "hello world");
+        assert_eq!(url_decode("a%2Fb"), "a/b");
+        assert_eq!(url_decode("plain"), "plain");
+    }
+
+    #[test]
+    fn email_from_id_token_extracts_email_claim() {
+        // Hand-crafted JWT with `email` claim. Header is irrelevant.
+        let header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+            r#"{"email":"alice@example.com","sub":"123"}"#,
+        );
+        let token = format!("{header}.{payload}.sig");
+        assert_eq!(
+            email_from_id_token(&token),
+            Some("alice@example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn email_from_id_token_falls_back_to_preferred_username() {
+        let header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+            r#"{"preferred_username":"bob@contoso.com"}"#,
+        );
+        let token = format!("{header}.{payload}.sig");
+        assert_eq!(
+            email_from_id_token(&token),
+            Some("bob@contoso.com".to_string())
+        );
+    }
+}
+
+// re-export base64 Engine trait so tests can use encode without a separate use clause.
+#[cfg(test)]
+use base64::Engine as _;

--- a/src-tauri/src/connectors/oauth.rs
+++ b/src-tauri/src/connectors/oauth.rs
@@ -98,7 +98,10 @@ pub async fn run_authorization_flow(
     // Bind the loopback FIRST — we need the chosen port to build the
     // redirect_uri before opening the browser.
     let (listener, port) = bind_loopback().await?;
-    let redirect_uri = format!("http://127.0.0.1:{port}/oauth/callback");
+    // Match the redirect URI registered in the provider console
+    // (no path suffix — keeps Azure / Google registration as just
+    // `http://127.0.0.1:<port>`).
+    let redirect_uri = format!("http://127.0.0.1:{port}");
 
     let oauth_client = build_client(provider, client_id, &redirect_uri)?;
     let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();

--- a/src-tauri/src/connectors/providers.rs
+++ b/src-tauri/src/connectors/providers.rs
@@ -1,0 +1,65 @@
+//! Static metadata for the OAuth providers Margin supports.
+//!
+//! Each entry hardcodes the public auth/token URLs and the scope set
+//! the connector needs. Client IDs are read from environment variables
+//! at build time (`option_env!`) so no secrets land in the source tree
+//! — see README's "OAuth client ID setup" section.
+//!
+//! Adding a new provider is one entry in `PROVIDERS`. The actual
+//! `Connector` factory and API client live in the connector's own
+//! module (e.g. `connectors/google_calendar.rs`, landing in #61).
+//!
+//! PKCE is the protection model: desktop apps register the client ID
+//! as a "public client" in the provider's developer console, which
+//! means no client secret. The flow is secured by the PKCE
+//! verifier/challenge pair instead.
+
+#[derive(Debug, Clone, Copy)]
+pub struct OAuthProvider {
+    pub kind: &'static str,
+    pub display_name: &'static str,
+    pub auth_url: &'static str,
+    pub token_url: &'static str,
+    pub scopes: &'static [&'static str],
+    /// `None` when the build doesn't have a client ID for this
+    /// provider — surfaced to the frontend's "Add connector" picker
+    /// so users don't see a button that can't actually work.
+    pub client_id: Option<&'static str>,
+}
+
+pub const PROVIDERS: &[OAuthProvider] = &[
+    OAuthProvider {
+        kind: "google_calendar",
+        display_name: "Google Calendar",
+        auth_url: "https://accounts.google.com/o/oauth2/v2/auth",
+        token_url: "https://oauth2.googleapis.com/token",
+        scopes: &[
+            "https://www.googleapis.com/auth/calendar.readonly",
+            "https://www.googleapis.com/auth/userinfo.email",
+            "openid",
+        ],
+        client_id: option_env!("MARGIN_GOOGLE_CLIENT_ID"),
+    },
+    OAuthProvider {
+        kind: "microsoft_graph",
+        display_name: "Microsoft Calendar",
+        auth_url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+        token_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+        scopes: &["Calendars.Read", "User.Read", "offline_access"],
+        client_id: option_env!("MARGIN_MICROSOFT_CLIENT_ID"),
+    },
+];
+
+pub fn lookup(kind: &str) -> Option<&'static OAuthProvider> {
+    PROVIDERS.iter().find(|p| p.kind == kind)
+}
+
+/// All providers whose client ID is set at build time. Drives the
+/// "Add connector" picker — providers without a configured client ID
+/// don't appear in the UI at all (they'd just fail at flow start).
+pub fn list_configured() -> Vec<&'static OAuthProvider> {
+    PROVIDERS
+        .iter()
+        .filter(|p| p.client_id.is_some())
+        .collect()
+}

--- a/src-tauri/src/connectors/registry.rs
+++ b/src-tauri/src/connectors/registry.rs
@@ -1,0 +1,188 @@
+//! Holds the `kind` → factory mapping and the live `Arc<dyn Connector>`
+//! instances. Future connector PRs (#61, #63) call `register_kind` at
+//! app boot to plug their factories in; the registry then instantiates
+//! one connector per row in the `connectors` table.
+//!
+//! Concurrency: two `RwLock`s, never held across `.await`. Reads (the
+//! runner's "give me the live connectors" call) dominate; writes (kind
+//! registration at boot, instance rebuild after add/remove) are rare.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use rusqlite::Connection;
+use tauri::AppHandle;
+
+use super::{Connector, ConnectorError, ConnectorRow};
+
+/// Constructs a `Connector` instance from its persisted row. The
+/// factory is responsible for parsing `row.config_json` and reading
+/// any per-instance secrets from the keychain.
+pub type ConnectorFactory = Arc<
+    dyn Fn(&ConnectorRow, &AppHandle) -> Result<Arc<dyn Connector>, ConnectorError>
+        + Send
+        + Sync,
+>;
+
+pub struct ConnectorRegistry {
+    factories: RwLock<HashMap<String, ConnectorFactory>>,
+    instances: RwLock<HashMap<String, Arc<dyn Connector>>>,
+}
+
+impl ConnectorRegistry {
+    pub fn new() -> Self {
+        Self {
+            factories: RwLock::new(HashMap::new()),
+            instances: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Plug a factory in. Called by individual connector modules at
+    /// app boot. Idempotent — re-registering a kind overwrites the
+    /// previous factory (useful for hot-reload during development).
+    pub fn register_kind(&self, kind: &str, factory: ConnectorFactory) {
+        if let Ok(mut f) = self.factories.write() {
+            f.insert(kind.to_string(), factory);
+        }
+    }
+
+    /// (Re)build the live instance set from the persisted rows. Any
+    /// row whose kind has no registered factory is logged and skipped
+    /// — that's the expected state in #59 (no real factories yet) and
+    /// stays the right behavior later when a connector kind is
+    /// removed from the binary while a row still exists in the DB.
+    pub fn rebuild_instances(
+        &self,
+        app: &AppHandle,
+        conn: &Connection,
+    ) -> rusqlite::Result<()> {
+        let rows = super::load_connector_rows(conn)?;
+        let factories = self.factories.read().ok();
+        let mut new_instances: HashMap<String, Arc<dyn Connector>> = HashMap::new();
+        for row in rows {
+            if !row.enabled {
+                continue;
+            }
+            let factory = match factories.as_ref().and_then(|f| f.get(&row.kind)) {
+                Some(f) => f.clone(),
+                None => {
+                    eprintln!(
+                        "[connectors] no factory registered for kind '{}' (id {}); skipping",
+                        row.kind, row.id
+                    );
+                    continue;
+                }
+            };
+            match factory(&row, app) {
+                Ok(c) => {
+                    new_instances.insert(row.id.clone(), c);
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[connectors] factory for {} (kind {}) failed: {e}",
+                        row.id, row.kind
+                    );
+                }
+            }
+        }
+        if let Ok(mut existing) = self.instances.write() {
+            *existing = new_instances;
+        }
+        Ok(())
+    }
+
+    /// Snapshot of all currently-instantiated connectors. Cheap clone
+    /// — `Arc<dyn Connector>` is just two pointers per entry.
+    pub fn live(&self) -> Vec<Arc<dyn Connector>> {
+        self.instances
+            .read()
+            .map(|m| m.values().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn get(&self, id: &str) -> Option<Arc<dyn Connector>> {
+        self.instances.read().ok()?.get(id).cloned()
+    }
+}
+
+impl Default for ConnectorRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ----- Tests --------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
+    use super::*;
+    use crate::connectors::{SyncCtx, SyncReport};
+
+    /// Test-only connector that just counts how many times `sync()`
+    /// was invoked. Used to validate the registry + (later) the
+    /// runner.
+    struct StubConnector {
+        id: String,
+        kind: String,
+        display: String,
+        sync_count: AtomicU64,
+    }
+
+    #[async_trait::async_trait]
+    impl Connector for StubConnector {
+        fn id(&self) -> &str {
+            &self.id
+        }
+        fn kind(&self) -> &str {
+            &self.kind
+        }
+        fn display_name(&self) -> &str {
+            &self.display
+        }
+        fn poll_interval(&self) -> Duration {
+            Duration::from_secs(60)
+        }
+        async fn sync(&self, _ctx: SyncCtx<'_>) -> Result<SyncReport, ConnectorError> {
+            self.sync_count.fetch_add(1, Ordering::SeqCst);
+            Ok(SyncReport {
+                added: 1,
+                ..Default::default()
+            })
+        }
+    }
+
+    fn make_stub_factory() -> ConnectorFactory {
+        Arc::new(|row: &ConnectorRow, _app: &AppHandle| {
+            Ok(Arc::new(StubConnector {
+                id: row.id.clone(),
+                kind: row.kind.clone(),
+                display: row.display_name.clone(),
+                sync_count: AtomicU64::new(0),
+            }) as Arc<dyn Connector>)
+        })
+    }
+
+    #[test]
+    fn register_kind_and_lookup() {
+        let reg = ConnectorRegistry::new();
+        reg.register_kind("stub", make_stub_factory());
+        let factories = reg.factories.read().unwrap();
+        assert!(factories.contains_key("stub"));
+    }
+
+    #[test]
+    fn rebuild_instances_skips_unknown_kinds() {
+        let reg = ConnectorRegistry::new();
+        // No factory registered. We can't easily build a real
+        // AppHandle in a unit test, but we can test the no-factory
+        // branch by exercising load + filter logic without calling
+        // any factory. The full rebuild path is exercised by the
+        // integration tests in `runner.rs` and validated by hand at
+        // app boot.
+        let factories = reg.factories.read().unwrap();
+        assert!(factories.is_empty());
+    }
+}

--- a/src-tauri/src/connectors/runner.rs
+++ b/src-tauri/src/connectors/runner.rs
@@ -1,0 +1,234 @@
+//! Background sync orchestration. One `tauri::async_runtime::spawn`
+//! task started at app boot, ticking every `RUNNER_TICK_SECS` seconds,
+//! checking each registered connector against `sync_status.next_due_ms`
+//! and invoking `sync()` for the ones that are due.
+//!
+//! Mirrors the existing reminders ticker in `src-tauri/src/reminders.rs`
+//! — same `tokio::time::interval` pattern, same `app.state::<...>()`
+//! discipline, errors logged but not fatal.
+
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rusqlite::Connection;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager};
+
+use super::{Connector, ConnectorError, ConnectorRegistry, SyncCtx, SyncReport};
+
+/// Minimum gap between runner iterations. The runner checks each live
+/// connector's `next_due_ms` on every tick — connectors with longer
+/// `poll_interval`s simply skip more ticks. 15s is fine-grained
+/// enough that a 60s `poll_interval` actually fires within ~75s of
+/// the last sync rather than rounded to a minute boundary.
+const RUNNER_TICK_SECS: u64 = 15;
+
+/// Spawn the runner task. Call once at app boot (in `lib.rs::setup`).
+pub fn start(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let mut tick = tokio::time::interval(Duration::from_secs(RUNNER_TICK_SECS));
+        // Skip the immediate tick — gives the rest of setup a chance
+        // to settle before the first sync hits the DB.
+        tick.tick().await;
+        loop {
+            tick.tick().await;
+            if let Err(e) = run_due(&app).await {
+                eprintln!("[connectors] runner error: {e}");
+            }
+        }
+    });
+}
+
+/// Iterate live connectors, sync the ones whose `next_due_ms <= now`,
+/// emit status events, and persist updated sync state.
+async fn run_due(app: &AppHandle) -> Result<(), String> {
+    let registry = app.state::<Arc<ConnectorRegistry>>();
+    let conn_state = app.state::<Mutex<Connection>>();
+
+    let now_ms = current_unix_ms();
+    let due_ids = collect_due_ids(&conn_state, now_ms)?;
+    if due_ids.is_empty() {
+        return Ok(());
+    }
+
+    // Resolve ids → live instances. A connector that was removed
+    // mid-iteration just disappears from the registry; we skip it.
+    let due: Vec<Arc<dyn Connector>> = due_ids
+        .iter()
+        .filter_map(|id| registry.get(id))
+        .collect();
+
+    for connector in due {
+        emit_status(app, connector.id(), StreamState::Syncing, None);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let ctx = SyncCtx {
+            app,
+            conn: &conn_state,
+            cancel: cancel.clone(),
+        };
+
+        let result = connector.sync(ctx).await;
+
+        let interval = connector.poll_interval();
+        let next_due = now_ms + interval.as_millis() as i64;
+        match &result {
+            Ok(report) => {
+                if let Err(e) =
+                    write_sync_status_ok(&conn_state, connector.id(), now_ms, next_due)
+                {
+                    eprintln!("[connectors] write sync_status (ok) failed: {e}");
+                }
+                emit_status(
+                    app,
+                    connector.id(),
+                    StreamState::Synced,
+                    Some(format_report(report)),
+                );
+            }
+            Err(err) => {
+                let tag = err.tag();
+                let msg = err.to_string();
+                // Backoff on rate-limit; otherwise schedule next attempt
+                // at the connector's regular interval.
+                let retry_ms = match err {
+                    ConnectorError::RateLimited { retry_after_ms } => {
+                        now_ms + (*retry_after_ms as i64)
+                    }
+                    _ => next_due,
+                };
+                if let Err(e) = write_sync_status_err(
+                    &conn_state,
+                    connector.id(),
+                    now_ms,
+                    retry_ms,
+                    &msg,
+                ) {
+                    eprintln!("[connectors] write sync_status (err) failed: {e}");
+                }
+                emit_status(
+                    app,
+                    connector.id(),
+                    StreamState::Errored,
+                    Some(format!("{tag}: {msg}")),
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn collect_due_ids(
+    conn_state: &Mutex<Connection>,
+    now_ms: i64,
+) -> Result<Vec<String>, String> {
+    let conn = conn_state.lock().map_err(|e| e.to_string())?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT c.id FROM connectors c \
+             LEFT JOIN sync_status s ON s.connector_id = c.id \
+             WHERE c.enabled = 1 AND COALESCE(s.next_due_ms, 0) <= ?1 \
+             ORDER BY c.id",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([now_ms], |r| r.get::<_, String>(0))
+        .map_err(|e| e.to_string())?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row.map_err(|e| e.to_string())?);
+    }
+    Ok(out)
+}
+
+fn write_sync_status_ok(
+    conn_state: &Mutex<Connection>,
+    connector_id: &str,
+    now_ms: i64,
+    next_due_ms: i64,
+) -> Result<(), String> {
+    let conn = conn_state.lock().map_err(|e| e.to_string())?;
+    conn.execute(
+        "INSERT INTO sync_status(connector_id, last_sync_ms, last_success_ms, last_error, cursor, next_due_ms) \
+         VALUES (?1, ?2, ?2, NULL, NULL, ?3) \
+         ON CONFLICT(connector_id) DO UPDATE SET \
+            last_sync_ms = excluded.last_sync_ms, \
+            last_success_ms = excluded.last_success_ms, \
+            last_error = NULL, \
+            next_due_ms = excluded.next_due_ms",
+        rusqlite::params![connector_id, now_ms, next_due_ms],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn write_sync_status_err(
+    conn_state: &Mutex<Connection>,
+    connector_id: &str,
+    now_ms: i64,
+    next_due_ms: i64,
+    error: &str,
+) -> Result<(), String> {
+    let conn = conn_state.lock().map_err(|e| e.to_string())?;
+    conn.execute(
+        "INSERT INTO sync_status(connector_id, last_sync_ms, last_success_ms, last_error, cursor, next_due_ms) \
+         VALUES (?1, ?2, NULL, ?3, NULL, ?4) \
+         ON CONFLICT(connector_id) DO UPDATE SET \
+            last_sync_ms = excluded.last_sync_ms, \
+            last_error = excluded.last_error, \
+            next_due_ms = excluded.next_due_ms",
+        rusqlite::params![connector_id, now_ms, error, next_due_ms],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[derive(Serialize, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+enum StreamState {
+    Syncing,
+    Synced,
+    Errored,
+    #[allow(dead_code)] // future: surfaced when a sync is skipped due to backoff
+    Skipped,
+}
+
+#[derive(Serialize, Clone)]
+struct StatusEvent<'a> {
+    connector_id: &'a str,
+    state: StreamState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+fn emit_status(
+    app: &AppHandle,
+    connector_id: &str,
+    state: StreamState,
+    message: Option<String>,
+) {
+    let _ = app.emit(
+        "connector-status",
+        StatusEvent {
+            connector_id,
+            state,
+            message,
+        },
+    );
+}
+
+fn format_report(r: &SyncReport) -> String {
+    format!(
+        "+{}/~{}/-{} (skipped {})",
+        r.added, r.updated, r.removed, r.skipped
+    )
+}
+
+fn current_unix_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -38,7 +38,8 @@ const SCHEMA_V4: &str = include_str!("migrations/004_actions.sql");
 const SCHEMA_V5: &str = include_str!("migrations/005_due_dates.sql");
 const SCHEMA_V6: &str = include_str!("migrations/006_team_members.sql");
 const SCHEMA_V7: &str = include_str!("migrations/007_action_owners.sql");
-const SCHEMA_VERSION: i64 = 7;
+const SCHEMA_V8: &str = include_str!("migrations/008_connectors.sql");
+const SCHEMA_VERSION: i64 = 8;
 
 /// Open the index DB at `db_path` (creating it if absent) and apply any
 /// pending migrations.
@@ -108,6 +109,10 @@ fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 6 {
         conn.execute_batch(SCHEMA_V7)?;
         version = 7;
+    }
+    if version == 7 {
+        conn.execute_batch(SCHEMA_V8)?;
+        version = 8;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/keychain.rs
+++ b/src-tauri/src/keychain.rs
@@ -1,10 +1,16 @@
 use keyring::Entry;
+use serde::{Deserialize, Serialize};
 
 const SERVICE: &str = "com.margin.app";
 const ACCOUNT: &str = "anthropic-api-key";
 
 fn entry() -> Result<Entry, String> {
     Entry::new(SERVICE, ACCOUNT).map_err(|e| e.to_string())
+}
+
+fn connector_entry(connector_id: &str) -> Result<Entry, String> {
+    let account = format!("connector::{connector_id}");
+    Entry::new(SERVICE, &account).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -62,4 +68,61 @@ pub fn has_anthropic_api_key() -> bool {
 #[allow(dead_code)]
 pub fn read_anthropic_api_key() -> Result<String, String> {
     entry()?.get_password().map_err(|e| e.to_string())
+}
+
+// ----- Per-connector OAuth tokens (#60) ---------------------------------
+
+/// One connector's OAuth state, stored as a single JSON-serialized
+/// keychain entry under `service=com.margin.app, account=connector::<id>`.
+/// Single entry per connector keeps the keychain clean compared to
+/// three separate entries (access / refresh / expiry).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConnectorTokens {
+    pub access_token: String,
+    /// Optional because some flows (notably Microsoft public-client
+    /// without `offline_access` scope) don't issue a refresh token.
+    /// We request `offline_access` for both providers, so this should
+    /// always be `Some` in practice.
+    pub refresh_token: Option<String>,
+    /// Unix-ms timestamp at which `access_token` expires. The
+    /// `with_valid_token` helper refreshes when `now + 60s >= this`.
+    pub expires_at_ms: i64,
+    /// Space-separated scopes the provider actually granted. May
+    /// differ from the request — Google/MS sometimes downgrade or
+    /// substitute scopes.
+    pub scope: String,
+}
+
+#[allow(dead_code)] // first caller lands with #60's oauth.rs
+pub fn write_connector_tokens(
+    connector_id: &str,
+    tokens: &ConnectorTokens,
+) -> Result<(), String> {
+    let json = serde_json::to_string(tokens).map_err(|e| e.to_string())?;
+    connector_entry(connector_id)?
+        .set_password(&json)
+        .map_err(|e| e.to_string())
+}
+
+#[allow(dead_code)]
+pub fn read_connector_tokens(
+    connector_id: &str,
+) -> Result<Option<ConnectorTokens>, String> {
+    let entry = connector_entry(connector_id)?;
+    match entry.get_password() {
+        Ok(json) => serde_json::from_str(&json)
+            .map(Some)
+            .map_err(|e| format!("connector tokens parse: {e}")),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+#[allow(dead_code)]
+pub fn delete_connector_tokens(connector_id: &str) -> Result<(), String> {
+    match connector_entry(connector_id)?.delete_credential() {
+        Ok(()) => Ok(()),
+        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(e.to_string()),
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -661,7 +661,10 @@ pub fn run() {
             team::delete_team_member,
             team::set_meeting_attendees,
             team::get_meeting_attendees,
-            connectors::commands::list_connectors
+            connectors::commands::list_connectors,
+            connectors::commands::list_oauth_providers,
+            connectors::commands::start_oauth_connector,
+            connectors::commands::delete_connector
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod ask;
 mod audio;
 mod chunker;
+mod connectors;
 mod dates;
 mod diarize;
 mod index;
@@ -519,6 +520,20 @@ pub fn run() {
             if let Err(e) = team::bootstrap_self_if_missing(&mut conn) {
                 eprintln!("team bootstrap failed at boot: {e}");
             }
+
+            // Connector registry: holds kind-factory mappings + live
+            // connector instances. Real factories register themselves
+            // in their own module's setup hook in future PRs (#61, #63).
+            // For #59 the registry boots empty — `rebuild_instances`
+            // is still called so any previously-persisted rows are
+            // observed (and skipped with a warning if their kind has
+            // no factory yet).
+            let registry = std::sync::Arc::new(connectors::ConnectorRegistry::new());
+            if let Err(e) = registry.rebuild_instances(app.handle(), &conn) {
+                eprintln!("connector registry rebuild failed at boot: {e}");
+            }
+            app.manage(registry);
+
             app.manage(Mutex::new(conn));
 
             // Recursive watcher over `~/.margin/notes/`. Keeps the index
@@ -594,6 +609,11 @@ pub fn run() {
             // task lives until the app exits.
             reminders::start(app.handle().clone());
 
+            // Connector sync runner (#59): ticks every 15s, syncs any
+            // due connectors, emits `connector-status` events per pass.
+            // Idle until a real connector is configured (#60+).
+            connectors::runner::start(app.handle().clone());
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -640,7 +660,8 @@ pub fn run() {
             team::update_team_member,
             team::delete_team_member,
             team::set_meeting_attendees,
-            team::get_meeting_attendees
+            team::get_meeting_attendees,
+            connectors::commands::list_connectors
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/migrations/008_connectors.sql
+++ b/src-tauri/src/migrations/008_connectors.sql
@@ -1,0 +1,24 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE connectors (
+  id            TEXT PRIMARY KEY,
+  kind          TEXT NOT NULL,
+  display_name  TEXT NOT NULL,
+  enabled       INTEGER NOT NULL DEFAULT 1,
+  config_json   TEXT NOT NULL DEFAULT '{}',
+  created_ms    INTEGER NOT NULL,
+  updated_ms    INTEGER NOT NULL
+);
+CREATE INDEX idx_connectors_kind ON connectors(kind);
+CREATE INDEX idx_connectors_enabled ON connectors(enabled);
+
+CREATE TABLE sync_status (
+  connector_id    TEXT PRIMARY KEY REFERENCES connectors(id) ON DELETE CASCADE,
+  last_sync_ms    INTEGER,
+  last_success_ms INTEGER,
+  last_error      TEXT,
+  cursor          TEXT,
+  next_due_ms     INTEGER NOT NULL DEFAULT 0
+);
+
+UPDATE meta SET value = '8' WHERE key = 'schema_version';

--- a/src/App.css
+++ b/src/App.css
@@ -680,6 +680,94 @@ body {
   font-style: italic;
 }
 
+.settings-section-intro {
+  font-size: 12.5px;
+  color: var(--fg-muted);
+  max-width: 56ch;
+  margin: 0 0 16px 0;
+  line-height: 1.45;
+}
+
+/* Connectors (#59) — empty state + per-row card. v1 only renders the
+   empty state; row styles are pre-built so #61 can drop straight in. */
+
+.settings-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 18px 16px;
+  border: 0.5px dashed var(--home-line);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+}
+
+.settings-empty-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.settings-empty-body {
+  font-size: 12.5px;
+  color: var(--fg-muted);
+  line-height: 1.45;
+}
+
+.connector-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.connector-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 0.5px solid var(--home-line);
+  border-radius: 8px;
+  background: var(--bg);
+}
+
+.connector-row-error {
+  margin-top: 4px;
+  font-size: 11.5px;
+  color: #c44a1f;
+}
+
+.connector-row-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.connector-row-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--fg);
+}
+
+.connector-row-sub {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  color: var(--fg-muted);
+  margin-top: 2px;
+}
+
+.connector-row-kind {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--home-chip);
+}
+
+.connector-row-error.connector-row-error,
+.connector-row.connector-row-error {
+  border-color: color-mix(in srgb, #c44a1f 30%, transparent);
+}
+
 .settings-row-control--col {
   flex-direction: column;
   align-items: stretch;

--- a/src/App.css
+++ b/src/App.css
@@ -768,6 +768,171 @@ body {
   border-color: color-mix(in srgb, #c44a1f 30%, transparent);
 }
 
+/* Connector add/remove UI (#60). */
+
+.settings-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+.settings-section-header h2 {
+  margin: 0;
+}
+
+.settings-add-btn {
+  appearance: none;
+  border: 0.5px solid var(--home-line);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 12px;
+  padding: 5px 10px;
+  cursor: pointer;
+  transition: background 80ms ease, border-color 80ms ease;
+}
+.settings-add-btn:hover:not(:disabled) {
+  background: var(--home-card-hover);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+.settings-add-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.connector-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.connector-row-remove,
+.connector-row-reconnect {
+  appearance: none;
+  border: 0.5px solid var(--home-line);
+  border-radius: 5px;
+  background: var(--bg);
+  color: var(--fg-muted);
+  font-size: 11.5px;
+  padding: 4px 8px;
+  cursor: pointer;
+  transition: background 80ms ease, color 80ms ease, border-color 80ms ease;
+}
+.connector-row-remove:hover {
+  background: color-mix(in srgb, #c44a1f 8%, transparent);
+  border-color: color-mix(in srgb, #c44a1f 30%, transparent);
+  color: #c44a1f;
+}
+.connector-row-reconnect {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 24%, transparent);
+  color: var(--accent);
+}
+.connector-row-reconnect:hover {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.connector-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--fg) 18%, transparent);
+  backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.connector-modal {
+  width: min(480px, calc(100vw - 32px));
+  background: var(--bg);
+  border: 0.5px solid var(--home-line);
+  border-radius: 12px;
+  padding: 18px 20px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.22);
+}
+
+.connector-modal-title {
+  margin: 0 0 4px 0;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.connector-modal-sub {
+  margin: 0 0 14px 0;
+  font-size: 12.5px;
+  color: var(--fg-muted);
+}
+
+.connector-modal-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.connector-modal-row {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 14px;
+  border: 0.5px solid var(--home-line);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 80ms ease, border-color 80ms ease;
+}
+
+.connector-modal-row:hover:not(:disabled) {
+  background: var(--home-card-hover);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.connector-modal-row:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.connector-modal-row-status {
+  font-size: 11.5px;
+  color: var(--accent);
+}
+
+.connector-modal-error {
+  margin-top: 12px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: color-mix(in srgb, #c44a1f 10%, transparent);
+  color: #c44a1f;
+  font-size: 12px;
+}
+
+.connector-modal-actions {
+  margin-top: 14px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.connector-modal-cancel {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--fg-muted);
+  font-size: 12.5px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+.connector-modal-cancel:hover:not(:disabled) {
+  color: var(--fg);
+}
+
 .settings-row-control--col {
   flex-direction: column;
   align-items: stretch;

--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -5,9 +5,13 @@ import {
   type ConnectorInfo,
   type ConnectorStatusEvent,
   deleteAnthropicApiKey,
+  deleteConnector,
   hasAnthropicApiKey,
   listConnectors,
+  listOAuthProviders,
+  type OAuthProviderInfo,
   setAnthropicApiKey,
+  startOAuthConnector,
 } from "./file";
 import {
   IconChevLeft,
@@ -261,19 +265,21 @@ export function Settings({
   );
 }
 
-/// Settings → Connectors. v1 ships the listing surface only — the
-/// add/remove flow lands with #60 (OAuth). The backend `SyncRunner`
-/// emits `connector-status` whenever any registered connector syncs;
-/// we refetch on each event so the per-row status (last sync time,
-/// errors) stays live without polling.
+/// Settings → Connectors. The backend `SyncRunner` emits
+/// `connector-status` whenever any registered connector syncs (or is
+/// added / removed via OAuth flow); we refetch on each event so the
+/// per-row status stays live without polling.
 function ConnectorsSection() {
   const [connectors, setConnectors] = useState<ConnectorInfo[]>([]);
+  const [providers, setProviders] = useState<OAuthProviderInfo[]>([]);
   const [loading, setLoading] = useState(true);
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   const refresh = async () => {
     try {
-      const list = await listConnectors();
+      const [list, provs] = await Promise.all([listConnectors(), listOAuthProviders()]);
       setConnectors(list);
+      setProviders(provs);
     } catch (e) {
       console.error("[settings] listConnectors failed:", e);
     } finally {
@@ -301,12 +307,51 @@ function ConnectorsSection() {
     };
   }, []);
 
+  const onRemove = async (connectorId: string, displayName: string) => {
+    const confirmed = await ask(
+      `Remove ${displayName}? Margin's local copy of its data will be cleared. The connection in your account stays granted until you revoke it on the provider's side.`,
+      { title: "Remove connector", kind: "warning" },
+    );
+    if (!confirmed) return;
+    try {
+      await deleteConnector(connectorId);
+    } catch (e) {
+      console.error("[settings] deleteConnector failed:", e);
+    }
+  };
+
+  const onReconnect = async (kind: string) => {
+    try {
+      await startOAuthConnector(kind);
+    } catch (e) {
+      console.error("[settings] reconnect failed:", e);
+    }
+  };
+
+  const noProviders = providers.length === 0;
+
   return (
     <section className="settings-section">
-      <h2>Connectors</h2>
+      <div className="settings-section-header">
+        <h2>Connectors</h2>
+        <button
+          type="button"
+          className="settings-add-btn"
+          onClick={() => setPickerOpen(true)}
+          disabled={noProviders}
+          title={
+            noProviders
+              ? "No OAuth client IDs configured at build time"
+              : "Connect an external account"
+          }
+        >
+          + Add connector
+        </button>
+      </div>
       <p className="settings-section-intro">
         Pull signals from external systems — calendar, email, chat — into your
-        notes context. Adding connectors arrives in the next release.
+        notes context. Connectors authenticate via OAuth and Margin only
+        stores tokens locally in your keychain.
       </p>
       {loading ? (
         <p className="settings-placeholder">Loading…</p>
@@ -314,22 +359,42 @@ function ConnectorsSection() {
         <div className="settings-empty">
           <div className="settings-empty-title">No connectors configured</div>
           <div className="settings-empty-body">
-            Calendar (Google &amp; Microsoft) lands in the next release. Future
-            connectors plug into the same surface.
+            {noProviders
+              ? "No OAuth providers built into this binary. See the README for setup."
+              : "Click + Add connector to authenticate one of the supported providers."}
           </div>
         </div>
       ) : (
         <div className="connector-list">
           {connectors.map((c) => (
-            <ConnectorRow key={c.id} info={c} />
+            <ConnectorRow
+              key={c.id}
+              info={c}
+              onRemove={() => onRemove(c.id, c.display_name)}
+              onReconnect={() => onReconnect(c.kind)}
+            />
           ))}
         </div>
+      )}
+      {pickerOpen && (
+        <ConnectorPickerModal
+          providers={providers}
+          onClose={() => setPickerOpen(false)}
+        />
       )}
     </section>
   );
 }
 
-function ConnectorRow({ info }: { info: ConnectorInfo }) {
+function ConnectorRow({
+  info,
+  onRemove,
+  onReconnect,
+}: {
+  info: ConnectorInfo;
+  onRemove: () => void;
+  onReconnect: () => void;
+}) {
   const status = info.last_error
     ? "error"
     : info.last_success_ms
@@ -338,6 +403,7 @@ function ConnectorRow({ info }: { info: ConnectorInfo }) {
   const lastLabel = info.last_sync_ms
     ? new Date(info.last_sync_ms).toLocaleString()
     : "never";
+  const reauthNeeded = info.last_error?.startsWith("reauth_needed:");
   return (
     <div className={`connector-row connector-row-${status}`}>
       <div className="connector-row-body">
@@ -350,6 +416,92 @@ function ConnectorRow({ info }: { info: ConnectorInfo }) {
         {info.last_error && (
           <div className="connector-row-error">{info.last_error}</div>
         )}
+      </div>
+      <div className="connector-row-actions">
+        {reauthNeeded && (
+          <button
+            type="button"
+            className="connector-row-reconnect"
+            onClick={onReconnect}
+          >
+            Reconnect
+          </button>
+        )}
+        <button
+          type="button"
+          className="connector-row-remove"
+          onClick={onRemove}
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ConnectorPickerModal({
+  providers,
+  onClose,
+}: {
+  providers: OAuthProviderInfo[];
+  onClose: () => void;
+}) {
+  const [pending, setPending] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const onPick = async (kind: string) => {
+    setPending(kind);
+    setError(null);
+    try {
+      await startOAuthConnector(kind);
+      onClose();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+    } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <div className="connector-modal-backdrop" onClick={onClose}>
+      <div
+        className="connector-modal"
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="connector-modal-title">Add connector</h3>
+        <p className="connector-modal-sub">
+          Pick a provider. Margin will open your browser to authenticate.
+        </p>
+        <div className="connector-modal-list">
+          {providers.map((p) => (
+            <button
+              key={p.kind}
+              type="button"
+              className="connector-modal-row"
+              onClick={() => onPick(p.kind)}
+              disabled={pending !== null}
+            >
+              <span className="connector-modal-row-name">{p.display_name}</span>
+              {pending === p.kind && (
+                <span className="connector-modal-row-status">Waiting for browser…</span>
+              )}
+            </button>
+          ))}
+        </div>
+        {error && <div className="connector-modal-error">{error}</div>}
+        <div className="connector-modal-actions">
+          <button
+            type="button"
+            className="connector-modal-cancel"
+            onClick={onClose}
+            disabled={pending !== null}
+          >
+            Close
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -1,14 +1,19 @@
 import { useEffect, useState } from "react";
 import { ask } from "@tauri-apps/plugin-dialog";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
+  type ConnectorInfo,
+  type ConnectorStatusEvent,
   deleteAnthropicApiKey,
   hasAnthropicApiKey,
+  listConnectors,
   setAnthropicApiKey,
 } from "./file";
 import {
   IconChevLeft,
   IconEdit,
   IconHome,
+  IconLink,
   IconSettings,
   IconSparkle,
 } from "./icons";
@@ -22,7 +27,7 @@ import type {
 import { loadGlossary } from "./settingsStore";
 import { THEMES, darkThemes, getTheme, lightThemes, type Theme } from "./themes";
 
-type Section = "appearance" | "ai" | "editor" | "shortcuts";
+type Section = "appearance" | "ai" | "connectors" | "editor" | "shortcuts";
 
 export type EditorPrefs = {
   tabSize: number;
@@ -50,6 +55,7 @@ const SECTIONS: {
 }[] = [
   { id: "appearance", label: "Appearance", icon: <IconSettings size={14} sw={1.7} /> },
   { id: "ai", label: "AI", icon: <IconSparkle size={14} sw={1.7} /> },
+  { id: "connectors", label: "Connectors", icon: <IconLink size={14} sw={1.7} /> },
   { id: "editor", label: "Editor", icon: <IconEdit size={14} sw={1.7} /> },
   { id: "shortcuts", label: "Shortcuts", icon: <IconHome size={14} sw={1.7} /> },
 ];
@@ -57,6 +63,7 @@ const SECTIONS: {
 const SECTION_TITLE: Record<Section, string> = {
   appearance: "Appearance",
   ai: "AI",
+  connectors: "Connectors",
   editor: "Editor",
   shortcuts: "Shortcuts",
 };
@@ -240,6 +247,8 @@ export function Settings({
           </section>
         )}
 
+        {active === "connectors" && <ConnectorsSection />}
+
         {active === "shortcuts" && (
           <section className="settings-section">
             <h2>Shortcuts</h2>
@@ -248,6 +257,100 @@ export function Settings({
         )}
         </div>
       </main>
+    </div>
+  );
+}
+
+/// Settings → Connectors. v1 ships the listing surface only — the
+/// add/remove flow lands with #60 (OAuth). The backend `SyncRunner`
+/// emits `connector-status` whenever any registered connector syncs;
+/// we refetch on each event so the per-row status (last sync time,
+/// errors) stays live without polling.
+function ConnectorsSection() {
+  const [connectors, setConnectors] = useState<ConnectorInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = async () => {
+    try {
+      const list = await listConnectors();
+      setConnectors(list);
+    } catch (e) {
+      console.error("[settings] listConnectors failed:", e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+    (async () => {
+      const fn = await listen<ConnectorStatusEvent>("connector-status", () => {
+        void refresh();
+      });
+      if (cancelled) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  return (
+    <section className="settings-section">
+      <h2>Connectors</h2>
+      <p className="settings-section-intro">
+        Pull signals from external systems — calendar, email, chat — into your
+        notes context. Adding connectors arrives in the next release.
+      </p>
+      {loading ? (
+        <p className="settings-placeholder">Loading…</p>
+      ) : connectors.length === 0 ? (
+        <div className="settings-empty">
+          <div className="settings-empty-title">No connectors configured</div>
+          <div className="settings-empty-body">
+            Calendar (Google &amp; Microsoft) lands in the next release. Future
+            connectors plug into the same surface.
+          </div>
+        </div>
+      ) : (
+        <div className="connector-list">
+          {connectors.map((c) => (
+            <ConnectorRow key={c.id} info={c} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ConnectorRow({ info }: { info: ConnectorInfo }) {
+  const status = info.last_error
+    ? "error"
+    : info.last_success_ms
+    ? "ok"
+    : "pending";
+  const lastLabel = info.last_sync_ms
+    ? new Date(info.last_sync_ms).toLocaleString()
+    : "never";
+  return (
+    <div className={`connector-row connector-row-${status}`}>
+      <div className="connector-row-body">
+        <div className="connector-row-title">{info.display_name}</div>
+        <div className="connector-row-sub">
+          <span className="connector-row-kind">{info.kind}</span>
+          <span className="connector-row-sep">·</span>
+          <span className="connector-row-last">last sync: {lastLabel}</span>
+        </div>
+        {info.last_error && (
+          <div className="connector-row-error">{info.last_error}</div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -313,13 +313,38 @@ export async function listConnectors(): Promise<ConnectorInfo[]> {
 }
 
 /** Pushed by the Rust side on the `connector-status` Tauri event channel
- *  whenever a connector starts/finishes/errors a sync. Consumers refetch
- *  via `listConnectors()` on each event to pick up the new state. */
+ *  whenever a connector starts/finishes/errors a sync, or is added /
+ *  removed. Consumers refetch via `listConnectors()` on each event to
+ *  pick up the new state. */
 export type ConnectorStatusEvent = {
   connector_id: string;
-  state: "syncing" | "synced" | "errored" | "skipped";
+  state: "syncing" | "synced" | "errored" | "skipped" | "added" | "removed";
   message?: string;
 };
+
+/** A configured OAuth provider that the user can pick from in the
+ *  "Add connector" modal. Only providers whose client ID is set at
+ *  build time appear in this list. */
+export type OAuthProviderInfo = {
+  kind: string;
+  display_name: string;
+};
+
+export async function listOAuthProviders(): Promise<OAuthProviderInfo[]> {
+  return invoke<OAuthProviderInfo[]>("list_oauth_providers");
+}
+
+/** Run the OAuth flow for `kind`. Opens the system browser; returns
+ *  the new (or updated) connector id when the user completes the
+ *  grant. Rejects with the provider/connector error message if the
+ *  user denies, the flow times out, or the network fails. */
+export async function startOAuthConnector(kind: string): Promise<string> {
+  return invoke<string>("start_oauth_connector", { kind });
+}
+
+export async function deleteConnector(connectorId: string): Promise<void> {
+  return invoke<void>("delete_connector", { connectorId });
+}
 
 export type NoteMeta = { modified_ms: number };
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -293,6 +293,34 @@ export async function stopVoiceRecording(model?: string): Promise<VoiceTranscrip
   return invoke<VoiceTranscript>("stop_voice_recording", { model });
 }
 
+// --- Connectors (#59) ----------------------------------------------------
+
+/** One connector + its current sync state. Returned by `list_connectors`,
+ *  joined from the `connectors` and `sync_status` tables. */
+export type ConnectorInfo = {
+  id: string;
+  kind: string;
+  display_name: string;
+  enabled: boolean;
+  last_sync_ms: number | null;
+  last_success_ms: number | null;
+  last_error: string | null;
+  next_due_ms: number;
+};
+
+export async function listConnectors(): Promise<ConnectorInfo[]> {
+  return invoke<ConnectorInfo[]>("list_connectors");
+}
+
+/** Pushed by the Rust side on the `connector-status` Tauri event channel
+ *  whenever a connector starts/finishes/errors a sync. Consumers refetch
+ *  via `listConnectors()` on each event to pick up the new state. */
+export type ConnectorStatusEvent = {
+  connector_id: string;
+  state: "syncing" | "synced" | "errored" | "skipped";
+  message?: string;
+};
+
 export type NoteMeta = { modified_ms: number };
 
 export async function noteMeta(notePath: string): Promise<NoteMeta> {


### PR DESCRIPTION
## Summary

Two-commit branch covering the first two issues of the [Connectors v1: Calendar](https://github.com/tjruesch/margin/milestone/3) milestone:

- **#59 — Connector platform foundation**: `Connector` trait, `ConnectorRegistry`, `SyncRunner` background task (15s tick), `connectors` + `sync_status` tables (migration 008), `list_connectors` Tauri command, empty Connectors tab in Settings.
- **#60 — OAuth + per-connector token storage**: PKCE flow runner with localhost loopback, `with_valid_token` refresh-on-demand helper, per-connector keychain entries (one JSON blob per connector), Google + Microsoft providers wired end-to-end, "+ Add connector" UI with picker modal, Remove/Reconnect per-row actions.

Closes #59, #60.

## What's testable now

Without OAuth client IDs configured at build time:
- App boots cleanly, schema migrates to v8
- Settings → Connectors renders the empty state
- "+ Add connector" button is disabled with a tooltip explaining the env-var setup

With `MARGIN_GOOGLE_CLIENT_ID` / `MARGIN_MICROSOFT_CLIENT_ID` exported (see README's new "OAuth client IDs" section):
- Add → Google → system browser opens → grant in browser → success page in tab → row appears in the list (kind=google_calendar, last_sync_ms=null since #61 hasn't shipped a factory yet)
- Keychain entry written at `service=com.margin.app, account=connector::google_calendar:<email>`
- Remove → DB row + keychain entry both gone
- Same flow for Microsoft

## Tests

7 unit tests pass: 2 from #59 registry tests, 5 new OAuth tests covering callback request-line parsing, percent-encoding decode, id_token email extraction (both `email` and `preferred_username` claims), provider error propagation. Run with `DYLD_FALLBACK_LIBRARY_PATH=/usr/lib/swift cargo test connectors::`.

## Test plan

- [ ] Verify schema migration: launch dev, sqlite3 ~/.margin/index.db `.schema` shows connectors + sync_status tables; `meta.schema_version = 8`
- [ ] Settings → Connectors renders without errors; empty state visible; Add button disabled
- [ ] [With env vars] Add Google Calendar → flow completes → row appears
- [ ] [With env vars] Add Microsoft → flow completes → row appears with the second connector
- [ ] Click Remove → confirmation dialog → row + keychain entry both gone
- [ ] Force a `reauth_needed` error (e.g. revoke at Google) → Reconnect button appears → click Reconnect → re-auth succeeds → error clears

## Out of scope (next issues in milestone)

- Actual sync logic for Google Calendar (#61) and Microsoft Graph (#63) — these register `Connector` factories that the foundation here picks up automatically
- "Coming up" UI strip on Home (#62)
- AI ask schedule integration (#64)