### PR TITLE
'Coming up' strip + greeting subline (#62)

### DIFF
--- a/src-tauri/src/connectors/calendar.rs
+++ b/src-tauri/src/connectors/calendar.rs
@@ -28,6 +28,11 @@ pub struct CalendarEvent {
     pub status: Option<String>,
     pub raw_etag: Option<String>,
     pub modified_ms: i64,
+    /// Path to the note bundle the user linked to this event (via the
+    /// "Coming up" strip click handler). Set lazily on first click;
+    /// preserved across re-syncs (#62). Null until the user opens the
+    /// event for the first time.
+    pub linked_note_path: Option<String>,
     pub attendees: Vec<CalendarAttendee>,
 }
 
@@ -112,11 +117,15 @@ pub fn upsert_window(
 }
 
 fn upsert_event(tx: &rusqlite::Transaction<'_>, e: &CalendarEvent) -> rusqlite::Result<()> {
+    // ON CONFLICT preserves `linked_note_path` — it's owned by the
+    // user (set on first click of the event), not by the connector.
+    // Re-syncing the event must not clobber it.
     tx.execute(
         "INSERT INTO calendar_events(\
             id, connector_id, external_id, title, start_ms, end_ms, all_day, \
-            location, description, source_calendar, status, raw_etag, modified_ms\
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13) \
+            location, description, source_calendar, status, raw_etag, modified_ms, \
+            linked_note_path\
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14) \
          ON CONFLICT(id) DO UPDATE SET \
             title = excluded.title, \
             start_ms = excluded.start_ms, \
@@ -142,6 +151,7 @@ fn upsert_event(tx: &rusqlite::Transaction<'_>, e: &CalendarEvent) -> rusqlite::
             e.status,
             e.raw_etag,
             e.modified_ms,
+            e.linked_note_path,
         ],
     )?;
 
@@ -181,14 +191,16 @@ pub fn list_events_in_range(
     let sql = match connector_id {
         Some(_) => {
             "SELECT id, connector_id, external_id, title, start_ms, end_ms, all_day, \
-                    location, description, source_calendar, status, raw_etag, modified_ms \
+                    location, description, source_calendar, status, raw_etag, modified_ms, \
+                    linked_note_path \
              FROM calendar_events \
              WHERE start_ms BETWEEN ?1 AND ?2 AND connector_id = ?3 \
              ORDER BY start_ms ASC"
         }
         None => {
             "SELECT id, connector_id, external_id, title, start_ms, end_ms, all_day, \
-                    location, description, source_calendar, status, raw_etag, modified_ms \
+                    location, description, source_calendar, status, raw_etag, modified_ms, \
+                    linked_note_path \
              FROM calendar_events \
              WHERE start_ms BETWEEN ?1 AND ?2 \
              ORDER BY start_ms ASC"
@@ -211,6 +223,7 @@ pub fn list_events_in_range(
             status: r.get(10)?,
             raw_etag: r.get(11)?,
             modified_ms: r.get(12)?,
+            linked_note_path: r.get(13)?,
             attendees: Vec::new(),
         })
     };
@@ -238,13 +251,29 @@ pub fn list_events_in_range(
     Ok(events)
 }
 
+/// Update an event's `linked_note_path`. Called after the user clicks
+/// an event card in the "Coming up" strip and we've created (or
+/// rediscovered) the linked note bundle.
+pub fn set_linked_note_path(
+    conn: &Connection,
+    event_id: &str,
+    note_path: &str,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE calendar_events SET linked_note_path = ?1 WHERE id = ?2",
+        params![note_path, event_id],
+    )?;
+    Ok(())
+}
+
 pub fn get_event_details(
     conn: &Connection,
     event_id: &str,
 ) -> rusqlite::Result<Option<CalendarEvent>> {
     let mut stmt = conn.prepare(
         "SELECT id, connector_id, external_id, title, start_ms, end_ms, all_day, \
-                location, description, source_calendar, status, raw_etag, modified_ms \
+                location, description, source_calendar, status, raw_etag, modified_ms, \
+                linked_note_path \
          FROM calendar_events WHERE id = ?1",
     )?;
     let mut event: Option<CalendarEvent> = stmt
@@ -263,6 +292,7 @@ pub fn get_event_details(
                 status: r.get(10)?,
                 raw_etag: r.get(11)?,
                 modified_ms: r.get(12)?,
+                linked_note_path: r.get(13)?,
                 attendees: Vec::new(),
             })
         })
