### PR TITLE
Email ingestion via Microsoft Mail (#69)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Local env files (OAuth client IDs, etc.)
+.env
+.env.*
+!.env.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src-tauri/src/connectors/commands.rs
+++ b/src-tauri/src/connectors/commands.rs
@@ -321,6 +321,77 @@ fn format_event_note_body(event: &super::calendar::CalendarEvent) -> String {
     s
 }
 
+// ----- Email query commands (#69) ----------------------------------------
+
+#[tauri::command]
+pub fn list_email_messages(
+    thread_id: Option<String>,
+    sent_from_ms: Option<i64>,
+    sent_to_ms: Option<i64>,
+    connector_id: Option<String>,
+    limit: Option<u32>,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<Vec<super::email::EmailMessage>, String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    if let Some(tid) = thread_id {
+        return super::email::list_messages_by_thread(&c, &tid).map_err(|e| e.to_string());
+    }
+    let from = sent_from_ms.unwrap_or(0);
+    let to = sent_to_ms.unwrap_or_else(|| current_unix_ms() + 24 * 3600 * 1000);
+    let lim = limit.unwrap_or(100) as usize;
+    super::email::list_messages_in_range(&c, from, to, connector_id.as_deref(), lim)
+        .map_err(|e| e.to_string())
+}
+
+/// Lazy-fetch a message body. On first call we GET `body` from Graph,
+/// persist it, and return. Subsequent calls return the cached value.
+#[tauri::command]
+pub async fn get_email_body(
+    app: AppHandle,
+    message_id: String,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<Option<String>, String> {
+    // Fast path: already cached.
+    {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        match super::email::get_message_body_html(&c, &message_id) {
+            Ok(Some(body)) => return Ok(Some(body)),
+            Ok(None) => {} // exists but body not yet fetched
+            Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+            Err(e) => return Err(e.to_string()),
+        }
+    }
+
+    // Look up origin (connector_id, external_id).
+    let origin = {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        super::email::get_message_origin(&c, &message_id).map_err(|e| e.to_string())?
+    };
+    let (connector_id, external_id) = match origin {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    // Fetch via Graph.
+    let kind = connector_id
+        .split_once(':')
+        .map(|(k, _)| k.to_string())
+        .unwrap_or_else(|| "microsoft_graph".to_string());
+    let body = oauth::with_valid_token(&app, &connector_id, &kind, |access| async move {
+        super::microsoft_graph::fetch_message_body(&access, &external_id).await
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    if let Some(ref html) = body {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        if let Err(e) = super::email::set_message_body_html(&c, &message_id, html) {
+            eprintln!("[connectors] persist email body failed for {message_id}: {e}");
+        }
+    }
+    Ok(body)
+}
+
 /// Minimal YAML string escape — sufficient for IDs / locations the
 /// connector hands us. If the value contains any special chars
 /// (colon, quotes, newline, leading/trailing whitespace) we wrap it

--- a/src-tauri/src/connectors/email.rs
+++ b/src-tauri/src/connectors/email.rs
@@ -1,0 +1,603 @@
+//! Provider-agnostic email storage layer (#69).
+//!
+//! Mirrors `connectors/calendar.rs`. The `microsoft_graph` connector
+//! (and any future provider — Gmail, IMAP, …) maps its provider-specific
+//! JSON onto `EmailMessage` and calls `upsert_messages` to persist into
+//! the shared `email_messages` / `email_recipients` tables.
+//!
+//! Unlike the calendar layer, this layer is **count-based / accumulate-only**:
+//! we don't define a sliding time window, so we don't delete orphans.
+//! Old messages stay in the DB until an explicit retention policy is
+//! introduced. Rationale: the workstream synthesizer (#70) may surface
+//! a thread that started months ago, and we don't want to keep
+//! re-fetching its lead.
+//!
+//! Bodies (`body_html`) are NOT populated at sync time — too expensive
+//! at 200 messages/sync. They're lazy-fetched via `get_email_body`
+//! Tauri command, persisted, and preserved across re-syncs via
+//! `COALESCE(excluded.body_html, email_messages.body_html)` on UPSERT.
+
+use rusqlite::{params, Connection};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EmailMessage {
+    pub id: String,
+    pub connector_id: String,
+    pub external_id: String,
+    pub thread_id: String,
+    pub subject: String,
+    pub from_email: String,
+    pub from_name: Option<String>,
+    pub sent_at_ms: i64,
+    pub body_preview: Option<String>,
+    /// Full HTML body. Always `None` from the connector's sync path —
+    /// populated lazily via `get_email_body`. `set_message_body_html`
+    /// is the only writer.
+    pub body_html: Option<String>,
+    pub has_attachments: bool,
+    pub is_read: bool,
+    pub raw_etag: Option<String>,
+    pub modified_ms: i64,
+    pub recipients: Vec<EmailRecipient>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EmailRecipient {
+    pub email: String,
+    pub display_name: Option<String>,
+    /// "to" | "cc" | "bcc"
+    pub recipient_type: String,
+    pub team_member_id: Option<String>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UpsertReport {
+    pub added: u64,
+    pub updated: u64,
+    pub skipped: u64,
+}
+
+/// Insert or update each message + replace its recipient set, in one
+/// transaction. Returns counts: `added` = new rows, `updated` = existing
+/// rows refreshed, `skipped` = rows we couldn't store (e.g. lacking a
+/// `from_email`; the connector layer is responsible for filtering those
+/// before calling — this is a defensive count).
+///
+/// `body_html` is preserved across upserts via `COALESCE` so a re-sync
+/// (which doesn't carry body) doesn't clobber a body the user already
+/// triggered a lazy fetch for.
+pub fn upsert_messages(
+    conn: &mut Connection,
+    connector_id: &str,
+    messages: &[EmailMessage],
+) -> rusqlite::Result<UpsertReport> {
+    let tx = conn.transaction()?;
+
+    let mut report = UpsertReport::default();
+    for msg in messages {
+        if msg.from_email.is_empty() {
+            report.skipped += 1;
+            continue;
+        }
+        let pre_existed: i64 = tx
+            .query_row(
+                "SELECT 1 FROM email_messages WHERE id = ?1",
+                params![msg.id],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        upsert_message(&tx, connector_id, msg)?;
+        if pre_existed != 0 {
+            report.updated += 1;
+        } else {
+            report.added += 1;
+        }
+    }
+
+    tx.commit()?;
+    Ok(report)
+}
+
+fn upsert_message(
+    tx: &rusqlite::Transaction<'_>,
+    _connector_id: &str,
+    m: &EmailMessage,
+) -> rusqlite::Result<()> {
+    // ON CONFLICT(id): refresh metadata, but NOT body_html — preserve
+    // any value populated by the lazy-fetch path. `excluded.body_html`
+    // is always NULL on the sync path, so COALESCE keeps the existing
+    // value. If a future caller does pass a body, COALESCE prefers the
+    // new (non-null) one — same shape as a normal upsert.
+    tx.execute(
+        "INSERT INTO email_messages(\
+            id, connector_id, external_id, thread_id, subject, from_email, from_name, \
+            sent_at_ms, body_preview, body_html, has_attachments, is_read, raw_etag, modified_ms\
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14) \
+         ON CONFLICT(id) DO UPDATE SET \
+            thread_id = excluded.thread_id, \
+            subject = excluded.subject, \
+            from_email = excluded.from_email, \
+            from_name = excluded.from_name, \
+            sent_at_ms = excluded.sent_at_ms, \
+            body_preview = excluded.body_preview, \
+            body_html = COALESCE(excluded.body_html, email_messages.body_html), \
+            has_attachments = excluded.has_attachments, \
+            is_read = excluded.is_read, \
+            raw_etag = excluded.raw_etag, \
+            modified_ms = excluded.modified_ms",
+        params![
+            m.id,
+            m.connector_id,
+            m.external_id,
+            m.thread_id,
+            m.subject,
+            m.from_email,
+            m.from_name,
+            m.sent_at_ms,
+            m.body_preview,
+            m.body_html,
+            m.has_attachments as i64,
+            m.is_read as i64,
+            m.raw_etag,
+            m.modified_ms,
+        ],
+    )?;
+
+    // Recipients: replace wholesale. Same pattern as calendar attendees.
+    tx.execute(
+        "DELETE FROM email_recipients WHERE message_id = ?1",
+        params![m.id],
+    )?;
+    let mut stmt = tx.prepare_cached(
+        "INSERT OR IGNORE INTO email_recipients(\
+            message_id, email, display_name, recipient_type, team_member_id\
+         ) VALUES (?1, ?2, ?3, ?4, ?5)",
+    )?;
+    for r in &m.recipients {
+        if r.email.is_empty() {
+            continue;
+        }
+        stmt.execute(params![
+            m.id,
+            r.email,
+            r.display_name,
+            r.recipient_type,
+            r.team_member_id,
+        ])?;
+    }
+    Ok(())
+}
+
+/// Most-recent-first listing of messages whose `sent_at_ms` falls in
+/// `[sent_from_ms, sent_to_ms]`. Optional connector filter. Limited
+/// to `limit` rows.
+pub fn list_messages_in_range(
+    conn: &Connection,
+    sent_from_ms: i64,
+    sent_to_ms: i64,
+    connector_id: Option<&str>,
+    limit: usize,
+) -> rusqlite::Result<Vec<EmailMessage>> {
+    let sql = match connector_id {
+        Some(_) => {
+            "SELECT id, connector_id, external_id, thread_id, subject, from_email, from_name, \
+                    sent_at_ms, body_preview, body_html, has_attachments, is_read, raw_etag, modified_ms \
+             FROM email_messages \
+             WHERE sent_at_ms BETWEEN ?1 AND ?2 AND connector_id = ?3 \
+             ORDER BY sent_at_ms DESC \
+             LIMIT ?4"
+        }
+        None => {
+            "SELECT id, connector_id, external_id, thread_id, subject, from_email, from_name, \
+                    sent_at_ms, body_preview, body_html, has_attachments, is_read, raw_etag, modified_ms \
+             FROM email_messages \
+             WHERE sent_at_ms BETWEEN ?1 AND ?2 \
+             ORDER BY sent_at_ms DESC \
+             LIMIT ?3"
+        }
+    };
+    let mut stmt = conn.prepare(sql)?;
+    let mut messages: Vec<EmailMessage> = match connector_id {
+        Some(id) => {
+            let rows = stmt.query_map(params![sent_from_ms, sent_to_ms, id, limit as i64], row_to_message)?;
+            rows.collect::<Result<Vec<_>, _>>()?
+        }
+        None => {
+            let rows = stmt.query_map(params![sent_from_ms, sent_to_ms, limit as i64], row_to_message)?;
+            rows.collect::<Result<Vec<_>, _>>()?
+        }
+    };
+    attach_recipients(conn, &mut messages)?;
+    Ok(messages)
+}
+
+/// All messages in a thread, oldest-first (so the UI can render the
+/// conversation top-down).
+pub fn list_messages_by_thread(
+    conn: &Connection,
+    thread_id: &str,
+) -> rusqlite::Result<Vec<EmailMessage>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, connector_id, external_id, thread_id, subject, from_email, from_name, \
+                sent_at_ms, body_preview, body_html, has_attachments, is_read, raw_etag, modified_ms \
+         FROM email_messages \
+         WHERE thread_id = ?1 \
+         ORDER BY sent_at_ms ASC",
+    )?;
+    let rows = stmt.query_map(params![thread_id], row_to_message)?;
+    let mut messages: Vec<EmailMessage> = rows.collect::<Result<Vec<_>, _>>()?;
+    attach_recipients(conn, &mut messages)?;
+    Ok(messages)
+}
+
+pub fn get_message_details(
+    conn: &Connection,
+    message_id: &str,
+) -> rusqlite::Result<Option<EmailMessage>> {
+    use rusqlite::OptionalExtension;
+    let mut stmt = conn.prepare(
+        "SELECT id, connector_id, external_id, thread_id, subject, from_email, from_name, \
+                sent_at_ms, body_preview, body_html, has_attachments, is_read, raw_etag, modified_ms \
+         FROM email_messages WHERE id = ?1",
+    )?;
+    let mut msg = stmt
+        .query_row(params![message_id], row_to_message)
+        .optional()?;
+    if let Some(ref mut m) = msg {
+        let mut as_slice = vec![std::mem::take(m)];
+        attach_recipients(conn, &mut as_slice)?;
+        *m = as_slice.pop().unwrap();
+    }
+    Ok(msg)
+}
+
+pub fn get_message_body_html(
+    conn: &Connection,
+    message_id: &str,
+) -> rusqlite::Result<Option<String>> {
+    conn.query_row(
+        "SELECT body_html FROM email_messages WHERE id = ?1",
+        params![message_id],
+        |r| r.get::<_, Option<String>>(0),
+    )
+    .map_err(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => rusqlite::Error::QueryReturnedNoRows,
+        other => other,
+    })
+}
+
+pub fn set_message_body_html(
+    conn: &Connection,
+    message_id: &str,
+    body_html: &str,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE email_messages SET body_html = ?1 WHERE id = ?2",
+        params![body_html, message_id],
+    )?;
+    Ok(())
+}
+
+/// Fetch `(connector_id, external_id)` for a message. Used by
+/// `get_email_body` to locate the upstream record before issuing the
+/// lazy Graph fetch.
+pub fn get_message_origin(
+    conn: &Connection,
+    message_id: &str,
+) -> rusqlite::Result<Option<(String, String)>> {
+    use rusqlite::OptionalExtension;
+    let mut stmt = conn.prepare(
+        "SELECT connector_id, external_id FROM email_messages WHERE id = ?1",
+    )?;
+    stmt.query_row(params![message_id], |r| {
+        Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+    })
+    .optional()
+}
+
+// ----- Internal helpers ----------------------------------------------------
+
+fn row_to_message(r: &rusqlite::Row<'_>) -> rusqlite::Result<EmailMessage> {
+    Ok(EmailMessage {
+        id: r.get(0)?,
+        connector_id: r.get(1)?,
+        external_id: r.get(2)?,
+        thread_id: r.get(3)?,
+        subject: r.get(4)?,
+        from_email: r.get(5)?,
+        from_name: r.get(6)?,
+        sent_at_ms: r.get(7)?,
+        body_preview: r.get(8)?,
+        body_html: r.get(9)?,
+        has_attachments: r.get::<_, i64>(10)? != 0,
+        is_read: r.get::<_, i64>(11)? != 0,
+        raw_etag: r.get(12)?,
+        modified_ms: r.get(13)?,
+        recipients: Vec::new(),
+    })
+}
+
+impl Default for EmailMessage {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            connector_id: String::new(),
+            external_id: String::new(),
+            thread_id: String::new(),
+            subject: String::new(),
+            from_email: String::new(),
+            from_name: None,
+            sent_at_ms: 0,
+            body_preview: None,
+            body_html: None,
+            has_attachments: false,
+            is_read: false,
+            raw_etag: None,
+            modified_ms: 0,
+            recipients: Vec::new(),
+        }
+    }
+}
+
+fn attach_recipients(
+    conn: &Connection,
+    messages: &mut [EmailMessage],
+) -> rusqlite::Result<()> {
+    if messages.is_empty() {
+        return Ok(());
+    }
+    let placeholders = std::iter::repeat("?")
+        .take(messages.len())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "SELECT message_id, email, display_name, recipient_type, team_member_id \
+         FROM email_recipients WHERE message_id IN ({placeholders}) \
+         ORDER BY message_id, recipient_type, email"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let id_refs: Vec<&dyn rusqlite::ToSql> = messages
+        .iter()
+        .map(|m| &m.id as &dyn rusqlite::ToSql)
+        .collect();
+    let rows = stmt.query_map(rusqlite::params_from_iter(id_refs), |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            EmailRecipient {
+                email: r.get(1)?,
+                display_name: r.get(2)?,
+                recipient_type: r.get(3)?,
+                team_member_id: r.get(4)?,
+            },
+        ))
+    })?;
+    let mut by_id: std::collections::HashMap<String, Vec<EmailRecipient>> =
+        std::collections::HashMap::new();
+    for row in rows {
+        let (mid, rec) = row?;
+        by_id.entry(mid).or_default().push(rec);
+    }
+    for m in messages.iter_mut() {
+        if let Some(recs) = by_id.remove(&m.id) {
+            m.recipients = recs;
+        }
+    }
+    Ok(())
+}
+
+// ----- Tests ---------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_test_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "PRAGMA foreign_keys = ON;
+             CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO meta(key, value) VALUES ('schema_version', '10');
+             CREATE TABLE team_members (id TEXT PRIMARY KEY);
+             CREATE TABLE connectors (id TEXT PRIMARY KEY);
+             INSERT INTO connectors(id) VALUES ('mg:test');
+             INSERT INTO team_members(id) VALUES ('tm:heike');",
+        )
+        .unwrap();
+        conn.execute_batch(include_str!("../migrations/011_email.sql"))
+            .unwrap();
+        conn
+    }
+
+    fn make_msg(
+        external_id: &str,
+        thread_id: &str,
+        sent_at_ms: i64,
+        recipients: Vec<EmailRecipient>,
+    ) -> EmailMessage {
+        EmailMessage {
+            id: format!("mg:test::{external_id}"),
+            connector_id: "mg:test".to_string(),
+            external_id: external_id.to_string(),
+            thread_id: thread_id.to_string(),
+            subject: format!("Subject {external_id}"),
+            from_email: "alice@example.com".to_string(),
+            from_name: Some("Alice".to_string()),
+            sent_at_ms,
+            body_preview: Some("preview".to_string()),
+            body_html: None,
+            has_attachments: false,
+            is_read: false,
+            raw_etag: None,
+            modified_ms: sent_at_ms,
+            recipients,
+        }
+    }
+
+    fn rcpt(email: &str, kind: &str, team_member_id: Option<&str>) -> EmailRecipient {
+        EmailRecipient {
+            email: email.to_string(),
+            display_name: None,
+            recipient_type: kind.to_string(),
+            team_member_id: team_member_id.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn upsert_messages_inserts_new_and_updates_existing() {
+        let mut conn = open_test_db();
+
+        let first = vec![
+            make_msg("a", "thread-1", 1_000, vec![rcpt("tj@e.com", "to", None)]),
+            make_msg("b", "thread-1", 2_000, vec![]),
+        ];
+        let r1 = upsert_messages(&mut conn, "mg:test", &first).unwrap();
+        assert_eq!(r1.added, 2);
+        assert_eq!(r1.updated, 0);
+
+        // Re-sync with updated subject on `a` and a new `c`.
+        let mut a_updated = make_msg("a", "thread-1", 1_000, vec![rcpt("tj@e.com", "to", None)]);
+        a_updated.subject = "Subject a (renamed)".to_string();
+        let second = vec![
+            a_updated,
+            make_msg("c", "thread-2", 3_000, vec![]),
+        ];
+        let r2 = upsert_messages(&mut conn, "mg:test", &second).unwrap();
+        assert_eq!(r2.added, 1, "c is new");
+        assert_eq!(r2.updated, 1, "a existed");
+
+        // Verify final row state — `b` survived (no orphan deletion).
+        let all = list_messages_in_range(&conn, 0, 100_000, Some("mg:test"), 100).unwrap();
+        assert_eq!(all.len(), 3);
+
+        let titles: Vec<&str> = all.iter().map(|m| m.subject.as_str()).collect();
+        // Most-recent-first: c (3000), b (2000), a (1000).
+        assert_eq!(titles, vec!["Subject c", "Subject b", "Subject a (renamed)"]);
+    }
+
+    #[test]
+    fn upsert_messages_preserves_body_html_across_resync() {
+        let mut conn = open_test_db();
+        let first = vec![make_msg("a", "thread-1", 1_000, vec![])];
+        upsert_messages(&mut conn, "mg:test", &first).unwrap();
+
+        // Lazy fetch populates body_html.
+        set_message_body_html(&conn, "mg:test::a", "<p>hello</p>").unwrap();
+        let body = get_message_body_html(&conn, "mg:test::a").unwrap();
+        assert_eq!(body.as_deref(), Some("<p>hello</p>"));
+
+        // Re-sync with an updated subject but body_html: None (the
+        // connector path never carries body).
+        let mut a_again = make_msg("a", "thread-1", 1_000, vec![]);
+        a_again.subject = "New subject".to_string();
+        a_again.body_html = None;
+        upsert_messages(&mut conn, "mg:test", &[a_again]).unwrap();
+
+        // Body must survive.
+        let body = get_message_body_html(&conn, "mg:test::a").unwrap();
+        assert_eq!(
+            body.as_deref(),
+            Some("<p>hello</p>"),
+            "body_html must be preserved across a re-sync that doesn't carry it"
+        );
+        // But subject was updated.
+        let m = get_message_details(&conn, "mg:test::a").unwrap().unwrap();
+        assert_eq!(m.subject, "New subject");
+    }
+
+    #[test]
+    fn list_messages_by_thread_orders_by_sent_at_asc() {
+        let mut conn = open_test_db();
+        let msgs = vec![
+            make_msg("c", "thread-1", 3_000, vec![]),
+            make_msg("a", "thread-1", 1_000, vec![]),
+            make_msg("b", "thread-1", 2_000, vec![]),
+            make_msg("z", "thread-2", 5_000, vec![]),
+        ];
+        upsert_messages(&mut conn, "mg:test", &msgs).unwrap();
+
+        let thread1 = list_messages_by_thread(&conn, "thread-1").unwrap();
+        let ids: Vec<&str> = thread1.iter().map(|m| m.external_id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn get_message_details_returns_none_for_missing() {
+        let conn = open_test_db();
+        let result = get_message_details(&conn, "nope").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn recipients_are_replaced_wholesale_on_resync() {
+        let mut conn = open_test_db();
+        let first = vec![make_msg(
+            "a",
+            "thread-1",
+            1_000,
+            vec![
+                rcpt("tj@e.com", "to", None),
+                rcpt("bob@e.com", "cc", None),
+            ],
+        )];
+        upsert_messages(&mut conn, "mg:test", &first).unwrap();
+
+        // Re-sync with different recipient set.
+        let second = vec![make_msg(
+            "a",
+            "thread-1",
+            1_000,
+            vec![rcpt("alice@e.com", "to", Some("tm:heike"))],
+        )];
+        upsert_messages(&mut conn, "mg:test", &second).unwrap();
+
+        let m = get_message_details(&conn, "mg:test::a").unwrap().unwrap();
+        assert_eq!(m.recipients.len(), 1);
+        assert_eq!(m.recipients[0].email, "alice@e.com");
+        assert_eq!(m.recipients[0].team_member_id.as_deref(), Some("tm:heike"));
+    }
+
+    #[test]
+    fn upsert_skips_messages_with_empty_from_email() {
+        let mut conn = open_test_db();
+        let mut bad = make_msg("bad", "thread-x", 1_000, vec![]);
+        bad.from_email = String::new();
+        let report = upsert_messages(&mut conn, "mg:test", &[bad]).unwrap();
+        assert_eq!(report.added, 0);
+        assert_eq!(report.skipped, 1);
+
+        let all = list_messages_in_range(&conn, 0, 100_000, Some("mg:test"), 100).unwrap();
+        assert_eq!(all.len(), 0);
+    }
+
+    #[test]
+    fn list_messages_in_range_filters_by_connector() {
+        let mut conn = open_test_db();
+        conn.execute("INSERT INTO connectors(id) VALUES ('gm:test')", [])
+            .unwrap();
+
+        upsert_messages(&mut conn, "mg:test", &[make_msg("a", "t-1", 1_000, vec![])]).unwrap();
+        let mut other = make_msg("b", "t-2", 2_000, vec![]);
+        other.id = "gm:test::b".into();
+        other.connector_id = "gm:test".into();
+        upsert_messages(&mut conn, "gm:test", &[other]).unwrap();
+
+        let mg = list_messages_in_range(&conn, 0, 100_000, Some("mg:test"), 10).unwrap();
+        assert_eq!(mg.len(), 1);
+        assert_eq!(mg[0].connector_id, "mg:test");
+        let all = list_messages_in_range(&conn, 0, 100_000, None, 10).unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn get_message_origin_returns_connector_and_external_id() {
+        let mut conn = open_test_db();
+        upsert_messages(&mut conn, "mg:test", &[make_msg("ext-1", "t", 1_000, vec![])]).unwrap();
+
+        let origin = get_message_origin(&conn, "mg:test::ext-1").unwrap().unwrap();
+        assert_eq!(origin, ("mg:test".into(), "ext-1".into()));
+
+        let none = get_message_origin(&conn, "mg:test::missing").unwrap();
+        assert!(none.is_none());
+    }
+}

--- a/src-tauri/src/connectors/microsoft_graph.rs
+++ b/src-tauri/src/connectors/microsoft_graph.rs
@@ -19,6 +19,7 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 use super::calendar::{CalendarAttendee, CalendarEvent};
+use super::email::{EmailMessage, EmailRecipient};
 use super::oauth::with_valid_token;
 use super::registry::ConnectorRegistry;
 use super::{Connector, ConnectorError, ConnectorRow, SyncCtx, SyncReport};
@@ -28,6 +29,12 @@ const POLL_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const WINDOW_BACK_MS: i64 = 14 * 24 * 3600 * 1000;
 const WINDOW_FORWARD_MS: i64 = 30 * 24 * 3600 * 1000;
 const PAGE_SIZE: u32 = 100;
+
+/// Mail ingestion: 200 most recent inbox messages per sync. 4 pages
+/// of 50 each — Graph caps `$top` at 1000 but smaller pages mean
+/// faster first-byte latency and tolerable memory at peak.
+const MAIL_PAGE_SIZE: u32 = 50;
+const MAIL_MAX_PAGES: usize = 4;
 
 const KIND: &str = "microsoft_graph";
 
@@ -73,14 +80,8 @@ impl Connector for MicrosoftGraphConnector {
         let window_start = now - WINDOW_BACK_MS;
         let window_end = now + WINDOW_FORWARD_MS;
 
-        // Fetch all events via /me/calendarView, paginated.
-        let raw_events = with_valid_token(ctx.app, &self.id, &self.kind, |access| async move {
-            fetch_calendar_view(&access, window_start, window_end).await
-        })
-        .await?;
-
-        // Snapshot team members for attendee resolution. Keep the
-        // lock window short — release before mapping.
+        // Snapshot team members once for both calendar and mail. Keep
+        // the lock window short — release before any network I/O.
         let team = {
             let conn = ctx
                 .conn
@@ -91,13 +92,18 @@ impl Connector for MicrosoftGraphConnector {
         let resolver = AttendeeResolver::new(&team);
         let self_email = self.self_email();
 
+        // ---- Calendar half ------------------------------------------------
+        let raw_events = with_valid_token(ctx.app, &self.id, &self.kind, |access| async move {
+            fetch_calendar_view(&access, window_start, window_end).await
+        })
+        .await?;
+
         let events: Vec<CalendarEvent> = raw_events
             .into_iter()
             .map(|raw| map_event(&self.id, raw, &resolver, self_email))
             .collect();
 
-        // Upsert in one transaction.
-        let report = {
+        let calendar_report = {
             let mut conn = ctx
                 .conn
                 .lock()
@@ -106,13 +112,88 @@ impl Connector for MicrosoftGraphConnector {
                 .map_err(|e| ConnectorError::Other(format!("upsert events: {e}")))?
         };
 
+        // ---- Mail half ----------------------------------------------------
+        // Calendar succeeded; if mail fails, log + skip rather than
+        // dropping the calendar half. This keeps the more visible
+        // "Coming up" UI healthy when, say, Mail.Read consent is
+        // outstanding but Calendars.Read still works.
+        let mail_report = match self.sync_mail(&ctx, &resolver).await {
+            Ok(report) => report,
+            Err(e) => {
+                eprintln!("[microsoft_graph] mail sync failed: {e}");
+                super::email::UpsertReport::default()
+            }
+        };
+
         Ok(SyncReport {
-            added: report.added,
-            updated: report.updated,
-            removed: report.removed,
-            skipped: 0,
+            added: calendar_report.added + mail_report.added,
+            updated: calendar_report.updated + mail_report.updated,
+            removed: calendar_report.removed,
+            skipped: mail_report.skipped,
         })
     }
+}
+
+impl MicrosoftGraphConnector {
+    async fn sync_mail(
+        &self,
+        ctx: &SyncCtx<'_>,
+        resolver: &AttendeeResolver<'_>,
+    ) -> Result<super::email::UpsertReport, ConnectorError> {
+        let raw_messages =
+            with_valid_token(ctx.app, &self.id, &self.kind, |access| async move {
+                fetch_inbox_messages(&access).await
+            })
+            .await?;
+
+        let messages: Vec<EmailMessage> = raw_messages
+            .into_iter()
+            .filter_map(|raw| map_message(&self.id, raw, resolver))
+            .collect();
+
+        let report = {
+            let mut conn = ctx
+                .conn
+                .lock()
+                .map_err(|e| ConnectorError::Other(format!("conn lock: {e}")))?;
+            super::email::upsert_messages(&mut conn, &self.id, &messages)
+                .map_err(|e| ConnectorError::Other(format!("upsert messages: {e}")))?
+        };
+        Ok(report)
+    }
+}
+
+/// Lazy-fetch a single message body via Graph. Public so the
+/// `get_email_body` Tauri command can call it.
+pub async fn fetch_message_body(
+    access_token: &str,
+    external_id: &str,
+) -> Result<Option<String>, ConnectorError> {
+    let client = reqwest::Client::builder()
+        .build()
+        .map_err(|e| ConnectorError::Network(format!("client init: {e}")))?;
+    // URL-encode the external id (Graph IDs contain `=`/`/`/`+`).
+    let encoded = percent_encode_path(external_id);
+    let url = format!(
+        "https://graph.microsoft.com/v1.0/me/messages/{encoded}?$select=body"
+    );
+    let resp = client
+        .get(&url)
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .map_err(|e| ConnectorError::Network(format!("graph GET body: {e}")))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let retry_after = parse_retry_after(resp.headers());
+        let body = resp.text().await.unwrap_or_default();
+        return Err(map_status(status, retry_after, body));
+    }
+    let parsed: RawMessageBody = resp
+        .json()
+        .await
+        .map_err(|e| ConnectorError::Other(format!("graph body parse: {e}")))?;
+    Ok(parsed.body.and_then(|b| b.content))
 }
 
 /// Plug the factory into the registry. Called once at app boot from
@@ -380,6 +461,214 @@ pub(crate) fn map_event(
     }
 }
 
+// ----- Mail: API client + JSON shape + mapping ----------------------------
+
+async fn fetch_inbox_messages(access_token: &str) -> Result<Vec<RawMessage>, ConnectorError> {
+    let client = reqwest::Client::builder()
+        .build()
+        .map_err(|e| ConnectorError::Network(format!("client init: {e}")))?;
+
+    let mut url = format!(
+        "https://graph.microsoft.com/v1.0/me/mailFolders/inbox/messages\
+         ?$top={MAIL_PAGE_SIZE}\
+         &$orderby=sentDateTime%20desc\
+         &$select=id,conversationId,subject,from,toRecipients,ccRecipients,bccRecipients,bodyPreview,sentDateTime,hasAttachments,isRead,lastModifiedDateTime"
+    );
+
+    let mut all: Vec<RawMessage> = Vec::new();
+    let mut pages = 0usize;
+
+    loop {
+        let resp = client
+            .get(&url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|e| ConnectorError::Network(format!("graph GET inbox: {e}")))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let retry_after = parse_retry_after(resp.headers());
+            let body = resp.text().await.unwrap_or_default();
+            return Err(map_status(status, retry_after, body));
+        }
+
+        let page: GraphMessagePage = resp
+            .json()
+            .await
+            .map_err(|e| ConnectorError::Other(format!("graph mail parse: {e}")))?;
+        all.extend(page.value);
+
+        pages += 1;
+        if pages >= MAIL_MAX_PAGES {
+            break;
+        }
+        match page.next_link {
+            Some(next) if !next.is_empty() => url = next,
+            _ => break,
+        }
+    }
+
+    Ok(all)
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphMessagePage {
+    value: Vec<RawMessage>,
+    #[serde(rename = "@odata.nextLink")]
+    next_link: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct RawMessage {
+    pub(crate) id: String,
+    #[serde(rename = "conversationId", default)]
+    pub(crate) conversation_id: Option<String>,
+    #[serde(default)]
+    pub(crate) subject: Option<String>,
+    #[serde(default)]
+    pub(crate) from: Option<RawRecipientWrapper>,
+    #[serde(rename = "toRecipients", default)]
+    pub(crate) to_recipients: Vec<RawRecipientWrapper>,
+    #[serde(rename = "ccRecipients", default)]
+    pub(crate) cc_recipients: Vec<RawRecipientWrapper>,
+    #[serde(rename = "bccRecipients", default)]
+    pub(crate) bcc_recipients: Vec<RawRecipientWrapper>,
+    #[serde(rename = "bodyPreview", default)]
+    pub(crate) body_preview: Option<String>,
+    #[serde(rename = "sentDateTime", default)]
+    pub(crate) sent_date_time: Option<String>,
+    #[serde(rename = "hasAttachments", default)]
+    pub(crate) has_attachments: bool,
+    #[serde(rename = "isRead", default)]
+    pub(crate) is_read: bool,
+    #[serde(rename = "lastModifiedDateTime", default)]
+    pub(crate) last_modified: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct RawRecipientWrapper {
+    #[serde(rename = "emailAddress", default)]
+    pub(crate) email_address: Option<RawEmailAddress>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMessageBody {
+    body: Option<RawBody>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawBody {
+    content: Option<String>,
+}
+
+/// Map a Graph message into the provider-agnostic `EmailMessage`.
+/// Returns `None` for messages we can't represent (no `from`, no
+/// sentDateTime — system-generated noise we'd otherwise persist with
+/// blank fields and a 1970 timestamp).
+pub(crate) fn map_message(
+    connector_id: &str,
+    raw: RawMessage,
+    resolver: &AttendeeResolver<'_>,
+) -> Option<EmailMessage> {
+    let from_addr = raw
+        .from
+        .as_ref()
+        .and_then(|w| w.email_address.as_ref())
+        .and_then(|a| a.address.as_deref())
+        .filter(|s| !s.is_empty())?;
+    let from_email = from_addr.to_lowercase();
+    let from_name = raw
+        .from
+        .as_ref()
+        .and_then(|w| w.email_address.as_ref())
+        .and_then(|a| a.name.clone());
+
+    let subject = match raw.subject {
+        Some(s) if !s.trim().is_empty() => s,
+        _ => "(no subject)".to_string(),
+    };
+
+    let sent_at_ms = raw
+        .sent_date_time
+        .as_deref()
+        .and_then(iso_to_ms)
+        .unwrap_or(0);
+    let modified_ms = raw
+        .last_modified
+        .as_deref()
+        .and_then(iso_to_ms)
+        .unwrap_or(sent_at_ms);
+
+    let thread_id = raw.conversation_id.unwrap_or_else(|| raw.id.clone());
+
+    let mut recipients: Vec<EmailRecipient> = Vec::new();
+    let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+
+    for (kind, list) in [
+        ("to", raw.to_recipients),
+        ("cc", raw.cc_recipients),
+        ("bcc", raw.bcc_recipients),
+    ] {
+        for r in list {
+            let addr = match r.email_address {
+                Some(a) => a,
+                None => continue,
+            };
+            let email = match addr.address {
+                Some(e) if !e.is_empty() => e.to_lowercase(),
+                _ => continue,
+            };
+            if !seen.insert((email.clone(), kind.to_string())) {
+                continue;
+            }
+            recipients.push(EmailRecipient {
+                team_member_id: resolver.resolve(&email, addr.name.as_deref()),
+                email,
+                display_name: addr.name,
+                recipient_type: kind.to_string(),
+            });
+        }
+    }
+
+    Some(EmailMessage {
+        id: format!("{connector_id}::{}", raw.id),
+        connector_id: connector_id.to_string(),
+        external_id: raw.id,
+        thread_id,
+        subject,
+        from_email,
+        from_name,
+        sent_at_ms,
+        body_preview: raw.body_preview.filter(|s| !s.is_empty()),
+        body_html: None,
+        has_attachments: raw.has_attachments,
+        is_read: raw.is_read,
+        raw_etag: None,
+        modified_ms,
+        recipients,
+    })
+}
+
+/// Percent-encode characters in a Microsoft Graph message ID for use
+/// as a URL path segment. Graph IDs use URL-safe Base64-ish strings
+/// that may include `=`, `/`, and `+`, none of which are valid
+/// unescaped in a path segment.
+fn percent_encode_path(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char);
+            }
+            _ => {
+                out.push_str(&format!("%{:02X}", b));
+            }
+        }
+    }
+    out
+}
+
 // ----- Attendee resolver -------------------------------------------------
 
 /// Resolve an attendee's `email` (and optional display name) to a
@@ -631,5 +920,142 @@ mod tests {
     fn attendee_resolver_no_match_returns_none() {
         let r = AttendeeResolver::new(&[]);
         assert!(r.resolve("nobody@nope.com", Some("Nobody")).is_none());
+    }
+
+    fn mk_recip(email: &str, name: Option<&str>) -> RawRecipientWrapper {
+        RawRecipientWrapper {
+            email_address: Some(RawEmailAddress {
+                address: Some(email.to_string()),
+                name: name.map(|s| s.to_string()),
+            }),
+        }
+    }
+
+    #[test]
+    fn map_message_basic() {
+        let raw = RawMessage {
+            id: "MSG1".into(),
+            conversation_id: Some("THREAD1".into()),
+            subject: Some("Roadmap review".into()),
+            from: Some(mk_recip("alice@Example.com", Some("Alice"))),
+            to_recipients: vec![mk_recip("tj@example.com", Some("TJ"))],
+            cc_recipients: vec![mk_recip("bob@example.com", Some("Bob"))],
+            bcc_recipients: vec![],
+            body_preview: Some("Let's align on…".into()),
+            sent_date_time: Some("2026-05-09T12:34:56Z".into()),
+            has_attachments: true,
+            is_read: false,
+            last_modified: Some("2026-05-09T12:35:00Z".into()),
+        };
+        let resolver = AttendeeResolver::new(&[]);
+        let m = map_message("microsoft_graph:tj@example.com", raw, &resolver).unwrap();
+
+        assert_eq!(m.id, "microsoft_graph:tj@example.com::MSG1");
+        assert_eq!(m.thread_id, "THREAD1");
+        assert_eq!(m.subject, "Roadmap review");
+        assert_eq!(m.from_email, "alice@example.com");
+        assert_eq!(m.from_name.as_deref(), Some("Alice"));
+        assert!(m.has_attachments);
+        assert!(!m.is_read);
+        assert_eq!(m.recipients.len(), 2);
+        assert_eq!(m.recipients[0].email, "tj@example.com");
+        assert_eq!(m.recipients[0].recipient_type, "to");
+        assert_eq!(m.recipients[1].email, "bob@example.com");
+        assert_eq!(m.recipients[1].recipient_type, "cc");
+    }
+
+    #[test]
+    fn map_message_no_recipients() {
+        let raw = RawMessage {
+            id: "MSG2".into(),
+            conversation_id: Some("THREAD2".into()),
+            subject: Some("Release notes".into()),
+            from: Some(mk_recip("notifications@github.com", None)),
+            to_recipients: vec![],
+            cc_recipients: vec![],
+            bcc_recipients: vec![],
+            body_preview: None,
+            sent_date_time: Some("2026-05-09T12:00:00Z".into()),
+            has_attachments: false,
+            is_read: true,
+            last_modified: None,
+        };
+        let resolver = AttendeeResolver::new(&[]);
+        let m = map_message("mg:tj", raw, &resolver).unwrap();
+        assert_eq!(m.recipients.len(), 0);
+        assert!(m.is_read);
+    }
+
+    #[test]
+    fn map_message_default_subject_when_missing() {
+        let raw = RawMessage {
+            id: "MSG3".into(),
+            conversation_id: None,
+            subject: Some("   ".into()),
+            from: Some(mk_recip("a@b.com", None)),
+            to_recipients: vec![],
+            cc_recipients: vec![],
+            bcc_recipients: vec![],
+            body_preview: None,
+            sent_date_time: None,
+            has_attachments: false,
+            is_read: false,
+            last_modified: None,
+        };
+        let resolver = AttendeeResolver::new(&[]);
+        let m = map_message("mg:x", raw, &resolver).unwrap();
+        assert_eq!(m.subject, "(no subject)");
+        // Falls back to message id when conversation_id missing.
+        assert_eq!(m.thread_id, "MSG3");
+    }
+
+    #[test]
+    fn map_message_returns_none_when_from_missing() {
+        let raw = RawMessage {
+            id: "MSG4".into(),
+            conversation_id: None,
+            subject: Some("???".into()),
+            from: None,
+            to_recipients: vec![],
+            cc_recipients: vec![],
+            bcc_recipients: vec![],
+            body_preview: None,
+            sent_date_time: None,
+            has_attachments: false,
+            is_read: false,
+            last_modified: None,
+        };
+        let resolver = AttendeeResolver::new(&[]);
+        assert!(map_message("mg:x", raw, &resolver).is_none());
+    }
+
+    #[test]
+    fn map_message_resolves_recipients_via_team() {
+        let members = [mk_member("hk1", "Heike Müller", &["heike@contoso.com"])];
+        let resolver = AttendeeResolver::new(&members);
+        let raw = RawMessage {
+            id: "MSG5".into(),
+            conversation_id: Some("THREAD5".into()),
+            subject: Some("Hi".into()),
+            from: Some(mk_recip("alice@e.com", None)),
+            to_recipients: vec![mk_recip("Heike@CONTOSO.com", Some("Heike"))],
+            cc_recipients: vec![],
+            bcc_recipients: vec![],
+            body_preview: None,
+            sent_date_time: Some("2026-05-09T12:00:00Z".into()),
+            has_attachments: false,
+            is_read: false,
+            last_modified: None,
+        };
+        let m = map_message("mg:tj", raw, &resolver).unwrap();
+        assert_eq!(m.recipients.len(), 1);
+        assert_eq!(m.recipients[0].email, "heike@contoso.com");
+        assert_eq!(m.recipients[0].team_member_id.as_deref(), Some("hk1"));
+    }
+
+    #[test]
+    fn percent_encode_path_handles_graph_id_chars() {
+        let encoded = percent_encode_path("AAMkA+/=foo");
+        assert_eq!(encoded, "AAMkA%2B%2F%3Dfoo");
     }
 }

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -27,6 +27,7 @@ use serde::Serialize;
 
 pub mod calendar;
 pub mod commands;
+pub mod email;
 pub mod microsoft_graph;
 pub mod oauth;
 pub mod providers;

--- a/src-tauri/src/connectors/providers.rs
+++ b/src-tauri/src/connectors/providers.rs
@@ -42,10 +42,10 @@ pub const PROVIDERS: &[OAuthProvider] = &[
     },
     OAuthProvider {
         kind: "microsoft_graph",
-        display_name: "Microsoft Calendar",
+        display_name: "Microsoft",
         auth_url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
         token_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-        scopes: &["Calendars.Read", "User.Read", "offline_access"],
+        scopes: &["Calendars.Read", "Mail.Read", "User.Read", "offline_access"],
         client_id: option_env!("MARGIN_MICROSOFT_CLIENT_ID"),
     },
 ];

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -41,7 +41,8 @@ const SCHEMA_V7: &str = include_str!("migrations/007_action_owners.sql");
 const SCHEMA_V8: &str = include_str!("migrations/008_connectors.sql");
 const SCHEMA_V9: &str = include_str!("migrations/009_calendar.sql");
 const SCHEMA_V10: &str = include_str!("migrations/010_event_note_link.sql");
-const SCHEMA_VERSION: i64 = 10;
+const SCHEMA_V11: &str = include_str!("migrations/011_email.sql");
+const SCHEMA_VERSION: i64 = 11;
 
 /// Open the index DB at `db_path` (creating it if absent) and apply any
 /// pending migrations.
@@ -123,6 +124,10 @@ fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 9 {
         conn.execute_batch(SCHEMA_V10)?;
         version = 10;
+    }
+    if version == 10 {
+        conn.execute_batch(SCHEMA_V11)?;
+        version = 11;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -668,7 +668,9 @@ pub fn run() {
             connectors::commands::delete_connector,
             connectors::commands::list_calendar_events,
             connectors::commands::get_event_details,
-            connectors::commands::open_or_create_event_note
+            connectors::commands::open_or_create_event_note,
+            connectors::commands::list_email_messages,
+            connectors::commands::get_email_body
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/migrations/011_email.sql
+++ b/src-tauri/src/migrations/011_email.sql
@@ -1,0 +1,34 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE email_messages (
+  id              TEXT PRIMARY KEY,
+  connector_id    TEXT NOT NULL REFERENCES connectors(id) ON DELETE CASCADE,
+  external_id     TEXT NOT NULL,
+  thread_id       TEXT NOT NULL,
+  subject         TEXT NOT NULL,
+  from_email      TEXT NOT NULL,
+  from_name       TEXT,
+  sent_at_ms      INTEGER NOT NULL,
+  body_preview    TEXT,
+  body_html       TEXT,
+  has_attachments INTEGER NOT NULL DEFAULT 0,
+  is_read         INTEGER NOT NULL DEFAULT 0,
+  raw_etag        TEXT,
+  modified_ms     INTEGER NOT NULL
+);
+CREATE INDEX idx_email_thread ON email_messages(thread_id);
+CREATE INDEX idx_email_sent ON email_messages(sent_at_ms);
+CREATE INDEX idx_email_connector ON email_messages(connector_id);
+CREATE UNIQUE INDEX idx_email_extid ON email_messages(connector_id, external_id);
+
+CREATE TABLE email_recipients (
+  message_id     TEXT NOT NULL REFERENCES email_messages(id) ON DELETE CASCADE,
+  email          TEXT NOT NULL,
+  display_name   TEXT,
+  recipient_type TEXT NOT NULL,
+  team_member_id TEXT REFERENCES team_members(id) ON DELETE SET NULL,
+  PRIMARY KEY (message_id, email, recipient_type)
+);
+CREATE INDEX idx_email_recip_team ON email_recipients(team_member_id);
+
+UPDATE meta SET value = '11' WHERE key = 'schema_version';

--- a/src/file.ts
+++ b/src/file.ts
@@ -423,6 +423,67 @@ export async function openOrCreateEventNote(eventId: string): Promise<string> {
   return invoke<string>("open_or_create_event_note", { eventId });
 }
 
+// ----- Email (#69) ---------------------------------------------------------
+
+export type EmailRecipient = {
+  email: string;
+  display_name: string | null;
+  /** "to" | "cc" | "bcc" */
+  recipient_type: string;
+  team_member_id: string | null;
+};
+
+export type EmailMessage = {
+  id: string;
+  connector_id: string;
+  external_id: string;
+  thread_id: string;
+  subject: string;
+  from_email: string;
+  from_name: string | null;
+  sent_at_ms: number;
+  body_preview: string | null;
+  /** Full HTML body. Null until lazy-fetched via `getEmailBody`. */
+  body_html: string | null;
+  has_attachments: boolean;
+  is_read: boolean;
+  raw_etag: string | null;
+  modified_ms: number;
+  recipients: EmailRecipient[];
+};
+
+export type ListEmailMessagesParams = {
+  /** When set, returns the full thread (oldest-first) and ignores all
+   *  other filters. */
+  threadId?: string;
+  sentFromMs?: number;
+  sentToMs?: number;
+  connectorId?: string;
+  /** Default 100. Ignored when `threadId` is set. */
+  limit?: number;
+};
+
+/** List inbox messages most-recent-first. Pass `threadId` to fetch a
+ *  full conversation in chronological order. */
+export async function listEmailMessages(
+  params: ListEmailMessagesParams = {},
+): Promise<EmailMessage[]> {
+  return invoke<EmailMessage[]>("list_email_messages", {
+    threadId: params.threadId,
+    sentFromMs: params.sentFromMs,
+    sentToMs: params.sentToMs,
+    connectorId: params.connectorId,
+    limit: params.limit,
+  });
+}
+
+/** Lazy-fetch the full HTML body for a message. First call hits Graph
+ *  and caches the result locally; subsequent calls return the cached
+ *  body. Returns `null` if the message id is unknown. */
+export async function getEmailBody(messageId: string): Promise<string | null> {
+  return invoke<string | null>("get_email_body", { messageId });
+}
+
 export type NoteMeta = { modified_ms: number };
 
 export async function noteMeta(notePath: string): Promise<NoteMeta> {


### PR DESCRIPTION
## Summary
- Extends the existing `microsoft_graph` connector with `Mail.Read` scope and a `sync_mail()` step alongside the calendar half
- Adds provider-agnostic `email_messages` / `email_recipients` schema (migration 011, schema → v11) with the same shape contract as the calendar layer
- Bodies are lazy-fetched on first read via the new `get_email_body` Tauri command and cached locally; `COALESCE` on `body_html` keeps them across re-syncs
- Two new Tauri commands: `list_email_messages` (recent / by thread) and `get_email_body`

First issue in the [Connectors v2: Mail + Workstreams](https://github.com/tjruesch/margin/milestone/4) milestone. Sets up the data layer that #70 (workstream synthesis), #71 (UI), and #72 (AI ask integration) will build on. No UI changes in this PR — data lands in SQLite ready for downstream consumers.

## Notes
- `microsoft_graph` provider's `display_name` is now "Microsoft" (it covers calendar + mail; calendar-specific labelling no longer fits)
- Existing connected users: their tokens lack `Mail.Read`. First mail fetch returns 403 → `ConnectorError::ReauthNeeded` → Settings surfaces "Reconnect"; calendar continues to work in the meantime because the mail half is best-effort within `sync()`
- Inbox folder only (`/me/mailFolders/inbox/messages`); 4 pages × 50 = 200 most recent messages per sync
- **Accumulate-don't-roll**: unlike calendar's sliding window, email persists indefinitely; old messages don't get reaped on re-sync (the synthesizer may cite older threads). A retention policy is out of scope for v1.

## Test plan
- [x] `cargo check` clean
- [x] `bunx tsc --noEmit -p tsconfig.json` clean
- [x] `cargo test --lib connectors::` — 22 connector tests pass (9 new for email + map_message)
- [x] Full `cargo test --lib` — 153 tests pass, no regressions
- [ ] Manual: existing Microsoft connector → next sync flips to `reauth_needed` → click Reconnect → consent screen shows Mail in scopes → re-grant → emails populate within 5 min
- [ ] Manual: `sqlite3 ~/.margin/index.db "SELECT subject, from_email, datetime(sent_at_ms/1000,'unixepoch') FROM email_messages ORDER BY sent_at_ms DESC LIMIT 10"` returns the most recent inbox messages
- [ ] Manual: invoke `getEmailBody(<id>)` from the dev console — first call fetches body, second returns the cached value; sqlite shows `body_html` populated