### PR TITLE
Microsoft Graph calendar connector (#63)

### DIFF
--- a/src-tauri/src/connectors/calendar.rs
+++ b/src-tauri/src/connectors/calendar.rs
@@ -1,0 +1,469 @@
+//! Provider-agnostic calendar storage layer (#63).
+//!
+//! Both `microsoft_graph` and (future) `google_calendar` connectors
+//! map their provider-specific JSON into `CalendarEvent` and call
+//! `upsert_window` to persist into the shared `calendar_events` /
+//! `calendar_attendees` tables. The "Coming up" UI strip (#62) and AI
+//! ask Schedule section (#64) read through `list_events_in_range` /
+//! `get_event_details` without caring which connector produced the
+//! data — the `connector_id` foreign key carries that.
+
+use std::collections::HashSet;
+
+use rusqlite::{params, Connection};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CalendarEvent {
+    pub id: String,
+    pub connector_id: String,
+    pub external_id: String,
+    pub title: String,
+    pub start_ms: i64,
+    pub end_ms: i64,
+    pub all_day: bool,
+    pub location: Option<String>,
+    pub description: Option<String>,
+    pub source_calendar: Option<String>,
+    pub status: Option<String>,
+    pub raw_etag: Option<String>,
+    pub modified_ms: i64,
+    pub attendees: Vec<CalendarAttendee>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CalendarAttendee {
+    pub email: String,
+    pub display_name: Option<String>,
+    pub response_status: Option<String>,
+    pub is_self: bool,
+    pub is_organizer: bool,
+    pub team_member_id: Option<String>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UpsertReport {
+    pub added: u64,
+    pub updated: u64,
+    pub removed: u64,
+}
+
+/// Replace the events for `connector_id` in `[window_start_ms,
+/// window_end_ms]` with `events`. Events outside the window are not
+/// touched — this is the "rolling window" model: each sync covers a
+/// fixed range relative to now.
+///
+/// Runs in a single transaction. Mirrors `index::reconcile`'s
+/// delete-orphan pattern: build a snapshot of in-window IDs, upsert
+/// the incoming set, delete in-window IDs that didn't appear.
+pub fn upsert_window(
+    conn: &mut Connection,
+    connector_id: &str,
+    events: &[CalendarEvent],
+    window_start_ms: i64,
+    window_end_ms: i64,
+) -> rusqlite::Result<UpsertReport> {
+    let tx = conn.transaction()?;
+
+    // Snapshot existing in-window event IDs.
+    let existing: HashSet<String> = {
+        let mut stmt = tx.prepare(
+            "SELECT id FROM calendar_events \
+             WHERE connector_id = ?1 AND start_ms BETWEEN ?2 AND ?3",
+        )?;
+        let rows = stmt.query_map(
+            params![connector_id, window_start_ms, window_end_ms],
+            |r| r.get::<_, String>(0),
+        )?;
+        let mut s = HashSet::new();
+        for row in rows {
+            s.insert(row?);
+        }
+        s
+    };
+
+    let incoming: HashSet<&str> = events.iter().map(|e| e.id.as_str()).collect();
+
+    let mut report = UpsertReport::default();
+    for ev in events {
+        let pre_existed = existing.contains(&ev.id);
+        upsert_event(&tx, ev)?;
+        if pre_existed {
+            report.updated += 1;
+        } else {
+            report.added += 1;
+        }
+    }
+
+    // Delete in-window orphans (event no longer returned by the
+    // upstream sync). CASCADE drops attendee rows.
+    for id in existing.iter() {
+        if !incoming.contains(id.as_str()) {
+            tx.execute(
+                "DELETE FROM calendar_events WHERE id = ?1",
+                params![id],
+            )?;
+            report.removed += 1;
+        }
+    }
+
+    tx.commit()?;
+    Ok(report)
+}
+
+fn upsert_event(tx: &rusqlite::Transaction<'_>, e: &CalendarEvent) -> rusqlite::Result<()> {
+    tx.execute(
+        "INSERT INTO calendar_events(\
+            id, connector_id, external_id, title, start_ms, end_ms, all_day, \
+            location, description, source_calendar, status, raw_etag, modified_ms\
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13) \
+         ON CONFLICT(id) DO UPDATE SET \
+            title = excluded.title, \
+            start_ms = excluded.start_ms, \
+            end_ms = excluded.end_ms, \
+            all_day = excluded.all_day, \
+            location = excluded.location, \
+            description = excluded.description, \
+            source_calendar = excluded.source_calendar, \
+            status = excluded.status, \
+            raw_etag = excluded.raw_etag, \
+            modified_ms = excluded.modified_ms",
+        params![
+            e.id,
+            e.connector_id,
+            e.external_id,
+            e.title,
+            e.start_ms,
+            e.end_ms,
+            e.all_day as i64,
+            e.location,
+            e.description,
+            e.source_calendar,
+            e.status,
+            e.raw_etag,
+            e.modified_ms,
+        ],
+    )?;
+
+    // Attendees: replace wholesale. Cheaper than diffing for the
+    // small attendee counts typical of meetings (< 50).
+    tx.execute(
+        "DELETE FROM calendar_attendees WHERE event_id = ?1",
+        params![e.id],
+    )?;
+    let mut stmt = tx.prepare_cached(
+        "INSERT INTO calendar_attendees(\
+            event_id, email, display_name, response_status, is_self, is_organizer, team_member_id\
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+    )?;
+    for a in &e.attendees {
+        stmt.execute(params![
+            e.id,
+            a.email,
+            a.display_name,
+            a.response_status,
+            a.is_self as i64,
+            a.is_organizer as i64,
+            a.team_member_id,
+        ])?;
+    }
+    Ok(())
+}
+
+/// Read events whose start time falls in `[start_ms, end_ms]`.
+/// Optional `connector_id` filter. Includes attendees.
+pub fn list_events_in_range(
+    conn: &Connection,
+    start_ms: i64,
+    end_ms: i64,
+    connector_id: Option<&str>,
+) -> rusqlite::Result<Vec<CalendarEvent>> {
+    let sql = match connector_id {
+        Some(_) => {
+            "SELECT id, connector_id, external_id, title, start_ms, end_ms, all_day, \
+                    location, description, source_calendar, status, raw_etag, modified_ms \
+             FROM calendar_events \
+             WHERE start_ms BETWEEN ?1 AND ?2 AND connector_id = ?3 \
+             ORDER BY start_ms ASC"
+        }
+        None => {
+            "SELECT id, connector_id, external_id, title, start_ms, end_ms, all_day, \
+                    location, description, source_calendar, status, raw_etag, modified_ms \
+             FROM calendar_events \
+             WHERE start_ms BETWEEN ?1 AND ?2 \
+             ORDER BY start_ms ASC"
+        }
+    };
+    let mut stmt = conn.prepare(sql)?;
+
+    let row_to_event = |r: &rusqlite::Row<'_>| -> rusqlite::Result<CalendarEvent> {
+        Ok(CalendarEvent {
+            id: r.get(0)?,
+            connector_id: r.get(1)?,
+            external_id: r.get(2)?,
+            title: r.get(3)?,
+            start_ms: r.get(4)?,
+            end_ms: r.get(5)?,
+            all_day: r.get::<_, i64>(6)? != 0,
+            location: r.get(7)?,
+            description: r.get(8)?,
+            source_calendar: r.get(9)?,
+            status: r.get(10)?,
+            raw_etag: r.get(11)?,
+            modified_ms: r.get(12)?,
+            attendees: Vec::new(),
+        })
+    };
+
+    let mut events: Vec<CalendarEvent> = match connector_id {
+        Some(id) => {
+            let rows = stmt.query_map(params![start_ms, end_ms, id], row_to_event)?;
+            rows.collect::<Result<Vec<_>, _>>()?
+        }
+        None => {
+            let rows = stmt.query_map(params![start_ms, end_ms], row_to_event)?;
+            rows.collect::<Result<Vec<_>, _>>()?
+        }
+    };
+
+    // Bulk-load attendees in one query rather than N+1.
+    if !events.is_empty() {
+        let attendees_by_event = load_attendees_for(conn, events.iter().map(|e| e.id.as_str()))?;
+        for ev in &mut events {
+            if let Some(rows) = attendees_by_event.get(&ev.id) {
+                ev.attendees = rows.clone();
+            }
+        }
+    }
+    Ok(events)
+}
+
+pub fn get_event_details(
+    conn: &Connection,
+    event_id: &str,
+) -> rusqlite::Result<Option<CalendarEvent>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, connector_id, external_id, title, start_ms, end_ms, all_day, \
+                location, description, source_calendar, status, raw_etag, modified_ms \
+         FROM calendar_events WHERE id = ?1",
+    )?;
+    let mut event: Option<CalendarEvent> = stmt
+        .query_row(params![event_id], |r| {
+            Ok(CalendarEvent {
+                id: r.get(0)?,
+                connector_id: r.get(1)?,
+                external_id: r.get(2)?,
+                title: r.get(3)?,
+                start_ms: r.get(4)?,
+                end_ms: r.get(5)?,
+                all_day: r.get::<_, i64>(6)? != 0,
+                location: r.get(7)?,
+                description: r.get(8)?,
+                source_calendar: r.get(9)?,
+                status: r.get(10)?,
+                raw_etag: r.get(11)?,
+                modified_ms: r.get(12)?,
+                attendees: Vec::new(),
+            })
+        })
+        .ok();
+
+    if let Some(ref mut ev) = event {
+        let by_event = load_attendees_for(conn, std::iter::once(ev.id.as_str()))?;
+        if let Some(rows) = by_event.get(&ev.id) {
+            ev.attendees = rows.clone();
+        }
+    }
+    Ok(event)
+}
+
+fn load_attendees_for<'a, I>(
+    conn: &Connection,
+    ids: I,
+) -> rusqlite::Result<std::collections::HashMap<String, Vec<CalendarAttendee>>>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let id_list: Vec<String> = ids.into_iter().map(|s| s.to_string()).collect();
+    if id_list.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    // SQL `IN (?, ?, ...)` with N placeholders. `rusqlite` needs the
+    // placeholder count baked into the SQL; build it dynamically.
+    let placeholders = std::iter::repeat("?")
+        .take(id_list.len())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "SELECT event_id, email, display_name, response_status, is_self, is_organizer, team_member_id \
+         FROM calendar_attendees WHERE event_id IN ({placeholders}) ORDER BY event_id, is_organizer DESC, email"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let params: Vec<&dyn rusqlite::ToSql> =
+        id_list.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+    let rows = stmt.query_map(rusqlite::params_from_iter(params), |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            CalendarAttendee {
+                email: r.get(1)?,
+                display_name: r.get(2)?,
+                response_status: r.get(3)?,
+                is_self: r.get::<_, i64>(4)? != 0,
+                is_organizer: r.get::<_, i64>(5)? != 0,
+                team_member_id: r.get(6)?,
+            },
+        ))
+    })?;
+    let mut out: std::collections::HashMap<String, Vec<CalendarAttendee>> =
+        std::collections::HashMap::new();
+    for row in rows {
+        let (event_id, attendee) = row?;
+        out.entry(event_id).or_default().push(attendee);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_test_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        // Replicate the relevant subset of the schema for unit tests.
+        conn.execute_batch(
+            "PRAGMA foreign_keys = ON;
+             CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             CREATE TABLE team_members (id TEXT PRIMARY KEY);
+             CREATE TABLE connectors (id TEXT PRIMARY KEY);
+             INSERT INTO connectors(id) VALUES ('mg:test');",
+        )
+        .unwrap();
+        conn.execute_batch(include_str!("../migrations/009_calendar.sql"))
+            .unwrap();
+        conn
+    }
+
+    fn make_event(id: &str, start_ms: i64, attendee_emails: &[&str]) -> CalendarEvent {
+        CalendarEvent {
+            id: format!("mg:test::{id}"),
+            connector_id: "mg:test".to_string(),
+            external_id: id.to_string(),
+            title: format!("Event {id}"),
+            start_ms,
+            end_ms: start_ms + 30 * 60 * 1000,
+            all_day: false,
+            location: None,
+            description: None,
+            source_calendar: None,
+            status: Some("confirmed".to_string()),
+            raw_etag: None,
+            modified_ms: start_ms,
+            attendees: attendee_emails
+                .iter()
+                .map(|e| CalendarAttendee {
+                    email: e.to_string(),
+                    display_name: None,
+                    response_status: None,
+                    is_self: false,
+                    is_organizer: false,
+                    team_member_id: None,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn upsert_window_inserts_and_deletes_orphans() {
+        let mut conn = open_test_db();
+        let window_start = 1_000;
+        let window_end = 100_000;
+
+        // First sync: 3 events.
+        let first = vec![
+            make_event("a", 5_000, &["alice@example.com"]),
+            make_event("b", 6_000, &[]),
+            make_event("c", 7_000, &["bob@example.com", "alice@example.com"]),
+        ];
+        let report1 =
+            upsert_window(&mut conn, "mg:test", &first, window_start, window_end).unwrap();
+        assert_eq!(report1.added, 3);
+        assert_eq!(report1.updated, 0);
+        assert_eq!(report1.removed, 0);
+
+        // Second sync: drop "b", update "a", add "d". "c" stays.
+        let mut updated_a = make_event("a", 5_000, &["alice@example.com"]);
+        updated_a.title = "Event a (renamed)".to_string();
+        let second = vec![
+            updated_a,
+            make_event("c", 7_000, &["bob@example.com", "alice@example.com"]),
+            make_event("d", 8_000, &[]),
+        ];
+        let report2 =
+            upsert_window(&mut conn, "mg:test", &second, window_start, window_end).unwrap();
+        assert_eq!(report2.added, 1, "d is new");
+        assert_eq!(report2.updated, 2, "a + c existed");
+        assert_eq!(report2.removed, 1, "b was orphaned");
+
+        // Verify final state via list_events_in_range.
+        let rows = list_events_in_range(&conn, window_start, window_end, Some("mg:test")).unwrap();
+        let titles: Vec<&str> = rows.iter().map(|e| e.title.as_str()).collect();
+        assert_eq!(titles, vec!["Event a (renamed)", "Event c", "Event d"]);
+
+        // a's attendees survived the upsert.
+        let a = rows.iter().find(|e| e.external_id == "a").unwrap();
+        assert_eq!(a.attendees.len(), 1);
+        assert_eq!(a.attendees[0].email, "alice@example.com");
+    }
+
+    #[test]
+    fn upsert_window_does_not_touch_outside_window_events() {
+        let mut conn = open_test_db();
+        // Pre-populate an event outside our window.
+        upsert_window(
+            &mut conn,
+            "mg:test",
+            &[make_event("outside", 999_999, &[])],
+            999_990,
+            1_000_000,
+        )
+        .unwrap();
+
+        // Sync a tighter window. "outside" should survive.
+        upsert_window(&mut conn, "mg:test", &[make_event("a", 5_000, &[])], 1_000, 100_000)
+            .unwrap();
+
+        let still_there =
+            list_events_in_range(&conn, 999_990, 1_000_000, Some("mg:test")).unwrap();
+        assert_eq!(still_there.len(), 1);
+        assert_eq!(still_there[0].external_id, "outside");
+    }
+
+    #[test]
+    fn list_events_in_range_filters_by_connector() {
+        let mut conn = open_test_db();
+        // Add a second connector row.
+        conn.execute("INSERT INTO connectors(id) VALUES ('gc:test')", [])
+            .unwrap();
+
+        upsert_window(&mut conn, "mg:test", &[make_event("a", 5_000, &[])], 0, 100_000).unwrap();
+
+        let mut other = make_event("b", 6_000, &[]);
+        other.id = "gc:test::b".to_string();
+        other.connector_id = "gc:test".to_string();
+        upsert_window(&mut conn, "gc:test", &[other], 0, 100_000).unwrap();
+
+        let mg_only = list_events_in_range(&conn, 0, 100_000, Some("mg:test")).unwrap();
+        assert_eq!(mg_only.len(), 1);
+        assert_eq!(mg_only[0].connector_id, "mg:test");
+
+        let all = list_events_in_range(&conn, 0, 100_000, None).unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn get_event_details_returns_none_for_missing() {
+        let conn = open_test_db();
+        let result = get_event_details(&conn, "nope").unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/src-tauri/src/connectors/commands.rs
+++ b/src-tauri/src/connectors/commands.rs
@@ -192,3 +192,26 @@ fn current_unix_ms() -> i64 {
         .map(|d| d.as_millis() as i64)
         .unwrap_or(0)
 }
+
+// ----- Calendar query commands (#63) -------------------------------------
+
+#[tauri::command]
+pub fn list_calendar_events(
+    start_ms: i64,
+    end_ms: i64,
+    connector_id: Option<String>,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<Vec<super::calendar::CalendarEvent>, String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    super::calendar::list_events_in_range(&c, start_ms, end_ms, connector_id.as_deref())
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn get_event_details(
+    event_id: String,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<Option<super::calendar::CalendarEvent>, String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    super::calendar::get_event_details(&c, &event_id).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/connectors/microsoft_graph.rs
+++ b/src-tauri/src/connectors/microsoft_graph.rs
@@ -1,0 +1,631 @@
+//! Microsoft Graph calendar connector (#63).
+//!
+//! Pulls calendar events from `/me/calendarView` via Microsoft Graph,
+//! maps them onto the provider-agnostic `CalendarEvent` shape, and
+//! writes through `connectors::calendar::upsert_window`.
+//!
+//! Window: last 14 days through next 30 days. Polled every 5 minutes
+//! by the `SyncRunner`.
+//!
+//! All times sent and received in UTC via the `Prefer:
+//! outlook.timezone="UTC"` header. Saves us from juggling Microsoft's
+//! Windows-style timezone names against IANA.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use super::calendar::{CalendarAttendee, CalendarEvent};
+use super::oauth::with_valid_token;
+use super::registry::ConnectorRegistry;
+use super::{Connector, ConnectorError, ConnectorRow, SyncCtx, SyncReport};
+use crate::team::{self, OwnerResolver, TeamMember};
+
+const POLL_INTERVAL: Duration = Duration::from_secs(5 * 60);
+const WINDOW_BACK_MS: i64 = 14 * 24 * 3600 * 1000;
+const WINDOW_FORWARD_MS: i64 = 30 * 24 * 3600 * 1000;
+const PAGE_SIZE: u32 = 100;
+
+const KIND: &str = "microsoft_graph";
+
+pub struct MicrosoftGraphConnector {
+    id: String,
+    kind: String,
+    display_name: String,
+}
+
+impl MicrosoftGraphConnector {
+    pub fn new(row: &ConnectorRow) -> Self {
+        Self {
+            id: row.id.clone(),
+            kind: row.kind.clone(),
+            display_name: row.display_name.clone(),
+        }
+    }
+
+    /// Email portion of the connector_id (`microsoft_graph:<email>`).
+    /// Used to flag the corresponding attendee row as `is_self`.
+    fn self_email(&self) -> Option<&str> {
+        self.id.split_once(':').map(|(_, email)| email)
+    }
+}
+
+#[async_trait::async_trait]
+impl Connector for MicrosoftGraphConnector {
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn kind(&self) -> &str {
+        &self.kind
+    }
+    fn display_name(&self) -> &str {
+        &self.display_name
+    }
+    fn poll_interval(&self) -> Duration {
+        POLL_INTERVAL
+    }
+
+    async fn sync(&self, ctx: SyncCtx<'_>) -> Result<SyncReport, ConnectorError> {
+        let now = current_unix_ms();
+        let window_start = now - WINDOW_BACK_MS;
+        let window_end = now + WINDOW_FORWARD_MS;
+
+        // Fetch all events via /me/calendarView, paginated.
+        let raw_events = with_valid_token(ctx.app, &self.id, &self.kind, |access| async move {
+            fetch_calendar_view(&access, window_start, window_end).await
+        })
+        .await?;
+
+        // Snapshot team members for attendee resolution. Keep the
+        // lock window short — release before mapping.
+        let team = {
+            let conn = ctx
+                .conn
+                .lock()
+                .map_err(|e| ConnectorError::Other(format!("conn lock: {e}")))?;
+            team::list_team_members_raw(&conn).map_err(ConnectorError::Other)?
+        };
+        let resolver = AttendeeResolver::new(&team);
+        let self_email = self.self_email();
+
+        let events: Vec<CalendarEvent> = raw_events
+            .into_iter()
+            .map(|raw| map_event(&self.id, raw, &resolver, self_email))
+            .collect();
+
+        // Upsert in one transaction.
+        let report = {
+            let mut conn = ctx
+                .conn
+                .lock()
+                .map_err(|e| ConnectorError::Other(format!("conn lock: {e}")))?;
+            super::calendar::upsert_window(&mut conn, &self.id, &events, window_start, window_end)
+                .map_err(|e| ConnectorError::Other(format!("upsert events: {e}")))?
+        };
+
+        Ok(SyncReport {
+            added: report.added,
+            updated: report.updated,
+            removed: report.removed,
+            skipped: 0,
+        })
+    }
+}
+
+/// Plug the factory into the registry. Called once at app boot from
+/// `lib.rs`. Future PR (#61, Google) calls a similar `register()` from
+/// its own module.
+pub fn register(registry: &ConnectorRegistry) {
+    registry.register_kind(
+        KIND,
+        Arc::new(|row, _app| {
+            Ok(Arc::new(MicrosoftGraphConnector::new(row)) as Arc<dyn Connector>)
+        }),
+    );
+}
+
+// ----- Graph API client --------------------------------------------------
+
+async fn fetch_calendar_view(
+    access_token: &str,
+    start_ms: i64,
+    end_ms: i64,
+) -> Result<Vec<RawEvent>, ConnectorError> {
+    let client = reqwest::Client::builder()
+        .build()
+        .map_err(|e| ConnectorError::Network(format!("client init: {e}")))?;
+
+    let start_iso = ms_to_iso(start_ms);
+    let end_iso = ms_to_iso(end_ms);
+    let mut url = format!(
+        "https://graph.microsoft.com/v1.0/me/calendarView?startDateTime={start_iso}&endDateTime={end_iso}&$top={PAGE_SIZE}&$orderby=start/dateTime"
+    );
+
+    let mut all_events: Vec<RawEvent> = Vec::new();
+
+    loop {
+        let resp = client
+            .get(&url)
+            .bearer_auth(access_token)
+            .header("Prefer", "outlook.timezone=\"UTC\"")
+            .send()
+            .await
+            .map_err(|e| ConnectorError::Network(format!("graph GET: {e}")))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let retry_after = parse_retry_after(resp.headers());
+            let body = resp.text().await.unwrap_or_default();
+            return Err(map_status(status, retry_after, body));
+        }
+
+        let page: GraphPage = resp
+            .json()
+            .await
+            .map_err(|e| ConnectorError::Other(format!("graph response parse: {e}")))?;
+        all_events.extend(page.value);
+
+        match page.next_link {
+            Some(next) if !next.is_empty() => url = next,
+            _ => break,
+        }
+    }
+
+    Ok(all_events)
+}
+
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+    headers
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(|secs| secs * 1000)
+}
+
+fn map_status(
+    status: reqwest::StatusCode,
+    retry_after_ms: Option<u64>,
+    body: String,
+) -> ConnectorError {
+    match status.as_u16() {
+        401 => ConnectorError::ReauthNeeded(format!("graph 401: {body}")),
+        429 => ConnectorError::RateLimited {
+            retry_after_ms: retry_after_ms.unwrap_or(60_000),
+        },
+        503 => ConnectorError::RateLimited {
+            retry_after_ms: retry_after_ms.unwrap_or(30_000),
+        },
+        _ => ConnectorError::Other(format!("graph {status}: {body}")),
+    }
+}
+
+// ----- JSON shape --------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct GraphPage {
+    value: Vec<RawEvent>,
+    #[serde(rename = "@odata.nextLink")]
+    next_link: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct RawEvent {
+    pub(crate) id: String,
+    #[serde(default)]
+    pub(crate) subject: Option<String>,
+    #[serde(rename = "start")]
+    pub(crate) start: Option<RawDateTime>,
+    #[serde(rename = "end")]
+    pub(crate) end: Option<RawDateTime>,
+    #[serde(rename = "isAllDay", default)]
+    pub(crate) is_all_day: bool,
+    #[serde(rename = "isCancelled", default)]
+    pub(crate) is_cancelled: bool,
+    #[serde(default)]
+    pub(crate) location: Option<RawLocation>,
+    #[serde(rename = "bodyPreview", default)]
+    pub(crate) body_preview: Option<String>,
+    #[serde(default)]
+    pub(crate) attendees: Vec<RawAttendee>,
+    #[serde(default)]
+    pub(crate) organizer: Option<RawOrganizer>,
+    #[serde(rename = "@odata.etag", default)]
+    pub(crate) etag: Option<String>,
+    #[serde(rename = "lastModifiedDateTime", default)]
+    pub(crate) last_modified: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct RawDateTime {
+    #[serde(rename = "dateTime")]
+    pub(crate) date_time: String,
+    #[serde(rename = "timeZone", default)]
+    pub(crate) time_zone: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct RawLocation {
+    #[serde(rename = "displayName", default)]
+    pub(crate) display_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct RawAttendee {
+    #[serde(rename = "emailAddress")]
+    pub(crate) email_address: Option<RawEmailAddress>,
+    #[serde(default)]
+    pub(crate) status: Option<RawAttendeeStatus>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct RawEmailAddress {
+    #[serde(default)]
+    pub(crate) address: Option<String>,
+    #[serde(default)]
+    pub(crate) name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct RawAttendeeStatus {
+    #[serde(default)]
+    pub(crate) response: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct RawOrganizer {
+    #[serde(rename = "emailAddress")]
+    pub(crate) email_address: Option<RawEmailAddress>,
+}
+
+// ----- Mapping -----------------------------------------------------------
+
+pub(crate) fn map_event(
+    connector_id: &str,
+    raw: RawEvent,
+    resolver: &AttendeeResolver<'_>,
+    self_email: Option<&str>,
+) -> CalendarEvent {
+    let title = raw.subject.unwrap_or_default();
+    let title = if title.trim().is_empty() {
+        "(no subject)".to_string()
+    } else {
+        title
+    };
+
+    let start_ms = raw
+        .start
+        .as_ref()
+        .and_then(|d| iso_to_ms(&d.date_time))
+        .unwrap_or(0);
+    let end_ms = raw
+        .end
+        .as_ref()
+        .and_then(|d| iso_to_ms(&d.date_time))
+        .unwrap_or(start_ms);
+
+    let location = raw.location.and_then(|l| l.display_name);
+    let description = raw.body_preview;
+    let status = Some(if raw.is_cancelled { "cancelled" } else { "confirmed" }.to_string());
+    let modified_ms = raw
+        .last_modified
+        .as_deref()
+        .and_then(iso_to_ms)
+        .unwrap_or_else(current_unix_ms);
+
+    // Attendees: organizer first, then other attendees deduped by email.
+    let mut attendees: Vec<CalendarAttendee> = Vec::new();
+    let mut seen_emails: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    if let Some(org) = raw.organizer.as_ref().and_then(|o| o.email_address.as_ref()) {
+        if let Some(email) = org.address.as_deref() {
+            let email_lc = email.to_lowercase();
+            if !email_lc.is_empty() && seen_emails.insert(email_lc.clone()) {
+                attendees.push(CalendarAttendee {
+                    email: email_lc.clone(),
+                    display_name: org.name.clone(),
+                    response_status: Some("organizer".to_string()),
+                    is_self: self_email.map(|e| e.eq_ignore_ascii_case(&email_lc)).unwrap_or(false),
+                    is_organizer: true,
+                    team_member_id: resolver.resolve(&email_lc, org.name.as_deref()),
+                });
+            }
+        }
+    }
+
+    for raw_a in raw.attendees {
+        let email_addr = match raw_a.email_address {
+            Some(e) => e,
+            None => continue,
+        };
+        let email = match email_addr.address {
+            Some(e) if !e.is_empty() => e.to_lowercase(),
+            _ => continue,
+        };
+        if !seen_emails.insert(email.clone()) {
+            // Already added (organizer dup, or duplicate attendee row).
+            continue;
+        }
+        attendees.push(CalendarAttendee {
+            email: email.clone(),
+            display_name: email_addr.name,
+            response_status: raw_a.status.and_then(|s| s.response),
+            is_self: self_email.map(|e| e.eq_ignore_ascii_case(&email)).unwrap_or(false),
+            is_organizer: false,
+            team_member_id: resolver.resolve(&email, None),
+        });
+    }
+
+    CalendarEvent {
+        id: format!("{connector_id}::{}", raw.id),
+        connector_id: connector_id.to_string(),
+        external_id: raw.id,
+        title,
+        start_ms,
+        end_ms,
+        all_day: raw.is_all_day,
+        location,
+        description,
+        source_calendar: None, // primary calendar only in v1
+        status,
+        raw_etag: raw.etag,
+        modified_ms,
+        attendees,
+    }
+}
+
+// ----- Attendee resolver -------------------------------------------------
+
+/// Resolve an attendee's `email` (and optional display name) to a
+/// `team_member_id`, if Margin knows the person.
+///
+/// Strategy:
+///   1. Email match: lowercased email vs. team_member's display_name
+///      (some teams use email-as-name) AND any of their aliases.
+///   2. Name match: display_name through the existing
+///      `team::OwnerResolver` (handles diacritic-insensitive
+///      first-name matching).
+///
+/// `OwnerResolver` is in #[allow(dead_code)] until owner resolution
+/// expands beyond the action-items pipeline; we hold a reference here.
+pub(crate) struct AttendeeResolver<'a> {
+    by_name: OwnerResolver,
+    by_email: HashMap<String, String>, // email_lc → team_member_id
+    _members: &'a [TeamMember],
+}
+
+impl<'a> AttendeeResolver<'a> {
+    pub(crate) fn new(members: &'a [TeamMember]) -> Self {
+        let mut by_email: HashMap<String, String> = HashMap::new();
+        for m in members {
+            // Some teams put the email itself as display_name; treat
+            // that as an email key too.
+            if m.display_name.contains('@') {
+                by_email.insert(m.display_name.to_lowercase(), m.id.clone());
+            }
+            for alias in &m.aliases {
+                if alias.contains('@') {
+                    by_email.insert(alias.to_lowercase(), m.id.clone());
+                }
+            }
+        }
+        Self {
+            by_name: OwnerResolver::from_members(members),
+            by_email,
+            _members: members,
+        }
+    }
+
+    pub(crate) fn resolve(&self, email_lc: &str, display_name: Option<&str>) -> Option<String> {
+        if let Some(id) = self.by_email.get(email_lc) {
+            return Some(id.clone());
+        }
+        if let Some(name) = display_name {
+            if let Some(id) = self.by_name.resolve(name) {
+                return Some(id);
+            }
+        }
+        None
+    }
+}
+
+// ----- Time helpers ------------------------------------------------------
+
+fn iso_to_ms(s: &str) -> Option<i64> {
+    // Microsoft sends `dateTime` like "2026-05-12T09:30:00.0000000"
+    // (no timezone suffix when Prefer outlook.timezone is UTC) OR
+    // RFC 3339 like "2026-05-09T12:34:56Z" for lastModifiedDateTime.
+    // Try both: first as RFC 3339 (with Z), fall back to assuming UTC.
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Some(dt.with_timezone(&Utc).timestamp_millis());
+    }
+    // No timezone suffix: parse as naive then attach UTC.
+    if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f") {
+        return Some(Utc.from_utc_datetime(&naive).timestamp_millis());
+    }
+    None
+}
+
+fn ms_to_iso(ms: i64) -> String {
+    let secs = ms / 1000;
+    let nsec = ((ms % 1000) * 1_000_000) as u32;
+    DateTime::<Utc>::from_timestamp(secs, nsec)
+        .map(|dt| dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string())
+        .unwrap_or_else(|| "1970-01-01T00:00:00.000Z".to_string())
+}
+
+fn current_unix_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+use chrono::TimeZone as _;
+
+// ----- Tests --------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_member(id: &str, name: &str, aliases: &[&str]) -> TeamMember {
+        TeamMember {
+            id: id.to_string(),
+            display_name: name.to_string(),
+            role: String::new(),
+            aliases: aliases.iter().map(|s| s.to_string()).collect(),
+            profile_md_path: String::new(),
+            is_self: false,
+            created_ms: 0,
+            updated_ms: 0,
+        }
+    }
+
+    #[test]
+    fn iso_to_ms_handles_rfc3339_and_utc_naive() {
+        let ms_z = iso_to_ms("2026-05-12T09:30:00Z").unwrap();
+        let ms_naive = iso_to_ms("2026-05-12T09:30:00.0000000").unwrap();
+        assert_eq!(ms_z, ms_naive);
+    }
+
+    #[test]
+    fn map_event_basic() {
+        let raw = RawEvent {
+            id: "AAMkA1".to_string(),
+            subject: Some("Standup".to_string()),
+            start: Some(RawDateTime {
+                date_time: "2026-05-12T09:30:00.0000000".to_string(),
+                time_zone: Some("UTC".to_string()),
+            }),
+            end: Some(RawDateTime {
+                date_time: "2026-05-12T10:00:00.0000000".to_string(),
+                time_zone: Some("UTC".to_string()),
+            }),
+            is_all_day: false,
+            is_cancelled: false,
+            location: Some(RawLocation {
+                display_name: Some("Zoom".to_string()),
+            }),
+            body_preview: Some("Quarterly metrics".to_string()),
+            attendees: vec![RawAttendee {
+                email_address: Some(RawEmailAddress {
+                    address: Some("Heike@Example.com".to_string()),
+                    name: Some("Heike Müller".to_string()),
+                }),
+                status: Some(RawAttendeeStatus {
+                    response: Some("accepted".to_string()),
+                }),
+            }],
+            organizer: Some(RawOrganizer {
+                email_address: Some(RawEmailAddress {
+                    address: Some("tj@example.com".to_string()),
+                    name: Some("Tom".to_string()),
+                }),
+            }),
+            etag: Some("W/\"abc\"".to_string()),
+            last_modified: Some("2026-05-09T12:34:56Z".to_string()),
+        };
+        let members = [mk_member("hk1", "Heike", &["heike@example.com"])];
+        let resolver = AttendeeResolver::new(&members);
+        let ev = map_event("microsoft_graph:tj@example.com", raw, &resolver, Some("tj@example.com"));
+
+        assert_eq!(ev.title, "Standup");
+        assert_eq!(ev.location.as_deref(), Some("Zoom"));
+        assert_eq!(ev.status.as_deref(), Some("confirmed"));
+        assert_eq!(ev.attendees.len(), 2);
+
+        // Organizer first, lowercased email, marked is_self.
+        let org = &ev.attendees[0];
+        assert_eq!(org.email, "tj@example.com");
+        assert!(org.is_organizer);
+        assert!(org.is_self);
+
+        // Heike was resolved via her email alias.
+        let heike = &ev.attendees[1];
+        assert_eq!(heike.email, "heike@example.com");
+        assert_eq!(heike.team_member_id.as_deref(), Some("hk1"));
+        assert!(!heike.is_organizer);
+    }
+
+    #[test]
+    fn map_event_treats_cancelled() {
+        let mut raw = RawEvent {
+            id: "x".into(),
+            subject: Some("Was a meeting".into()),
+            start: Some(RawDateTime {
+                date_time: "2026-05-12T09:00:00".into(),
+                time_zone: None,
+            }),
+            end: Some(RawDateTime {
+                date_time: "2026-05-12T10:00:00".into(),
+                time_zone: None,
+            }),
+            is_all_day: false,
+            is_cancelled: true,
+            location: None,
+            body_preview: None,
+            attendees: vec![],
+            organizer: None,
+            etag: None,
+            last_modified: None,
+        };
+        raw.is_cancelled = true;
+        let resolver = AttendeeResolver::new(&[]);
+        let ev = map_event("mg:tj@e.com", raw, &resolver, None);
+        assert_eq!(ev.status.as_deref(), Some("cancelled"));
+    }
+
+    #[test]
+    fn map_event_default_subject_when_missing() {
+        let raw = RawEvent {
+            id: "y".into(),
+            subject: None,
+            start: Some(RawDateTime {
+                date_time: "2026-05-12T09:00:00".into(),
+                time_zone: None,
+            }),
+            end: Some(RawDateTime {
+                date_time: "2026-05-12T10:00:00".into(),
+                time_zone: None,
+            }),
+            is_all_day: false,
+            is_cancelled: false,
+            location: None,
+            body_preview: None,
+            attendees: vec![],
+            organizer: None,
+            etag: None,
+            last_modified: None,
+        };
+        let resolver = AttendeeResolver::new(&[]);
+        let ev = map_event("mg:tj@e.com", raw, &resolver, None);
+        assert_eq!(ev.title, "(no subject)");
+    }
+
+    #[test]
+    fn attendee_resolver_email_match() {
+        let members = [mk_member("hk1", "Heike Müller", &["heike@contoso.com"])];
+        let r = AttendeeResolver::new(&members);
+        assert_eq!(r.resolve("heike@contoso.com", None).as_deref(), Some("hk1"));
+        // Case-insensitive
+        assert_eq!(r.resolve("Heike@CONTOSO.com".to_lowercase().as_str(), None).as_deref(), Some("hk1"));
+    }
+
+    #[test]
+    fn attendee_resolver_name_fallback() {
+        let members = [mk_member("hk1", "Heike Müller", &[])];
+        let r = AttendeeResolver::new(&members);
+        // Email not registered as alias.
+        assert_eq!(r.resolve("unknown@x.com", Some("Heike Müller")).as_deref(), Some("hk1"));
+    }
+
+    #[test]
+    fn attendee_resolver_no_match_returns_none() {
+        let r = AttendeeResolver::new(&[]);
+        assert!(r.resolve("nobody@nope.com", Some("Nobody")).is_none());
+    }
+}

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -25,7 +25,9 @@ use std::time::Duration;
 use rusqlite::Connection;
 use serde::Serialize;
 
+pub mod calendar;
 pub mod commands;
+pub mod microsoft_graph;
 pub mod oauth;
 pub mod providers;
 pub mod registry;

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -39,7 +39,8 @@ const SCHEMA_V5: &str = include_str!("migrations/005_due_dates.sql");
 const SCHEMA_V6: &str = include_str!("migrations/006_team_members.sql");
 const SCHEMA_V7: &str = include_str!("migrations/007_action_owners.sql");
 const SCHEMA_V8: &str = include_str!("migrations/008_connectors.sql");
-const SCHEMA_VERSION: i64 = 8;
+const SCHEMA_V9: &str = include_str!("migrations/009_calendar.sql");
+const SCHEMA_VERSION: i64 = 9;
 
 /// Open the index DB at `db_path` (creating it if absent) and apply any
 /// pending migrations.
@@ -113,6 +114,10 @@ fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 7 {
         conn.execute_batch(SCHEMA_V8)?;
         version = 8;
+    }
+    if version == 8 {
+        conn.execute_batch(SCHEMA_V9)?;
+        version = 9;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -522,13 +522,14 @@ pub fn run() {
             }
 
             // Connector registry: holds kind-factory mappings + live
-            // connector instances. Real factories register themselves
-            // in their own module's setup hook in future PRs (#61, #63).
-            // For #59 the registry boots empty — `rebuild_instances`
-            // is still called so any previously-persisted rows are
-            // observed (and skipped with a warning if their kind has
-            // no factory yet).
+            // connector instances. Real connector modules register
+            // their factories at boot (Microsoft Graph in #63;
+            // Google Calendar in a future #61). `rebuild_instances`
+            // then hydrates `Arc<dyn Connector>` instances from the
+            // persisted `connectors` table — kinds without registered
+            // factories are skipped with a warning.
             let registry = std::sync::Arc::new(connectors::ConnectorRegistry::new());
+            connectors::microsoft_graph::register(&registry);
             if let Err(e) = registry.rebuild_instances(app.handle(), &conn) {
                 eprintln!("connector registry rebuild failed at boot: {e}");
             }
@@ -664,7 +665,9 @@ pub fn run() {
             connectors::commands::list_connectors,
             connectors::commands::list_oauth_providers,
             connectors::commands::start_oauth_connector,
-            connectors::commands::delete_connector
+            connectors::commands::delete_connector,
+            connectors::commands::list_calendar_events,
+            connectors::commands::get_event_details
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/migrations/009_calendar.sql
+++ b/src-tauri/src/migrations/009_calendar.sql
@@ -1,0 +1,34 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE calendar_events (
+  id              TEXT PRIMARY KEY,
+  connector_id    TEXT NOT NULL REFERENCES connectors(id) ON DELETE CASCADE,
+  external_id     TEXT NOT NULL,
+  title           TEXT NOT NULL,
+  start_ms        INTEGER NOT NULL,
+  end_ms          INTEGER NOT NULL,
+  all_day         INTEGER NOT NULL DEFAULT 0,
+  location        TEXT,
+  description     TEXT,
+  source_calendar TEXT,
+  status          TEXT,
+  raw_etag        TEXT,
+  modified_ms     INTEGER NOT NULL
+);
+CREATE INDEX idx_events_start ON calendar_events(start_ms);
+CREATE INDEX idx_events_connector ON calendar_events(connector_id);
+CREATE UNIQUE INDEX idx_events_extid ON calendar_events(connector_id, external_id);
+
+CREATE TABLE calendar_attendees (
+  event_id        TEXT NOT NULL REFERENCES calendar_events(id) ON DELETE CASCADE,
+  email           TEXT NOT NULL,
+  display_name    TEXT,
+  response_status TEXT,
+  is_self         INTEGER NOT NULL DEFAULT 0,
+  is_organizer    INTEGER NOT NULL DEFAULT 0,
+  team_member_id  TEXT REFERENCES team_members(id) ON DELETE SET NULL,
+  PRIMARY KEY (event_id, email)
+);
+CREATE INDEX idx_attendees_team_member ON calendar_attendees(team_member_id);
+
+UPDATE meta SET value = '9' WHERE key = 'schema_version';

--- a/src/file.ts
+++ b/src/file.ts
@@ -346,6 +346,54 @@ export async function deleteConnector(connectorId: string): Promise<void> {
   return invoke<void>("delete_connector", { connectorId });
 }
 
+// --- Calendar events (#63) -----------------------------------------------
+
+export type CalendarAttendee = {
+  email: string;
+  display_name: string | null;
+  response_status: string | null;
+  is_self: boolean;
+  is_organizer: boolean;
+  team_member_id: string | null;
+};
+
+export type CalendarEvent = {
+  id: string;
+  connector_id: string;
+  external_id: string;
+  title: string;
+  start_ms: number;
+  end_ms: number;
+  all_day: boolean;
+  location: string | null;
+  description: string | null;
+  source_calendar: string | null;
+  status: string | null;
+  raw_etag: string | null;
+  modified_ms: number;
+  attendees: CalendarAttendee[];
+};
+
+/** Read calendar events whose start time falls in [startMs, endMs].
+ *  Optional `connectorId` to scope to a single source. The backend
+ *  joins attendees in a single query; results are ordered by start
+ *  time ascending. */
+export async function listCalendarEvents(
+  startMs: number,
+  endMs: number,
+  connectorId?: string,
+): Promise<CalendarEvent[]> {
+  return invoke<CalendarEvent[]>("list_calendar_events", {
+    startMs,
+    endMs,
+    connectorId,
+  });
+}
+
+export async function getEventDetails(eventId: string): Promise<CalendarEvent | null> {
+  return invoke<CalendarEvent | null>("get_event_details", { eventId });
+}
+
 export type NoteMeta = { modified_ms: number };
 
 export async function noteMeta(notePath: string): Promise<NoteMeta> {


### PR DESCRIPTION
## Summary
- First concrete `Connector` implementation, on top of #59 + #60 (PR #65)
- Pulls events from Microsoft Graph `/me/calendarView` into new shared `calendar_events` + `calendar_attendees` tables (migration 009)
- Provider-agnostic storage layer (`connectors/calendar.rs`) — Google Calendar (#61) drops in unchanged
- 5-minute poll interval, 14-day-back / 30-day-forward window, UTC-only via `Prefer: outlook.timezone="UTC"`
- Pagination via `@odata.nextLink`. Status mapping: 401 → ReauthNeeded, 429/503 → RateLimited (with Retry-After), other non-2xx → Other
- `AttendeeResolver`: email-first match against `team_members.aliases`, falls back to display-name match through the existing `OwnerResolver` (handles diacritic-insensitive first-name matching). Resolves to `team_member_id` when unambiguous
- New Tauri commands: `list_calendar_events(start_ms, end_ms, connector_id?)` and `get_event_details(event_id)` — used by #62

Closes #63.

Stacks on PR #65 (#59 + #60). Base set to `connector-foundation` so the diff is just the Microsoft work.

## Test plan
- [ ] Schema 009 migration applies cleanly
- [ ] With `MARGIN_MICROSOFT_CLIENT_ID` exported, register Microsoft Calendar in Settings → Connectors → events appear in `calendar_events` within ~30s
- [ ] Run `sqlite3 ~/.margin/index.db "SELECT title, datetime(start_ms/1000,'unixepoch') FROM calendar_events ORDER BY start_ms LIMIT 5;"` — sees real meetings
- [ ] Verify attendees populate and some resolve to `team_member_id`
- [ ] 11 new unit tests pass: `DYLD_FALLBACK_LIBRARY_PATH=/usr/lib/swift cargo test connectors::` runs 18+ green
- [ ] Force a 401 (revoke at Microsoft) → `last_error` becomes `reauth_needed:` → Settings shows Reconnect