@@ -340,6 +370,8 @@ mod tests {
         .unwrap();
         conn.execute_batch(include_str!("../migrations/009_calendar.sql"))
             .unwrap();
+        conn.execute_batch(include_str!("../migrations/010_event_note_link.sql"))
+            .unwrap();
         conn
     }
 
@@ -358,6 +390,7 @@ mod tests {
             status: Some("confirmed".to_string()),
             raw_etag: None,
             modified_ms: start_ms,
+            linked_note_path: None,
             attendees: attendee_emails
                 .iter()
                 .map(|e| CalendarAttendee {
@@ -465,5 +498,34 @@ mod tests {
         let conn = open_test_db();
         let result = get_event_details(&conn, "nope").unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn set_linked_note_path_round_trips_and_survives_resync() {
+        let mut conn = open_test_db();
+        let event = make_event("a", 5_000, &[]);
+        upsert_window(&mut conn, "mg:test", &[event.clone()], 0, 100_000).unwrap();
+
+        // User clicks the event → set linked path.
+        set_linked_note_path(&conn, &event.id, "/tmp/notes/x/note.md").unwrap();
+        let after_link = get_event_details(&conn, &event.id).unwrap().unwrap();
+        assert_eq!(after_link.linked_note_path.as_deref(), Some("/tmp/notes/x/note.md"));
+
+        // Now re-sync the same event with `linked_note_path: None`
+        // (the connector doesn't know about the link).
+        let mut resynced = event.clone();
+        resynced.title = "Renamed in calendar".to_string();
+        resynced.linked_note_path = None;
+        upsert_window(&mut conn, "mg:test", &[resynced], 0, 100_000).unwrap();
+
+        // Title updated, link preserved (the COALESCE skip on
+        // ON CONFLICT keeps the user-set value).
+        let after_resync = get_event_details(&conn, &event.id).unwrap().unwrap();
+        assert_eq!(after_resync.title, "Renamed in calendar");
+        assert_eq!(
+            after_resync.linked_note_path.as_deref(),
+            Some("/tmp/notes/x/note.md"),
+            "linked_note_path must survive a re-sync that doesn't carry it"
+        );
     }
 }

--- a/src-tauri/src/connectors/commands.rs
+++ b/src-tauri/src/connectors/commands.rs
@@ -215,3 +215,128 @@ pub fn get_event_details(
     let c = conn.lock().map_err(|e| e.to_string())?;
     super::calendar::get_event_details(&c, &event_id).map_err(|e| e.to_string())
 }
+
+/// Click handler for the "Coming up" strip (#62). Returns a path to a
+/// note bundle that "belongs" to this calendar event:
+///   - If the event already has a `linked_note_path` AND the file still
+///     exists on disk, return that path.
+///   - Otherwise, create a fresh bundle, write a starter body with
+///     calendar metadata in frontmatter, persist meeting attendees in
+///     the team module, and store the path on the event row for next
+///     time.
+#[tauri::command]
+pub fn open_or_create_event_note(
+    event_id: String,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<String, String> {
+    use std::fs;
+    use std::path::Path;
+
+    let event = {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        super::calendar::get_event_details(&c, &event_id)
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("event {event_id} not found"))?
+    };
+
+    // Reuse the linked bundle if it still exists on disk.
+    if let Some(path) = &event.linked_note_path {
+        if Path::new(path).exists() {
+            return Ok(path.clone());
+        }
+    }
+
+    // Create a fresh bundle. Mirrors notes::create_note's body — we
+    // can't call that directly because it's a Tauri command; the
+    // create-dir + write-file + index touch is small enough to
+    // duplicate.
+    let id = uuid::Uuid::new_v4().to_string();
+    let dir = crate::paths::notes_dir().join(&id);
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let note_path = dir.join(crate::notes::NOTE_FILENAME);
+
+    // Compose starter body with frontmatter. AI ask (#64) will key off
+    // `calendar_event_id` to join the note back to its event in
+    // future contextual prompts.
+    let body = format_event_note_body(&event);
+    fs::write(&note_path, body).map_err(|e| e.to_string())?;
+
+    let note_path_str = note_path.to_string_lossy().into_owned();
+
+    // Persist attendees + the link in one lock window.
+    {
+        let mut c = conn.lock().map_err(|e| e.to_string())?;
+        // Index the new bundle so it shows up in list_notes / search
+        // immediately.
+        if let Err(e) = crate::index::upsert(&mut c, &note_path) {
+            eprintln!("[connectors] index upsert for new event note failed: {e}");
+        }
+        // Save attendees that resolved to known team_members. Mirrors
+        // team::set_meeting_attendees inline (the latter is a Tauri
+        // command and awkward to call from here).
+        let member_ids: Vec<String> = event
+            .attendees
+            .iter()
+            .filter_map(|a| a.team_member_id.clone())
+            .collect();
+        if !member_ids.is_empty() {
+            let tx = c.transaction().map_err(|e| e.to_string())?;
+            tx.execute(
+                "DELETE FROM meeting_attendees WHERE note_path = ?1",
+                rusqlite::params![&note_path_str],
+            )
+            .map_err(|e| e.to_string())?;
+            {
+                let mut stmt = tx
+                    .prepare(
+                        "INSERT INTO meeting_attendees(note_path, member_id) VALUES (?1, ?2) \
+                         ON CONFLICT(note_path, member_id) DO NOTHING",
+                    )
+                    .map_err(|e| e.to_string())?;
+                for member_id in &member_ids {
+                    stmt.execute(rusqlite::params![&note_path_str, member_id])
+                        .map_err(|e| e.to_string())?;
+                }
+            }
+            tx.commit().map_err(|e| e.to_string())?;
+        }
+        super::calendar::set_linked_note_path(&c, &event.id, &note_path_str)
+            .map_err(|e| e.to_string())?;
+    }
+
+    Ok(note_path_str)
+}
+
+fn format_event_note_body(event: &super::calendar::CalendarEvent) -> String {
+    let mut s = String::new();
+    s.push_str("---\n");
+    s.push_str(&format!("calendar_event_id: {}\n", yaml_escape(&event.id)));
+    s.push_str(&format!("meeting_start_ms: {}\n", event.start_ms));
+    s.push_str(&format!("meeting_end_ms: {}\n", event.end_ms));
+    if let Some(loc) = &event.location {
+        s.push_str(&format!("location: {}\n", yaml_escape(loc)));
+    }
+    s.push_str("---\n\n");
+    s.push_str(&format!("# {}\n\n", event.title));
+    s
+}
+
+/// Minimal YAML string escape — sufficient for IDs / locations the
+/// connector hands us. If the value contains any special chars
+/// (colon, quotes, newline, leading/trailing whitespace) we wrap it
+/// in double quotes and backslash-escape internal quotes/backslashes.
+fn yaml_escape(s: &str) -> String {
+    let needs_quoting = s.is_empty()
+        || s.starts_with(' ')
+        || s.ends_with(' ')
+        || s.contains(':')
+        || s.contains('\n')
+        || s.contains('"')
+        || s.contains('\'')
+        || s.contains('#');
+    if !needs_quoting {
+        return s.to_string();
+    }
+    let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}

--- a/src-tauri/src/connectors/microsoft_graph.rs
+++ b/src-tauri/src/connectors/microsoft_graph.rs
@@ -372,6 +372,10 @@ pub(crate) fn map_event(
         status,
         raw_etag: raw.etag,
         modified_ms,
+        // Connector never sets the link — only the user does, via the
+        // "Coming up" strip click handler. `upsert_event` preserves
+        // any existing value across re-syncs.
+        linked_note_path: None,
         attendees,
     }
 }

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -40,7 +40,8 @@ const SCHEMA_V6: &str = include_str!("migrations/006_team_members.sql");
 const SCHEMA_V7: &str = include_str!("migrations/007_action_owners.sql");
 const SCHEMA_V8: &str = include_str!("migrations/008_connectors.sql");
 const SCHEMA_V9: &str = include_str!("migrations/009_calendar.sql");
-const SCHEMA_VERSION: i64 = 9;
+const SCHEMA_V10: &str = include_str!("migrations/010_event_note_link.sql");
+const SCHEMA_VERSION: i64 = 10;
 
 /// Open the index DB at `db_path` (creating it if absent) and apply any
 /// pending migrations.
@@ -118,6 +119,10 @@ fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 8 {
         conn.execute_batch(SCHEMA_V9)?;
         version = 9;
+    }
+    if version == 9 {
+        conn.execute_batch(SCHEMA_V10)?;
+        version = 10;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -667,7 +667,8 @@ pub fn run() {
             connectors::commands::start_oauth_connector,
             connectors::commands::delete_connector,
             connectors::commands::list_calendar_events,
-            connectors::commands::get_event_details
+            connectors::commands::get_event_details,
+            connectors::commands::open_or_create_event_note
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/migrations/010_event_note_link.sql
+++ b/src-tauri/src/migrations/010_event_note_link.sql
@@ -1,0 +1,4 @@
+ALTER TABLE calendar_events ADD COLUMN linked_note_path TEXT;
+CREATE INDEX idx_events_linked_note ON calendar_events(linked_note_path);
+
+UPDATE meta SET value = '10' WHERE key = 'schema_version';

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,8 +1,17 @@
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { AssigneeChip, stripLeadingOwnerPrefix } from "./AssigneeChip";
 import { dueBucket, friendlyDueLabel } from "./dueLabel";
-import { type ActionListItem, type NoteListItem, type TeamMember } from "./file";
+import {
+  type ActionListItem,
+  type CalendarEvent,
+  type ConnectorStatusEvent,
+  listCalendarEvents,
+  type NoteListItem,
+  openOrCreateEventNote,
+  type TeamMember,
+} from "./file";
 import { avatarColor } from "./initials";
 import { MoreMenu } from "./MoreMenu";
 import { type NotificationRecord, unreadCount } from "./notifications";
@@ -101,10 +110,158 @@ function DueChip({ dueMs }: { dueMs: number | null }) {
   );
 }
 
-// Stub data for sections whose backends don't exist yet (#27 calendar).
-// Returns empty so the section hides gracefully; swap in live data when
-// the backend lands.
-const UPCOMING_EVENTS: UpcomingEvent[] = [];
+/// Live calendar data hook (#62). Returns mapped `UpcomingEvent`s for
+/// the next 24 hours plus a 30-minute look-back window so an
+/// in-progress meeting still appears with a "Now" indicator. Refetches
+/// on every `connector-status` Tauri event so a freshly-synced
+/// connector lights up immediately. Ticks once per minute so relative
+/// labels ("in 12 min" → "in 11 min") update without manual refresh.
+function useUpcomingEvents(): {
+  upcoming: UpcomingEvent[];
+  raw: CalendarEvent[];
+  nowMs: number;
+} {
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [tickMs, setTickMs] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      const now = Date.now();
+      try {
+        const list = await listCalendarEvents(
+          now - 30 * 60_000,
+          now + 24 * 3600_000,
+        );
+        if (!cancelled) setEvents(list);
+      } catch (e) {
+        if (!cancelled) console.error("[home] listCalendarEvents failed:", e);
+      }
+    };
+    void load();
+    let unlisten: UnlistenFn | null = null;
+    (async () => {
+      const fn = await listen<ConnectorStatusEvent>("connector-status", () => {
+        void load();
+      });
+      if (cancelled) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  useEffect(() => {
+    const id = window.setInterval(() => setTickMs(Date.now()), 60_000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const upcoming = useMemo(
+    () =>
+      events
+        .filter(
+          (e) =>
+            // Defensive against any event whose start_ms didn't parse —
+            // would render with a misleading "Now" label.
+            e.start_ms > tickMs - 24 * 3600_000 && e.status !== "cancelled",
+        )
+        .map((e) => mapToUpcoming(e, tickMs)),
+    [events, tickMs],
+  );
+
+  return { upcoming, raw: events, nowMs: tickMs };
+}
+
+function mapToUpcoming(e: CalendarEvent, nowMs: number): UpcomingEvent {
+  const live = e.start_ms <= nowMs && nowMs < e.end_ms;
+  return {
+    id: e.id,
+    when: live ? "now" : formatRelative(e.start_ms, nowMs),
+    tStart: formatHm(e.start_ms),
+    tEnd: formatHm(e.end_ms),
+    title: e.title,
+    attendees: e.attendees
+      .filter((a) => !a.is_self)
+      .slice(0, 8)
+      .map((a) => initialsOf(a.display_name ?? a.email)),
+    tags: [],
+    color: connectorColor(e.connector_id),
+    live,
+  };
+}
+
+function formatHm(ms: number): string {
+  return new Intl.DateTimeFormat([], {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(ms));
+}
+
+function formatRelative(startMs: number, nowMs: number): string {
+  const delta = startMs - nowMs;
+  if (delta < 60_000) return "now";
+  const min = Math.floor(delta / 60_000);
+  if (min < 60) return `in ${min} min`;
+
+  const startDay = startOfDay(startMs);
+  const todayDay = startOfDay(nowMs);
+  if (startDay === todayDay) {
+    const h = Math.floor(min / 60);
+    const m = min % 60;
+    return m > 0 ? `in ${h}h ${m}m` : `in ${h}h`;
+  }
+  if (startDay === todayDay + 24 * 3600_000) {
+    return `tomorrow at ${formatHm(startMs)}`;
+  }
+  const weekday = new Intl.DateTimeFormat([], { weekday: "short" }).format(
+    new Date(startMs),
+  );
+  return `${weekday} at ${formatHm(startMs)}`;
+}
+
+function startOfDay(ms: number): number {
+  const d = new Date(ms);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+/// Two-character initials extracted from a display name or email. For
+/// emails we use the local part. AttendeeStack already calls
+/// `avatarColor()` per initials string so different attendees get
+/// different chip colors.
+function initialsOf(s: string): string {
+  const trimmed = s.trim();
+  if (trimmed.length === 0) return "?";
+  // Email: take the first letter of the local part.
+  if (trimmed.includes("@")) {
+    const local = trimmed.split("@")[0];
+    return (local.slice(0, 2) || "?").toUpperCase();
+  }
+  // Name: first letter of first two whitespace-separated tokens.
+  const parts = trimmed.split(/\s+/).filter(Boolean);
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[1][0]).toUpperCase();
+}
+
+/// Map connector_id to a stable accent color. Provider-aware lookup —
+/// Microsoft = MS blue, Google = Google blue, others = neutral. v1
+/// keeps this static; per-account variation can be a v2 nicety.
+function connectorColor(connectorId: string): string {
+  const kind = connectorId.split(":")[0];
+  switch (kind) {
+    case "microsoft_graph":
+      return "#0078d4";
+    case "google_calendar":
+      return "#1a73e8";
+    default:
+      return "#888";
+  }
+}
 
 export function Home({
   notes,
@@ -266,6 +423,39 @@ export function Home({
 
   const openActionCount = actions.filter((a) => !a.done).length;
 
+  const { upcoming, raw: rawEvents, nowMs: eventsNowMs } = useUpcomingEvents();
+
+  // Today-bound count for the greeting subline. Counts events whose
+  // start falls between today's midnight and tomorrow's, ignoring
+  // cancelled events.
+  const todayCount = useMemo(() => {
+    const dayStart = startOfDay(eventsNowMs);
+    const dayEnd = dayStart + 24 * 3600_000;
+    return rawEvents.filter(
+      (e) =>
+        e.status !== "cancelled" &&
+        e.start_ms >= dayStart &&
+        e.start_ms < dayEnd,
+    ).length;
+  }, [rawEvents, eventsNowMs]);
+
+  // The next future event drives the greeting accent ("1 starts in
+  // Xm"). Skip in-progress events here — those already get a Now
+  // pulse on their card.
+  const nextEvent = useMemo(
+    () => upcoming.find((e) => !e.live) ?? null,
+    [upcoming],
+  );
+
+  const openEventNote = async (eventId: string) => {
+    try {
+      const path = await openOrCreateEventNote(eventId);
+      onOpen(path);
+    } catch (e) {
+      console.error("[home] openOrCreateEventNote failed:", e);
+    }
+  };
+
   return (
     <div className={"home" + (sidebarOpen ? "" : " home-collapsed")}>
       <SearchPalette
@@ -281,7 +471,7 @@ export function Home({
           active={nav}
           onSelect={setNav}
           actionCount={openActionCount}
-          meetingCount={UPCOMING_EVENTS.length}
+          meetingCount={upcoming.length}
           tags={allTags}
           activeTag={tagFilter}
           onTagSelect={(t) => setTagFilter(t === tagFilter ? null : t)}
@@ -329,13 +519,13 @@ export function Home({
         </div>
 
         <Greeting
-          upcomingCount={UPCOMING_EVENTS.length}
-          nextEvent={UPCOMING_EVENTS[0] ?? null}
+          upcomingCount={todayCount}
+          nextEvent={nextEvent}
           onNewNote={onNewNote}
           onNewMeeting={onNewMeeting}
         />
 
-        {UPCOMING_EVENTS.length > 0 && <UpcomingStrip events={UPCOMING_EVENTS} />}
+        {upcoming.length > 0 && <UpcomingStrip events={upcoming} onOpen={openEventNote} />}
 
         {nav === "team" ? (
           <TeamView
@@ -616,13 +806,24 @@ type UpcomingEvent = {
   live?: boolean;
 };
 
-function UpcomingStrip({ events }: { events: UpcomingEvent[] }) {
+function UpcomingStrip({
+  events,
+  onOpen,
+}: {
+  events: UpcomingEvent[];
+  onOpen: (eventId: string) => void;
+}) {
   return (
     <section className="home-section">
-      <SectionTitle eyebrow="Upcoming" title="Coming up" actionLabel="View calendar" actionIssue={27} />
+      <SectionTitle eyebrow="Upcoming" title="Coming up" />
       <div className="home-upcoming">
         {events.map((ev) => (
-          <button key={ev.id} type="button" className="home-upcoming-card">
+          <button
+            key={ev.id}
+            type="button"
+            className="home-upcoming-card"
+            onClick={() => onOpen(ev.id)}
+          >
             <span className="home-upcoming-strip" style={{ background: ev.color }} />
             <div className="home-upcoming-row">
               <span className={"home-upcoming-when" + (ev.live ? " live" : "")}>

--- a/src/file.ts
+++ b/src/file.ts
@@ -371,6 +371,10 @@ export type CalendarEvent = {
   status: string | null;
   raw_etag: string | null;
   modified_ms: number;
+  /** Path to the note bundle the user linked to this event (set on
+   *  first click of the event card). Null until linked. Survives
+   *  re-syncs of the same event. */
+  linked_note_path: string | null;
   attendees: CalendarAttendee[];
 };
 
@@ -392,6 +396,16 @@ export async function listCalendarEvents(
 
 export async function getEventDetails(eventId: string): Promise<CalendarEvent | null> {
   return invoke<CalendarEvent | null>("get_event_details", { eventId });
+}
+
+/** Returns a path to the note bundle for this calendar event. If the
+ *  event was already linked, returns the existing path. Otherwise
+ *  creates a fresh bundle with calendar metadata in the frontmatter,
+ *  records meeting attendees in the team module, and persists the
+ *  link on the event row. Used by the "Coming up" strip click
+ *  handler (#62). */
+export async function openOrCreateEventNote(eventId: string): Promise<string> {
+  return invoke<string>("open_or_create_event_note", { eventId });
 }
 
 export type NoteMeta = { modified_ms: number };


### PR DESCRIPTION
## Summary
- Replaces the empty `UPCOMING_EVENTS` stub with real data flowing from `calendar_events` (via #63) into the Home page
- Greeting subline shows real meeting counts ("You have N meetings today and 1 starts in Xm")
- "Coming up" strip renders cards in start-time order with live "Now" pulse for in-progress meetings
- 60-second tick refreshes relative-time labels; auto-refetch on every `connector-status` event
- Migration 010 adds `linked_note_path` column to `calendar_events`. Click a card → open (or create) a linked note bundle. The link survives re-syncs (UPSERT preserves the user-set value)
- `open_or_create_event_note` Tauri command writes starter frontmatter (`calendar_event_id`, `meeting_start_ms`, `meeting_end_ms`, `location`), indexes the new note, and persists attendees with resolved `team_member_id`s

Closes #62. Stacks on PR #66 (#63).

## Test plan
- [ ] Migration 010 applies cleanly (schema → v10)
- [ ] With Microsoft Calendar configured: real meetings appear in the strip in start-time order
- [ ] Greeting subline shows correct count
- [ ] In-progress meeting (start ≤ now < end) shows blue "Now" pulse
- [ ] Card showing "in 12 min" updates to "in 11 min" after 60s
- [ ] Click a card → fresh bundle opens with frontmatter + title; attendees recorded via the team module
- [ ] Click the same card again → reopens the same bundle (no duplicate)
- [ ] Delete the bundle from disk → next click creates a new one + updates the link
- [ ] Re-sync the event from Microsoft (e.g. rename in Outlook) → strip title updates, link is preserved (covered by `set_linked_note_path_round_trips_and_survives_resync`)
- [ ] No connectors configured → strip hidden, greeting shows default copy