### PR TITLE
Workstream synthesis pipeline (#70)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2392,6 +2392,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yml",
+ "sha2",
  "sherpa-onnx",
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,7 +37,8 @@ futures-util = "0.3"
 rubato = { version = "0.16", default-features = false }
 whisper-rs = { version = "0.16", default-features = false, features = ["metal"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
-tokio = { version = "1", features = ["fs", "io-util"] }
+tokio = { version = "1", features = ["fs", "io-util", "sync"] }
+sha2 = "0.10"
 uuid = { version = "1", features = ["v4"] }
 chrono = "0.4"
 screencapturekit = { version = "1.5", features = ["macos_14_0"] }

--- a/src-tauri/src/anthropic.rs
+++ b/src-tauri/src/anthropic.rs
@@ -1,0 +1,10 @@
+//! Shared Anthropic API constants.
+//!
+//! Two callers consume the Anthropic Messages API: `ask.rs` (streaming
+//! Q&A over notes) and `workstreams::synthesizer` (single-shot JSON
+//! clustering pass). Centralizing the endpoint, version, and default
+//! model here keeps them in lockstep when we bump or pin.
+
+pub const ENDPOINT: &str = "https://api.anthropic.com/v1/messages";
+pub const ANTHROPIC_VERSION: &str = "2023-06-01";
+pub const DEFAULT_MODEL: &str = "claude-sonnet-4-6";

--- a/src-tauri/src/ask.rs
+++ b/src-tauri/src/ask.rs
@@ -25,11 +25,9 @@ use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager};
 
+use crate::anthropic::{ANTHROPIC_VERSION, DEFAULT_MODEL, ENDPOINT};
 use crate::{index::DirectoryEntry, keychain};
 
-const ENDPOINT: &str = "https://api.anthropic.com/v1/messages";
-const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
-const ANTHROPIC_VERSION: &str = "2023-06-01";
 const MAX_TOKENS: u32 = 2048;
 
 /// Top-K retrieved notes whose full body is loaded into the prompt.

--- a/src-tauri/src/connectors/microsoft_graph.rs
+++ b/src-tauri/src/connectors/microsoft_graph.rs
@@ -113,14 +113,20 @@ impl Connector for MicrosoftGraphConnector {
         };
 
         // ---- Mail half ----------------------------------------------------
-        // Calendar succeeded; if mail fails, log + skip rather than
-        // dropping the calendar half. This keeps the more visible
-        // "Coming up" UI healthy when, say, Mail.Read consent is
-        // outstanding but Calendars.Read still works.
+        // Calendar succeeded and rows are committed; the mail half is
+        // best-effort for transient errors (network, rate limit). But
+        // a `ReauthNeeded` (typically: existing token lacks `Mail.Read`)
+        // MUST surface as the connector's overall last_error so the
+        // Settings UI prompts a Reconnect — otherwise mail would
+        // silently never sync and the user has no signal.
         let mail_report = match self.sync_mail(&ctx, &resolver).await {
             Ok(report) => report,
+            Err(ConnectorError::ReauthNeeded(msg)) => {
+                eprintln!("[microsoft_graph] mail sync needs reauth: {msg}");
+                return Err(ConnectorError::ReauthNeeded(msg));
+            }
             Err(e) => {
-                eprintln!("[microsoft_graph] mail sync failed: {e}");
+                eprintln!("[microsoft_graph] mail sync failed (non-fatal): {e}");
                 super::email::UpsertReport::default()
             }
         };
@@ -273,6 +279,11 @@ fn map_status(
 ) -> ConnectorError {
     match status.as_u16() {
         401 => ConnectorError::ReauthNeeded(format!("graph 401: {body}")),
+        // 403 typically means the token's grant doesn't cover the
+        // requested resource (e.g. existing token without Mail.Read
+        // calling /me/messages). Reconnecting re-prompts consent for
+        // the new scope set, which is the right user action.
+        403 => ConnectorError::ReauthNeeded(format!("graph 403: {body}")),
         429 => ConnectorError::RateLimited {
             retry_after_ms: retry_after_ms.unwrap_or(60_000),
         },
@@ -1057,5 +1068,21 @@ mod tests {
     fn percent_encode_path_handles_graph_id_chars() {
         let encoded = percent_encode_path("AAMkA+/=foo");
         assert_eq!(encoded, "AAMkA%2B%2F%3Dfoo");
+    }
+
+    #[test]
+    fn map_status_treats_403_as_reauth_needed() {
+        let err = map_status(
+            reqwest::StatusCode::FORBIDDEN,
+            None,
+            "ErrorAccessDenied".into(),
+        );
+        match err {
+            ConnectorError::ReauthNeeded(msg) => {
+                assert!(msg.contains("403"));
+                assert!(msg.contains("ErrorAccessDenied"));
+            }
+            other => panic!("expected ReauthNeeded, got {other:?}"),
+        }
     }
 }

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -42,7 +42,8 @@ const SCHEMA_V8: &str = include_str!("migrations/008_connectors.sql");
 const SCHEMA_V9: &str = include_str!("migrations/009_calendar.sql");
 const SCHEMA_V10: &str = include_str!("migrations/010_event_note_link.sql");
 const SCHEMA_V11: &str = include_str!("migrations/011_email.sql");
-const SCHEMA_VERSION: i64 = 11;
+const SCHEMA_V12: &str = include_str!("migrations/012_workstreams.sql");
+const SCHEMA_VERSION: i64 = 12;
 
 /// Open the index DB at `db_path` (creating it if absent) and apply any
 /// pending migrations.
@@ -128,6 +129,10 @@ fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 10 {
         conn.execute_batch(SCHEMA_V11)?;
         version = 11;
+    }
+    if version == 11 {
+        conn.execute_batch(SCHEMA_V12)?;
+        version = 12;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod anthropic;
 mod ask;
 mod audio;
 mod chunker;
@@ -15,6 +16,7 @@ mod sysaudio;
 mod team;
 mod transcribe;
 mod voice;
+mod workstreams;
 
 use notify::{RecommendedWatcher, RecursiveMode};
 use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, RecommendedCache};
@@ -615,6 +617,19 @@ pub fn run() {
             // Idle until a real connector is configured (#60+).
             connectors::runner::start(app.handle().clone());
 
+            // Workstream synthesizer boot tick (#70). Stale-checks
+            // last_clustered_ms inside; no-op if a fresh pass landed
+            // within the last 6h.
+            let app_for_cluster = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                if let Err(e) =
+                    workstreams::synthesizer::maybe_cluster(&app_for_cluster, false).await
+                {
+                    eprintln!("[workstreams] boot cluster failed: {e}");
+                }
+            });
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -670,7 +685,12 @@ pub fn run() {
             connectors::commands::get_event_details,
             connectors::commands::open_or_create_event_note,
             connectors::commands::list_email_messages,
-            connectors::commands::get_email_body
+            connectors::commands::get_email_body,
+            workstreams::commands::synthesize_workstreams,
+            workstreams::commands::list_workstreams,
+            workstreams::commands::get_workstream_details,
+            workstreams::commands::set_workstream_action_done,
+            workstreams::commands::set_workstream_status
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/migrations/012_workstreams.sql
+++ b/src-tauri/src/migrations/012_workstreams.sql
@@ -1,0 +1,51 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE workstreams (
+  id                 TEXT PRIMARY KEY,
+  title              TEXT NOT NULL,
+  summary            TEXT NOT NULL,
+  status             TEXT NOT NULL DEFAULT 'active',
+  last_activity_ms   INTEGER NOT NULL,
+  created_ms         INTEGER NOT NULL,
+  updated_ms         INTEGER NOT NULL
+);
+CREATE INDEX idx_workstreams_status ON workstreams(status, last_activity_ms DESC);
+
+CREATE TABLE workstream_emails (
+  workstream_id  TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+  message_id     TEXT NOT NULL REFERENCES email_messages(id) ON DELETE CASCADE,
+  relevance      REAL,
+  PRIMARY KEY (workstream_id, message_id)
+);
+CREATE INDEX idx_ws_emails_msg ON workstream_emails(message_id);
+
+CREATE TABLE workstream_events (
+  workstream_id  TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+  event_id       TEXT NOT NULL REFERENCES calendar_events(id) ON DELETE CASCADE,
+  PRIMARY KEY (workstream_id, event_id)
+);
+CREATE INDEX idx_ws_events_ev ON workstream_events(event_id);
+
+CREATE TABLE workstream_notes (
+  workstream_id  TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+  note_path      TEXT NOT NULL,
+  PRIMARY KEY (workstream_id, note_path)
+);
+CREATE INDEX idx_ws_notes_path ON workstream_notes(note_path);
+
+CREATE TABLE workstream_actions (
+  id              TEXT PRIMARY KEY,
+  workstream_id   TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+  text            TEXT NOT NULL,
+  due_ms          INTEGER,
+  source_kind     TEXT NOT NULL,
+  source_id       TEXT NOT NULL,
+  done            INTEGER NOT NULL DEFAULT 0,
+  created_ms      INTEGER NOT NULL
+);
+CREATE INDEX idx_ws_actions_ws ON workstream_actions(workstream_id);
+CREATE INDEX idx_ws_actions_done ON workstream_actions(done, created_ms DESC);
+
+INSERT INTO meta(key, value) VALUES ('last_clustered_ms', '0');
+
+UPDATE meta SET value = '12' WHERE key = 'schema_version';

--- a/src-tauri/src/workstreams/commands.rs
+++ b/src-tauri/src/workstreams/commands.rs
@@ -1,0 +1,56 @@
+//! Tauri commands for the workstreams module.
+
+use std::sync::Mutex;
+
+use rusqlite::Connection;
+use tauri::AppHandle;
+
+use super::{persist, synthesizer, ClusterReport, Workstream, WorkstreamDetail};
+
+#[tauri::command]
+pub async fn synthesize_workstreams(
+    app: AppHandle,
+    force: bool,
+) -> Result<ClusterReport, String> {
+    synthesizer::maybe_cluster(&app, force).await
+}
+
+#[tauri::command]
+pub fn list_workstreams(
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<Vec<Workstream>, String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    persist::list_workstreams_active(&c).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn get_workstream_details(
+    id: String,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<Option<WorkstreamDetail>, String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    persist::get_workstream_detail(&c, &id).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn set_workstream_action_done(
+    action_id: String,
+    done: bool,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<(), String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    persist::set_action_done(&c, &action_id, done).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn set_workstream_status(
+    id: String,
+    status: String,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<(), String> {
+    if !matches!(status.as_str(), "active" | "archived" | "snoozed") {
+        return Err(format!("invalid status: {status}"));
+    }
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    persist::set_status(&c, &id, &status).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/workstreams/mod.rs
+++ b/src-tauri/src/workstreams/mod.rs
@@ -1,0 +1,104 @@
+//! Workstream synthesis pipeline (#70).
+//!
+//! Takes raw signals from #69 (emails), #63 (calendar events), and the
+//! existing notes index, hands them to Claude, and writes back named
+//! "workstreams" — ongoing efforts the user is participating in (e.g.
+//! "Hyundai POC review", "Q3 hiring") with attached action items.
+//!
+//! No UI in this module — the data layer is callable end-to-end after
+//! this PR; the Workstreams view (#71) and AI ask integration (#72)
+//! consume the rows produced here.
+//!
+//! Concurrency: `CLUSTER_LOCK` ensures at most one synthesis pass is
+//! in flight at a time. `try_lock` callers (boot tick + manual
+//! refresh) early-return when the lock is held instead of queueing.
+
+use std::sync::OnceLock;
+
+use serde::Serialize;
+use tokio::sync::Mutex;
+
+pub mod commands;
+pub mod persist;
+pub mod synthesizer;
+
+/// Process-wide guard against overlapping synthesis passes. The boot
+/// hook fires `maybe_cluster(false)` ~5s after launch; the user can
+/// also click Refresh in the Workstreams view (#71) at any time. Both
+/// paths must serialize on this lock to avoid duplicate Anthropic
+/// calls and racing pivot writes.
+pub fn cluster_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Persisted workstream row + joined counts for the list view.
+#[derive(Debug, Clone, Serialize)]
+pub struct Workstream {
+    pub id: String,
+    pub title: String,
+    pub summary: String,
+    pub status: String,
+    pub last_activity_ms: i64,
+    pub created_ms: i64,
+    pub updated_ms: i64,
+    pub email_count: u32,
+    pub event_count: u32,
+    pub note_count: u32,
+    pub open_action_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkstreamAction {
+    pub id: String,
+    pub workstream_id: String,
+    pub text: String,
+    pub due_ms: Option<i64>,
+    /// "email" | "event" | "note"
+    pub source_kind: String,
+    pub source_id: String,
+    pub done: bool,
+    pub created_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct NoteRef {
+    pub note_path: String,
+    pub title: String,
+    pub modified_ms: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkstreamDetail {
+    #[serde(flatten)]
+    pub workstream: Workstream,
+    pub emails: Vec<crate::connectors::email::EmailMessage>,
+    pub events: Vec<crate::connectors::calendar::CalendarEvent>,
+    pub notes: Vec<NoteRef>,
+    pub actions: Vec<WorkstreamAction>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct ClusterReport {
+    pub workstreams_added: u32,
+    pub workstreams_updated: u32,
+    pub actions_added: u32,
+    pub actions_updated: u32,
+    pub items_clustered: u32,
+    pub model: String,
+    pub last_clustered_ms: i64,
+    /// "synced" on a successful pass, "skipped" when stale-check or
+    /// lock guard short-circuited, "errored" on failure (caller
+    /// returns Err in that case but the field is left here for
+    /// future event payload reuse).
+    pub state: String,
+}
+
+/// Per-workstream contribution to a `ClusterReport`. Returned from
+/// `persist::write_workstream` so the synthesizer can roll up totals.
+#[derive(Debug, Default, Clone)]
+pub struct WriteCounts {
+    pub workstream_added: bool,
+    pub actions_added: u32,
+    pub actions_updated: u32,
+}

--- a/src-tauri/src/workstreams/persist.rs
+++ b/src-tauri/src/workstreams/persist.rs
@@ -1,0 +1,798 @@
+//! Storage layer for workstreams + their pivots and actions.
+//!
+//! Mirrors the per-domain pattern from `connectors/calendar.rs` /
+//! `connectors/email.rs`: small, transparent functions that take a
+//! `Connection` (or a `Transaction` on the write side), no hidden
+//! state, no caching. The synthesizer composes these into the
+//! end-to-end cluster pass.
+
+use rusqlite::{params, Connection, OptionalExtension};
+use sha2::{Digest, Sha256};
+
+use super::{NoteRef, WorkstreamDetail, Workstream, WorkstreamAction, WriteCounts};
+use crate::connectors::calendar;
+use crate::connectors::email;
+
+const META_LAST_CLUSTERED: &str = "last_clustered_ms";
+
+// ----- Synthesizer input shape (parsed from Claude's JSON) -----------------
+
+#[derive(Debug, Clone)]
+pub struct SynthesizedWorkstream {
+    /// `Some(id)` to update an existing workstream; `None` to insert
+    /// a fresh one (we generate the id).
+    pub id: Option<String>,
+    pub title: String,
+    pub summary: String,
+    pub member_emails: Vec<String>,
+    pub member_events: Vec<String>,
+    pub member_notes: Vec<String>,
+    pub actions: Vec<SynthesizedAction>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SynthesizedAction {
+    pub text: String,
+    pub due_ms: Option<i64>,
+    pub source_kind: String,
+    pub source_id: String,
+}
+
+// ----- meta key/value ------------------------------------------------------
+
+pub fn last_clustered_ms(conn: &Connection) -> rusqlite::Result<i64> {
+    let s: Option<String> = conn
+        .query_row(
+            "SELECT value FROM meta WHERE key = ?1",
+            params![META_LAST_CLUSTERED],
+            |r| r.get(0),
+        )
+        .optional()?;
+    Ok(s.and_then(|v| v.parse::<i64>().ok()).unwrap_or(0))
+}
+
+pub fn set_last_clustered_ms(conn: &Connection, ms: i64) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO meta(key, value) VALUES (?1, ?2) \
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![META_LAST_CLUSTERED, ms.to_string()],
+    )?;
+    Ok(())
+}
+
+// ----- Read helpers --------------------------------------------------------
+
+pub fn list_workstreams_active(conn: &Connection) -> rusqlite::Result<Vec<Workstream>> {
+    let mut stmt = conn.prepare(
+        "SELECT w.id, w.title, w.summary, w.status, w.last_activity_ms, w.created_ms, w.updated_ms, \
+                COALESCE((SELECT COUNT(*) FROM workstream_emails WHERE workstream_id = w.id), 0) AS ec, \
+                COALESCE((SELECT COUNT(*) FROM workstream_events WHERE workstream_id = w.id), 0) AS evc, \
+                COALESCE((SELECT COUNT(*) FROM workstream_notes  WHERE workstream_id = w.id), 0) AS nc, \
+                COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0) AS ac \
+         FROM workstreams w \
+         WHERE w.status = 'active' \
+         ORDER BY w.last_activity_ms DESC",
+    )?;
+    let rows = stmt.query_map([], |r| {
+        Ok(Workstream {
+            id: r.get(0)?,
+            title: r.get(1)?,
+            summary: r.get(2)?,
+            status: r.get(3)?,
+            last_activity_ms: r.get(4)?,
+            created_ms: r.get(5)?,
+            updated_ms: r.get(6)?,
+            email_count: r.get::<_, i64>(7)? as u32,
+            event_count: r.get::<_, i64>(8)? as u32,
+            note_count: r.get::<_, i64>(9)? as u32,
+            open_action_count: r.get::<_, i64>(10)? as u32,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+pub fn get_workstream_detail(
+    conn: &Connection,
+    id: &str,
+) -> rusqlite::Result<Option<WorkstreamDetail>> {
+    let workstream = match get_workstream_one(conn, id)? {
+        Some(w) => w,
+        None => return Ok(None),
+    };
+
+    // Emails: join through pivot, hydrate via `email::get_message_details`.
+    let mut stmt = conn.prepare(
+        "SELECT message_id FROM workstream_emails WHERE workstream_id = ?1",
+    )?;
+    let mut emails = Vec::new();
+    let rows = stmt.query_map(params![id], |r| r.get::<_, String>(0))?;
+    for row in rows {
+        if let Some(m) = email::get_message_details(conn, &row?)? {
+            emails.push(m);
+        }
+    }
+    // Sort by sent_at_ms desc.
+    emails.sort_by(|a, b| b.sent_at_ms.cmp(&a.sent_at_ms));
+
+    // Events: ditto via calendar::get_event_details.
+    let mut stmt = conn.prepare(
+        "SELECT event_id FROM workstream_events WHERE workstream_id = ?1",
+    )?;
+    let mut events = Vec::new();
+    let rows = stmt.query_map(params![id], |r| r.get::<_, String>(0))?;
+    for row in rows {
+        if let Some(e) = calendar::get_event_details(conn, &row?)? {
+            events.push(e);
+        }
+    }
+    events.sort_by(|a, b| b.start_ms.cmp(&a.start_ms));
+
+    // Notes: join workstream_notes against notes table for title.
+    let mut stmt = conn.prepare(
+        "SELECT wn.note_path, COALESCE(n.title, ''), COALESCE(n.modified_ms, 0) \
+         FROM workstream_notes wn \
+         LEFT JOIN notes n ON n.note_path = wn.note_path \
+         WHERE wn.workstream_id = ?1 \
+         ORDER BY n.modified_ms DESC",
+    )?;
+    let note_rows = stmt.query_map(params![id], |r| {
+        Ok(NoteRef {
+            note_path: r.get(0)?,
+            title: r.get(1)?,
+            modified_ms: r.get(2)?,
+        })
+    })?;
+    let notes = note_rows.collect::<Result<Vec<_>, _>>()?;
+
+    let actions = list_actions_for(conn, id)?;
+
+    Ok(Some(WorkstreamDetail {
+        workstream,
+        emails,
+        events,
+        notes,
+        actions,
+    }))
+}
+
+fn get_workstream_one(conn: &Connection, id: &str) -> rusqlite::Result<Option<Workstream>> {
+    let mut stmt = conn.prepare(
+        "SELECT w.id, w.title, w.summary, w.status, w.last_activity_ms, w.created_ms, w.updated_ms, \
+                COALESCE((SELECT COUNT(*) FROM workstream_emails WHERE workstream_id = w.id), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_events WHERE workstream_id = w.id), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_notes  WHERE workstream_id = w.id), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0) \
+         FROM workstreams w WHERE w.id = ?1",
+    )?;
+    stmt.query_row(params![id], |r| {
+        Ok(Workstream {
+            id: r.get(0)?,
+            title: r.get(1)?,
+            summary: r.get(2)?,
+            status: r.get(3)?,
+            last_activity_ms: r.get(4)?,
+            created_ms: r.get(5)?,
+            updated_ms: r.get(6)?,
+            email_count: r.get::<_, i64>(7)? as u32,
+            event_count: r.get::<_, i64>(8)? as u32,
+            note_count: r.get::<_, i64>(9)? as u32,
+            open_action_count: r.get::<_, i64>(10)? as u32,
+        })
+    })
+    .optional()
+}
+
+fn list_actions_for(
+    conn: &Connection,
+    workstream_id: &str,
+) -> rusqlite::Result<Vec<WorkstreamAction>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, workstream_id, text, due_ms, source_kind, source_id, done, created_ms \
+         FROM workstream_actions WHERE workstream_id = ?1 \
+         ORDER BY done ASC, created_ms DESC",
+    )?;
+    let rows = stmt.query_map(params![workstream_id], |r| {
+        Ok(WorkstreamAction {
+            id: r.get(0)?,
+            workstream_id: r.get(1)?,
+            text: r.get(2)?,
+            due_ms: r.get(3)?,
+            source_kind: r.get(4)?,
+            source_id: r.get(5)?,
+            done: r.get::<_, i64>(6)? != 0,
+            created_ms: r.get(7)?,
+        })
+    })?;
+    rows.collect::<Result<Vec<_>, _>>()
+}
+
+// ----- Write helpers -------------------------------------------------------
+
+/// Upsert a workstream + replace its pivot sets + upsert actions in a
+/// single transaction. Returns the per-workstream contribution to the
+/// outer ClusterReport.
+///
+/// `record.id` is the existing workstream id when the synthesizer
+/// recognized this thread as a continuation; otherwise we generate a
+/// fresh `ws_<uuid>`. Action ids are content-hash so re-runs preserve
+/// the user's `done` flag.
+pub fn write_workstream(
+    tx: &rusqlite::Transaction<'_>,
+    record: &SynthesizedWorkstream,
+    now_ms: i64,
+) -> rusqlite::Result<WriteCounts> {
+    let mut counts = WriteCounts::default();
+
+    let id = match &record.id {
+        Some(s) if !s.is_empty() => s.clone(),
+        _ => format!("ws_{}", uuid::Uuid::new_v4()),
+    };
+    let pre_existed: i64 = tx
+        .query_row(
+            "SELECT 1 FROM workstreams WHERE id = ?1",
+            params![id],
+            |r| r.get(0),
+        )
+        .optional()?
+        .unwrap_or(0);
+
+    // Last activity = max modified across joined items, fallback now.
+    let last_activity = compute_last_activity(tx, record)?.unwrap_or(now_ms);
+
+    if pre_existed == 0 {
+        tx.execute(
+            "INSERT INTO workstreams(id, title, summary, status, last_activity_ms, created_ms, updated_ms) \
+             VALUES (?1, ?2, ?3, 'active', ?4, ?5, ?5)",
+            params![id, record.title, record.summary, last_activity, now_ms],
+        )?;
+        counts.workstream_added = true;
+    } else {
+        tx.execute(
+            "UPDATE workstreams SET title = ?2, summary = ?3, last_activity_ms = ?4, updated_ms = ?5 \
+             WHERE id = ?1",
+            params![id, record.title, record.summary, last_activity, now_ms],
+        )?;
+    }
+
+    // Replace pivots wholesale. Smaller than diffing for the typical
+    // dozens-of-items per workstream.
+    tx.execute(
+        "DELETE FROM workstream_emails WHERE workstream_id = ?1",
+        params![id],
+    )?;
+    {
+        let mut stmt = tx.prepare_cached(
+            "INSERT OR IGNORE INTO workstream_emails(workstream_id, message_id) VALUES (?1, ?2)",
+        )?;
+        for mid in &record.member_emails {
+            stmt.execute(params![id, mid])?;
+        }
+    }
+
+    tx.execute(
+        "DELETE FROM workstream_events WHERE workstream_id = ?1",
+        params![id],
+    )?;
+    {
+        let mut stmt = tx.prepare_cached(
+            "INSERT OR IGNORE INTO workstream_events(workstream_id, event_id) VALUES (?1, ?2)",
+        )?;
+        for eid in &record.member_events {
+            stmt.execute(params![id, eid])?;
+        }
+    }
+
+    tx.execute(
+        "DELETE FROM workstream_notes WHERE workstream_id = ?1",
+        params![id],
+    )?;
+    {
+        let mut stmt = tx.prepare_cached(
+            "INSERT OR IGNORE INTO workstream_notes(workstream_id, note_path) VALUES (?1, ?2)",
+        )?;
+        for np in &record.member_notes {
+            stmt.execute(params![id, np])?;
+        }
+    }
+
+    // Actions: upsert by hashed id. ON CONFLICT preserves `done` and
+    // `created_ms` (the user's state); refreshes everything else.
+    {
+        let mut stmt = tx.prepare_cached(
+            "INSERT INTO workstream_actions(\
+                id, workstream_id, text, due_ms, source_kind, source_id, done, created_ms\
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 0, ?7) \
+             ON CONFLICT(id) DO UPDATE SET \
+                text = excluded.text, \
+                due_ms = excluded.due_ms, \
+                source_kind = excluded.source_kind, \
+                source_id = excluded.source_id",
+        )?;
+        for a in &record.actions {
+            let aid = action_id(&id, &a.text);
+            let pre_existed_action: i64 = tx
+                .query_row(
+                    "SELECT 1 FROM workstream_actions WHERE id = ?1",
+                    params![aid],
+                    |r| r.get(0),
+                )
+                .optional()?
+                .unwrap_or(0);
+            stmt.execute(params![
+                aid,
+                id,
+                a.text,
+                a.due_ms,
+                a.source_kind,
+                a.source_id,
+                now_ms,
+            ])?;
+            if pre_existed_action == 0 {
+                counts.actions_added += 1;
+            } else {
+                counts.actions_updated += 1;
+            }
+        }
+    }
+
+    Ok(counts)
+}
+
+fn compute_last_activity(
+    tx: &rusqlite::Transaction<'_>,
+    record: &SynthesizedWorkstream,
+) -> rusqlite::Result<Option<i64>> {
+    let mut max_ms: Option<i64> = None;
+
+    if !record.member_emails.is_empty() {
+        let placeholders = std::iter::repeat("?")
+            .take(record.member_emails.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT MAX(sent_at_ms) FROM email_messages WHERE id IN ({placeholders})"
+        );
+        let mut stmt = tx.prepare(&sql)?;
+        let p: Vec<&dyn rusqlite::ToSql> = record
+            .member_emails
+            .iter()
+            .map(|s| s as &dyn rusqlite::ToSql)
+            .collect();
+        let v: Option<i64> = stmt
+            .query_row(rusqlite::params_from_iter(p), |r| r.get(0))
+            .optional()?
+            .flatten();
+        max_ms = max_opt(max_ms, v);
+    }
+
+    if !record.member_events.is_empty() {
+        let placeholders = std::iter::repeat("?")
+            .take(record.member_events.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT MAX(start_ms) FROM calendar_events WHERE id IN ({placeholders})"
+        );
+        let mut stmt = tx.prepare(&sql)?;
+        let p: Vec<&dyn rusqlite::ToSql> = record
+            .member_events
+            .iter()
+            .map(|s| s as &dyn rusqlite::ToSql)
+            .collect();
+        let v: Option<i64> = stmt
+            .query_row(rusqlite::params_from_iter(p), |r| r.get(0))
+            .optional()?
+            .flatten();
+        max_ms = max_opt(max_ms, v);
+    }
+
+    if !record.member_notes.is_empty() {
+        let placeholders = std::iter::repeat("?")
+            .take(record.member_notes.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT MAX(modified_ms) FROM notes WHERE note_path IN ({placeholders})"
+        );
+        let mut stmt = tx.prepare(&sql)?;
+        let p: Vec<&dyn rusqlite::ToSql> = record
+            .member_notes
+            .iter()
+            .map(|s| s as &dyn rusqlite::ToSql)
+            .collect();
+        let v: Option<i64> = stmt
+            .query_row(rusqlite::params_from_iter(p), |r| r.get(0))
+            .optional()?
+            .flatten();
+        max_ms = max_opt(max_ms, v);
+    }
+
+    Ok(max_ms)
+}
+
+fn max_opt(a: Option<i64>, b: Option<i64>) -> Option<i64> {
+    match (a, b) {
+        (Some(x), Some(y)) => Some(x.max(y)),
+        (Some(x), None) | (None, Some(x)) => Some(x),
+        (None, None) => None,
+    }
+}
+
+pub fn set_action_done(
+    conn: &Connection,
+    action_id: &str,
+    done: bool,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE workstream_actions SET done = ?2 WHERE id = ?1",
+        params![action_id, done as i64],
+    )?;
+    Ok(())
+}
+
+pub fn set_status(conn: &Connection, id: &str, status: &str) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE workstreams SET status = ?2, updated_ms = ?3 WHERE id = ?1",
+        params![id, status, now_ms()],
+    )?;
+    Ok(())
+}
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Stable id for a workstream action: sha256 of `workstream_id\ntrim(text)`.
+/// Re-runs that produce the same workstream + same action text generate
+/// the same id, so the upsert preserves any user-set `done`.
+pub fn action_id(workstream_id: &str, text: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(workstream_id.as_bytes());
+    h.update(b"\n");
+    h.update(text.trim().as_bytes());
+    format!("wsa_{:x}", h.finalize())
+}
+
+// ----- Tests ---------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_test_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        // Minimal schema replica needed for the workstreams tests.
+        conn.execute_batch(
+            "PRAGMA foreign_keys = ON;
+             CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO meta(key, value) VALUES ('schema_version', '11');
+             CREATE TABLE team_members (id TEXT PRIMARY KEY);
+             CREATE TABLE connectors (id TEXT PRIMARY KEY);
+             INSERT INTO connectors(id) VALUES ('mg:test');
+             CREATE TABLE notes (
+                 note_path  TEXT PRIMARY KEY,
+                 title      TEXT NOT NULL,
+                 modified_ms INTEGER NOT NULL
+             );",
+        )
+        .unwrap();
+        conn.execute_batch(include_str!("../migrations/009_calendar.sql"))
+            .unwrap();
+        conn.execute_batch(include_str!("../migrations/010_event_note_link.sql"))
+            .unwrap();
+        conn.execute_batch(include_str!("../migrations/011_email.sql"))
+            .unwrap();
+        conn.execute_batch(include_str!("../migrations/012_workstreams.sql"))
+            .unwrap();
+        conn
+    }
+
+    fn seed_email(conn: &Connection, id: &str, sent_at: i64) {
+        conn.execute(
+            "INSERT INTO email_messages(\
+                id, connector_id, external_id, thread_id, subject, from_email, from_name, \
+                sent_at_ms, body_preview, body_html, has_attachments, is_read, raw_etag, modified_ms\
+             ) VALUES (?1, 'mg:test', ?1, 't1', 'Sub', 'a@e', NULL, ?2, NULL, NULL, 0, 0, NULL, ?2)",
+            params![id, sent_at],
+        )
+        .unwrap();
+    }
+
+    fn seed_event(conn: &Connection, id: &str, start: i64) {
+        conn.execute(
+            "INSERT INTO calendar_events(\
+                id, connector_id, external_id, title, start_ms, end_ms, all_day, modified_ms\
+             ) VALUES (?1, 'mg:test', ?1, 'Ev', ?2, ?2, 0, ?2)",
+            params![id, start],
+        )
+        .unwrap();
+    }
+
+    fn seed_note(conn: &Connection, path: &str, modified: i64) {
+        conn.execute(
+            "INSERT INTO notes(note_path, title, modified_ms) VALUES (?1, ?2, ?3)",
+            params![path, "Note", modified],
+        )
+        .unwrap();
+    }
+
+    fn make_ws(id: Option<&str>, title: &str, emails: &[&str], events: &[&str], notes: &[&str], actions: Vec<SynthesizedAction>) -> SynthesizedWorkstream {
+        SynthesizedWorkstream {
+            id: id.map(|s| s.to_string()),
+            title: title.to_string(),
+            summary: format!("Summary of {title}"),
+            member_emails: emails.iter().map(|s| s.to_string()).collect(),
+            member_events: events.iter().map(|s| s.to_string()).collect(),
+            member_notes: notes.iter().map(|s| s.to_string()).collect(),
+            actions,
+        }
+    }
+
+    fn make_action(text: &str, source_kind: &str, source_id: &str) -> SynthesizedAction {
+        SynthesizedAction {
+            text: text.to_string(),
+            due_ms: None,
+            source_kind: source_kind.to_string(),
+            source_id: source_id.to_string(),
+        }
+    }
+
+    #[test]
+    fn last_clustered_ms_default_is_zero_then_round_trips() {
+        let conn = open_test_db();
+        assert_eq!(last_clustered_ms(&conn).unwrap(), 0);
+        set_last_clustered_ms(&conn, 1_700_000_000_000).unwrap();
+        assert_eq!(last_clustered_ms(&conn).unwrap(), 1_700_000_000_000);
+    }
+
+    #[test]
+    fn write_workstream_inserts_new_record() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+        seed_event(&conn, "mg:test::e1", 2_000);
+        seed_note(&conn, "/n/a.md", 3_000);
+
+        let tx = conn.transaction().unwrap();
+        let ws = make_ws(
+            None,
+            "Hyundai POC",
+            &["mg:test::m1"],
+            &["mg:test::e1"],
+            &["/n/a.md"],
+            vec![make_action("Send invoice", "email", "mg:test::m1")],
+        );
+        let counts = write_workstream(&tx, &ws, 5_000).unwrap();
+        tx.commit().unwrap();
+
+        assert!(counts.workstream_added);
+        assert_eq!(counts.actions_added, 1);
+
+        let active = list_workstreams_active(&conn).unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].title, "Hyundai POC");
+        assert_eq!(active[0].email_count, 1);
+        assert_eq!(active[0].event_count, 1);
+        assert_eq!(active[0].note_count, 1);
+        assert_eq!(active[0].open_action_count, 1);
+        // last_activity = max(1000, 2000, 3000) = 3000
+        assert_eq!(active[0].last_activity_ms, 3_000);
+    }
+
+    #[test]
+    fn write_workstream_updates_existing_and_replaces_pivots() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+        seed_email(&conn, "mg:test::m2", 4_000);
+        seed_event(&conn, "mg:test::e1", 2_000);
+
+        let tx = conn.transaction().unwrap();
+        let ws = make_ws(
+            Some("ws_existing"),
+            "Workstream A",
+            &["mg:test::m1"],
+            &["mg:test::e1"],
+            &[],
+            vec![],
+        );
+        write_workstream(&tx, &ws, 1_000).unwrap();
+        tx.commit().unwrap();
+
+        // Re-sync: replace m1 with m2, drop the event entirely, change title.
+        let tx = conn.transaction().unwrap();
+        let ws2 = make_ws(
+            Some("ws_existing"),
+            "Workstream A (renamed)",
+            &["mg:test::m2"],
+            &[],
+            &[],
+            vec![],
+        );
+        let counts = write_workstream(&tx, &ws2, 2_000).unwrap();
+        tx.commit().unwrap();
+        assert!(!counts.workstream_added);
+
+        let detail = get_workstream_detail(&conn, "ws_existing").unwrap().unwrap();
+        assert_eq!(detail.workstream.title, "Workstream A (renamed)");
+        assert_eq!(detail.emails.len(), 1);
+        assert_eq!(detail.emails[0].id, "mg:test::m2");
+        assert_eq!(detail.events.len(), 0);
+    }
+
+    #[test]
+    fn write_workstream_preserves_action_done_on_resync() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+
+        let tx = conn.transaction().unwrap();
+        write_workstream(
+            &tx,
+            &make_ws(
+                Some("ws1"),
+                "WS",
+                &["mg:test::m1"],
+                &[],
+                &[],
+                vec![make_action("Reply to invoice", "email", "mg:test::m1")],
+            ),
+            1_000,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        // User checks the action.
+        let aid = action_id("ws1", "Reply to invoice");
+        set_action_done(&conn, &aid, true).unwrap();
+        let detail = get_workstream_detail(&conn, "ws1").unwrap().unwrap();
+        assert_eq!(detail.actions.len(), 1);
+        assert!(detail.actions[0].done);
+
+        // Re-sync emits the same action text.
+        let tx = conn.transaction().unwrap();
+        let counts = write_workstream(
+            &tx,
+            &make_ws(
+                Some("ws1"),
+                "WS",
+                &["mg:test::m1"],
+                &[],
+                &[],
+                vec![make_action("Reply to invoice", "email", "mg:test::m1")],
+            ),
+            2_000,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        assert_eq!(counts.actions_added, 0);
+        assert_eq!(counts.actions_updated, 1);
+
+        let detail = get_workstream_detail(&conn, "ws1").unwrap().unwrap();
+        assert!(
+            detail.actions[0].done,
+            "done flag must survive a re-sync of the same action text"
+        );
+    }
+
+    #[test]
+    fn list_workstreams_active_excludes_archived() {
+        let mut conn = open_test_db();
+        let tx = conn.transaction().unwrap();
+        write_workstream(
+            &tx,
+            &make_ws(Some("ws_a"), "Active", &[], &[], &[], vec![]),
+            1_000,
+        )
+        .unwrap();
+        write_workstream(
+            &tx,
+            &make_ws(Some("ws_b"), "Archived", &[], &[], &[], vec![]),
+            1_000,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        set_status(&conn, "ws_b", "archived").unwrap();
+
+        let active = list_workstreams_active(&conn).unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].id, "ws_a");
+    }
+
+    #[test]
+    fn set_action_done_round_trips() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+
+        let tx = conn.transaction().unwrap();
+        write_workstream(
+            &tx,
+            &make_ws(
+                Some("ws1"),
+                "WS",
+                &["mg:test::m1"],
+                &[],
+                &[],
+                vec![make_action("Do thing", "email", "mg:test::m1")],
+            ),
+            1_000,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        let aid = action_id("ws1", "Do thing");
+        set_action_done(&conn, &aid, true).unwrap();
+        let detail = get_workstream_detail(&conn, "ws1").unwrap().unwrap();
+        assert!(detail.actions[0].done);
+        set_action_done(&conn, &aid, false).unwrap();
+        let detail = get_workstream_detail(&conn, "ws1").unwrap().unwrap();
+        assert!(!detail.actions[0].done);
+    }
+
+    #[test]
+    fn get_workstream_detail_returns_joined_emails_events_notes_and_actions() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+        seed_email(&conn, "mg:test::m2", 5_000);
+        seed_event(&conn, "mg:test::e1", 2_000);
+        seed_note(&conn, "/n/a.md", 3_000);
+
+        let tx = conn.transaction().unwrap();
+        write_workstream(
+            &tx,
+            &make_ws(
+                Some("ws_x"),
+                "X",
+                &["mg:test::m1", "mg:test::m2"],
+                &["mg:test::e1"],
+                &["/n/a.md"],
+                vec![
+                    make_action("a1", "email", "mg:test::m1"),
+                    make_action("a2", "note", "/n/a.md"),
+                ],
+            ),
+            10_000,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        let d = get_workstream_detail(&conn, "ws_x").unwrap().unwrap();
+        assert_eq!(d.emails.len(), 2);
+        // Sorted desc by sent_at_ms: m2 (5000), m1 (1000).
+        assert_eq!(d.emails[0].id, "mg:test::m2");
+        assert_eq!(d.emails[1].id, "mg:test::m1");
+        assert_eq!(d.events.len(), 1);
+        assert_eq!(d.notes.len(), 1);
+        assert_eq!(d.notes[0].note_path, "/n/a.md");
+        assert_eq!(d.actions.len(), 2);
+    }
+
+    #[test]
+    fn action_id_is_stable_for_same_inputs() {
+        let id1 = action_id("ws1", "Do thing");
+        let id2 = action_id("ws1", "Do thing");
+        assert_eq!(id1, id2);
+
+        let id3 = action_id("ws2", "Do thing");
+        assert_ne!(id1, id3);
+        let id4 = action_id("ws1", "Do other thing");
+        assert_ne!(id1, id4);
+    }
+
+    #[test]
+    fn action_id_is_trim_normalized() {
+        // Trimming the text means whitespace drift in Claude output
+        // doesn't fragment action history.
+        let id1 = action_id("ws1", "Do thing");
+        let id2 = action_id("ws1", "  Do thing  ");
+        assert_eq!(id1, id2);
+        // But internal whitespace still matters (different action).
+        let id3 = action_id("ws1", "Do  thing");
+        assert_ne!(id1, id3);
+    }
+}

--- a/src-tauri/src/workstreams/synthesizer.rs
+++ b/src-tauri/src/workstreams/synthesizer.rs
@@ -1,0 +1,840 @@
+//! The cluster pass: snapshot recent signals, ask Claude to cluster
+//! them into named workstreams, persist the result.
+//!
+//! Single-shot (non-streaming) Claude call. JSON-only output. Strict
+//! parsing — unknown label refs are dropped, malformed responses bail.
+//!
+//! Failure semantics: `last_clustered_ms` is **only** updated on
+//! success. Anthropic 5xx, network blips, malformed JSON all fall
+//! through to the next 6h tick or manual refresh; existing rows are
+//! left untouched.
+
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager};
+
+use super::persist::{self, SynthesizedAction, SynthesizedWorkstream};
+use super::{ClusterReport, NoteRef, Workstream};
+use crate::anthropic::{ANTHROPIC_VERSION, DEFAULT_MODEL, ENDPOINT};
+use crate::connectors::{calendar, email, microsoft_graph, oauth};
+use crate::index;
+use crate::keychain;
+
+/// 6 hours. Boot tick + manual Refresh are no-ops if a successful pass
+/// landed within this window.
+const CLUSTER_TTL_MS: i64 = 6 * 3600 * 1000;
+
+const EMAIL_WINDOW_BACK_MS: i64 = 14 * 24 * 3600 * 1000;
+const EVENT_WINDOW_BACK_MS: i64 = 14 * 24 * 3600 * 1000;
+const EVENT_WINDOW_FORWARD_MS: i64 = 14 * 24 * 3600 * 1000;
+const NOTE_WINDOW_BACK_MS: i64 = 30 * 24 * 3600 * 1000;
+
+/// Cap on lazy body fetches per pass. Each is a Graph round-trip, so
+/// 100 keeps the pre-call work bounded for users with very busy inboxes.
+const MAX_BODY_FETCHES: usize = 100;
+
+const MAX_TOKENS: u32 = 8192;
+
+const SYSTEM_PROMPT: &str = "You are a workstream synthesizer. Given a user's recent emails, calendar events, \
+and notes, group them into 3-15 active workstreams: ongoing efforts the user is participating in \
+(projects, hiring loops, vendor evaluations, support escalations, etc.).
+
+Stickiness: an \"Existing workstreams\" section lists workstream ids already in the database. When new \
+items naturally extend one of those, REUSE its id verbatim. Spawn a new workstream only when no \
+existing one is a clean fit.
+
+Titles: short, specific, proper-noun-leaning (\"Hyundai POC review\", \"Q3 sourcing\", \
+\"Bridge integration\") — not generic (\"Project work\", \"Various meetings\").
+
+Summaries: 1-3 sentences. State what's happening and what's next, not what it is in the abstract.
+
+Action items: extract concrete TODOs the user owes (or owns) per workstream. Each must reference \
+a source by its label. Skip items that are already done.
+
+Output: a strict JSON array. No prose. No markdown fences. No keys other than the schema below.
+
+Schema:
+[
+  {
+    \"id\": \"<existing workstream id or null>\",
+    \"title\": \"...\",
+    \"summary\": \"...\",
+    \"members\": { \"emails\": [\"M1\", \"M2\"], \"events\": [\"E3\"], \"notes\": [\"N1\"] },
+    \"actions\": [
+      { \"text\": \"...\", \"due_ms\": null, \"source_kind\": \"email\", \"source_label\": \"M2\" }
+    ]
+  }
+]";
+
+// ----- Public entry point --------------------------------------------------
+
+pub async fn maybe_cluster(app: &AppHandle, force: bool) -> Result<ClusterReport, String> {
+    let lock = super::cluster_lock();
+    let _guard = match lock.try_lock() {
+        Ok(g) => g,
+        Err(_) => {
+            eprintln!("[workstreams] another cluster pass is in flight; skipping");
+            return Ok(ClusterReport {
+                state: "skipped".into(),
+                ..Default::default()
+            });
+        }
+    };
+
+    let conn_state = app.state::<std::sync::Mutex<rusqlite::Connection>>();
+    let now_ms = current_unix_ms();
+
+    let last = {
+        let c = conn_state.lock().map_err(|e| e.to_string())?;
+        persist::last_clustered_ms(&c).map_err(|e| e.to_string())?
+    };
+
+    if !force && now_ms.saturating_sub(last) < CLUSTER_TTL_MS {
+        eprintln!("[workstreams] cluster pass skipped (last {last}, now {now_ms})");
+        emit_status(app, "skipped", None);
+        return Ok(ClusterReport {
+            state: "skipped".into(),
+            last_clustered_ms: last,
+            ..Default::default()
+        });
+    }
+
+    emit_status(app, "clustering", None);
+
+    let report = match run_cluster_pass(app, &conn_state, now_ms).await {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("[workstreams] cluster pass failed: {e}");
+            emit_status(app, "errored", Some(e.clone()));
+            return Err(e);
+        }
+    };
+
+    {
+        let c = conn_state.lock().map_err(|e| e.to_string())?;
+        persist::set_last_clustered_ms(&c, now_ms).map_err(|e| e.to_string())?;
+    }
+
+    emit_status(app, "synced", Some(format_report_summary(&report)));
+    Ok(report)
+}
+
+async fn run_cluster_pass(
+    app: &AppHandle,
+    conn_state: &std::sync::Mutex<rusqlite::Connection>,
+    now_ms: i64,
+) -> Result<ClusterReport, String> {
+    // ---- 1. Snapshot inputs in a single lock window ---------------------
+    let (existing_ws, mut emails, events, notes) = {
+        let c = conn_state.lock().map_err(|e| e.to_string())?;
+        let existing = persist::list_workstreams_active(&c).map_err(|e| e.to_string())?;
+        let emails = email::list_messages_in_range(
+            &c,
+            now_ms - EMAIL_WINDOW_BACK_MS,
+            now_ms + 24 * 3600 * 1000,
+            None,
+            500,
+        )
+        .map_err(|e| e.to_string())?;
+        let events = calendar::list_events_in_range(
+            &c,
+            now_ms - EVENT_WINDOW_BACK_MS,
+            now_ms + EVENT_WINDOW_FORWARD_MS,
+            None,
+        )
+        .map_err(|e| e.to_string())?;
+        let directory = index::list_directory(&c, 200).map_err(|e| e.to_string())?;
+        let notes_cutoff = now_ms - NOTE_WINDOW_BACK_MS;
+        let notes: Vec<NoteRef> = directory
+            .into_iter()
+            .filter(|d| d.modified_ms >= notes_cutoff)
+            .map(|d| NoteRef {
+                note_path: d.note_path,
+                title: d.title,
+                modified_ms: d.modified_ms,
+            })
+            .collect();
+        (existing, emails, events, notes)
+    };
+
+    if emails.is_empty() && events.is_empty() && notes.is_empty() {
+        eprintln!("[workstreams] no recent items to cluster; skipping");
+        return Ok(ClusterReport {
+            state: "skipped".into(),
+            last_clustered_ms: now_ms,
+            ..Default::default()
+        });
+    }
+
+    // ---- 2. Lazy-fetch missing email bodies -----------------------------
+    // Bound the work to MAX_BODY_FETCHES per pass; older messages stay
+    // preview-only. Errors per message are logged and skipped — a body
+    // fetch failure must not abort the cluster pass.
+    let mut fetched = 0usize;
+    for m in emails.iter_mut() {
+        if fetched >= MAX_BODY_FETCHES {
+            break;
+        }
+        if m.body_html.is_some() {
+            continue;
+        }
+        let kind = m
+            .connector_id
+            .split_once(':')
+            .map(|(k, _)| k.to_string())
+            .unwrap_or_else(|| "microsoft_graph".to_string());
+        let connector_id = m.connector_id.clone();
+        let external_id = m.external_id.clone();
+        let body_result = oauth::with_valid_token(app, &connector_id, &kind, |access| async move {
+            microsoft_graph::fetch_message_body(&access, &external_id).await
+        })
+        .await;
+        match body_result {
+            Ok(Some(body)) => {
+                {
+                    let c = match conn_state.lock() {
+                        Ok(g) => g,
+                        Err(e) => {
+                            eprintln!("[workstreams] conn lock for body persist: {e}");
+                            continue;
+                        }
+                    };
+                    if let Err(e) = email::set_message_body_html(&c, &m.id, &body) {
+                        eprintln!("[workstreams] persist body for {}: {e}", m.id);
+                    }
+                }
+                m.body_html = Some(body);
+                fetched += 1;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                eprintln!("[workstreams] body fetch failed for {}: {e}", m.id);
+            }
+        }
+    }
+
+    // ---- 3. Build prompt, label maps ------------------------------------
+    let (user_message, label_maps) = build_user_message(&existing_ws, &emails, &events, &notes);
+    let items_clustered = (emails.len() + events.len() + notes.len()) as u32;
+
+    // ---- 4. Single-shot Claude call -------------------------------------
+    let api_key = keychain::read_anthropic_api_key().map_err(|_| {
+        "Anthropic API key not configured — open Settings → AI to add one".to_string()
+    })?;
+    let response_text = call_anthropic(&api_key, DEFAULT_MODEL, &user_message).await?;
+
+    // ---- 5. Parse JSON --------------------------------------------------
+    let synthesized = parse_synthesizer_response(&response_text, &label_maps);
+
+    // ---- 6. Persist in a single transaction -----------------------------
+    let mut report = ClusterReport {
+        state: "synced".into(),
+        model: DEFAULT_MODEL.to_string(),
+        items_clustered,
+        last_clustered_ms: now_ms,
+        ..Default::default()
+    };
+
+    {
+        let mut c = conn_state.lock().map_err(|e| e.to_string())?;
+        let tx = c.transaction().map_err(|e| e.to_string())?;
+        for ws in &synthesized {
+            let counts = persist::write_workstream(&tx, ws, now_ms)
+                .map_err(|e| format!("write workstream: {e}"))?;
+            if counts.workstream_added {
+                report.workstreams_added += 1;
+            } else {
+                report.workstreams_updated += 1;
+            }
+            report.actions_added += counts.actions_added;
+            report.actions_updated += counts.actions_updated;
+        }
+        tx.commit().map_err(|e| e.to_string())?;
+    }
+
+    Ok(report)
+}
+
+// ----- Anthropic call ------------------------------------------------------
+
+#[derive(Serialize)]
+struct ApiRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    stream: bool,
+    system: &'a str,
+    messages: Vec<ApiMessage<'a>>,
+}
+
+#[derive(Serialize)]
+struct ApiMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+async fn call_anthropic(api_key: &str, model: &str, user_message: &str) -> Result<String, String> {
+    let body = ApiRequest {
+        model,
+        max_tokens: MAX_TOKENS,
+        stream: false,
+        system: SYSTEM_PROMPT,
+        messages: vec![ApiMessage {
+            role: "user",
+            content: user_message,
+        }],
+    };
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(120))
+        .build()
+        .map_err(|e| format!("client init: {e}"))?;
+    let resp = client
+        .post(ENDPOINT)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", ANTHROPIC_VERSION)
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("network: {e}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let raw = resp.text().await.unwrap_or_default();
+        return Err(match status.as_u16() {
+            401 => format!("Invalid Anthropic API key — check Settings → AI ({raw})"),
+            429 => "Rate limited by Anthropic — try again shortly".to_string(),
+            _ => format!("Anthropic returned {status}: {raw}"),
+        });
+    }
+
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("anthropic response parse: {e}"))?;
+    // Concatenate all `text` content blocks (typically just one in
+    // non-streaming). Tool use blocks are not requested for synthesis,
+    // so we ignore unrelated block types.
+    let text = json
+        .get("content")
+        .and_then(|c| c.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .unwrap_or_default();
+    if text.is_empty() {
+        return Err("anthropic returned no text content".into());
+    }
+    Ok(text)
+}
+
+// ----- Prompt building -----------------------------------------------------
+
+/// Maps from Claude-facing labels (M1, E1, N1) back to canonical IDs.
+struct LabelMaps {
+    emails: HashMap<String, String>,    // "M1" → "<connector>:<external>"
+    events: HashMap<String, String>,    // "E1" → calendar_events.id
+    notes: HashMap<String, String>,     // "N1" → note_path
+}
+
+fn build_user_message(
+    existing: &[Workstream],
+    emails: &[email::EmailMessage],
+    events: &[calendar::CalendarEvent],
+    notes: &[NoteRef],
+) -> (String, LabelMaps) {
+    let mut s = String::new();
+    s.push_str("# Existing workstreams\n\n");
+    if existing.is_empty() {
+        s.push_str("(none)\n");
+    } else {
+        for w in existing {
+            s.push_str(&format!(
+                "[{}] {} — {} (active)\n",
+                w.id,
+                w.title,
+                summarize_one_line(&w.summary)
+            ));
+        }
+    }
+
+    let mut email_map = HashMap::new();
+    s.push_str("\n# Recent emails (last 14 days)\n\n");
+    if emails.is_empty() {
+        s.push_str("(none)\n");
+    } else {
+        for (i, m) in emails.iter().enumerate() {
+            let label = format!("M{}", i + 1);
+            email_map.insert(label.clone(), m.id.clone());
+            let date = format_iso_date(m.sent_at_ms);
+            let from = format_from(&m.from_email, m.from_name.as_deref());
+            let body = email_body_excerpt(m);
+            s.push_str(&format!(
+                "[{label}] {date} — From: {from} — Subject: {subject}\n{body}\n\n",
+                subject = m.subject,
+            ));
+        }
+    }
+
+    let mut event_map = HashMap::new();
+    s.push_str("\n# Recent calendar events (window: -14d .. +14d)\n\n");
+    if events.is_empty() {
+        s.push_str("(none)\n");
+    } else {
+        for (i, e) in events.iter().enumerate() {
+            let label = format!("E{}", i + 1);
+            event_map.insert(label.clone(), e.id.clone());
+            let when = format_iso_datetime(e.start_ms);
+            let attendees: Vec<&str> =
+                e.attendees.iter().take(8).map(|a| a.email.as_str()).collect();
+            let attendees_str = if attendees.is_empty() {
+                String::new()
+            } else {
+                format!(" — Attendees: {}", attendees.join(", "))
+            };
+            s.push_str(&format!(
+                "[{label}] {when} — {title}{attendees_str}\n",
+                title = e.title
+            ));
+        }
+    }
+
+    let mut note_map = HashMap::new();
+    s.push_str("\n# Recent notes (last 30 days)\n\n");
+    if notes.is_empty() {
+        s.push_str("(none)\n");
+    } else {
+        for (i, n) in notes.iter().enumerate() {
+            let label = format!("N{}", i + 1);
+            note_map.insert(label.clone(), n.note_path.clone());
+            let date = format_iso_date(n.modified_ms);
+            s.push_str(&format!(
+                "[{label}] {date} — {title}\n",
+                title = n.title
+            ));
+        }
+    }
+
+    s.push_str(
+        "\n# Instructions\n\nReturn a JSON array matching the schema in the system prompt. \
+         Reuse an existing workstream id when the new items extend it; spawn a new one (id: null) \
+         only when no existing fit. Each action's source_label MUST be one of the labels above \
+         (M*/E*/N*). Output JSON only — no prose, no fences.\n",
+    );
+
+    (
+        s,
+        LabelMaps {
+            emails: email_map,
+            events: event_map,
+            notes: note_map,
+        },
+    )
+}
+
+fn email_body_excerpt(m: &email::EmailMessage) -> String {
+    let raw = m
+        .body_html
+        .as_deref()
+        .or(m.body_preview.as_deref())
+        .unwrap_or("");
+    if raw.is_empty() {
+        return String::new();
+    }
+    // Strip HTML tags + collapse whitespace. Keeps the prompt token-
+    // efficient without pulling in a full HTML parser; preview-only
+    // emails skip the strip logic.
+    let stripped = if raw.contains('<') {
+        strip_html(raw)
+    } else {
+        raw.to_string()
+    };
+    let collapsed = collapse_ws(&stripped);
+    let truncated: String = collapsed.chars().take(800).collect();
+    format!("    {}", truncated)
+}
+
+fn strip_html(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_tag = false;
+    for ch in s.chars() {
+        if ch == '<' {
+            in_tag = true;
+            continue;
+        }
+        if ch == '>' {
+            in_tag = false;
+            out.push(' ');
+            continue;
+        }
+        if !in_tag {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn collapse_ws(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut last_space = false;
+    for ch in s.chars() {
+        if ch.is_whitespace() {
+            if !last_space {
+                out.push(' ');
+                last_space = true;
+            }
+        } else {
+            out.push(ch);
+            last_space = false;
+        }
+    }
+    out.trim().to_string()
+}
+
+fn summarize_one_line(s: &str) -> String {
+    let collapsed = collapse_ws(s);
+    if collapsed.chars().count() <= 200 {
+        collapsed
+    } else {
+        let truncated: String = collapsed.chars().take(200).collect();
+        format!("{}…", truncated)
+    }
+}
+
+fn format_from(email: &str, name: Option<&str>) -> String {
+    match name {
+        Some(n) if !n.is_empty() => format!("{n} <{email}>"),
+        _ => email.to_string(),
+    }
+}
+
+fn format_iso_date(ms: i64) -> String {
+    DateTime::<Utc>::from_timestamp_millis(ms)
+        .map(|dt| dt.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn format_iso_datetime(ms: i64) -> String {
+    DateTime::<Utc>::from_timestamp_millis(ms)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+// ----- Response parsing ----------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct RawWorkstream {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    members: Option<RawMembers>,
+    #[serde(default)]
+    actions: Option<Vec<RawAction>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMembers {
+    #[serde(default)]
+    emails: Vec<String>,
+    #[serde(default)]
+    events: Vec<String>,
+    #[serde(default)]
+    notes: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawAction {
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    due_ms: Option<i64>,
+    #[serde(default)]
+    source_kind: Option<String>,
+    #[serde(default)]
+    source_label: Option<String>,
+}
+
+fn parse_synthesizer_response(
+    raw: &str,
+    label_maps: &LabelMaps,
+) -> Vec<SynthesizedWorkstream> {
+    let stripped = strip_json_fences(raw);
+    let parsed: Vec<RawWorkstream> = match serde_json::from_str(&stripped) {
+        Ok(v) => v,
+        Err(e) => {
+            let preview: String = stripped.chars().take(500).collect();
+            eprintln!("[workstreams] response parse failed: {e}; preview: {preview}");
+            return Vec::new();
+        }
+    };
+
+    let mut out = Vec::with_capacity(parsed.len());
+    let mut existing_ids: HashSet<String> = HashSet::new();
+    for raw in parsed {
+        let title = match raw.title.as_deref().map(str::trim) {
+            Some(t) if !t.is_empty() => t.to_string(),
+            _ => {
+                eprintln!("[workstreams] dropping workstream with empty title");
+                continue;
+            }
+        };
+        let summary = raw
+            .summary
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("")
+            .to_string();
+        let id = raw
+            .id
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty() && *s != "null")
+            .map(|s| s.to_string());
+        if let Some(ref existing) = id {
+            if !existing_ids.insert(existing.clone()) {
+                eprintln!("[workstreams] duplicate workstream id {existing} in response");
+            }
+        }
+
+        let members = raw.members.unwrap_or(RawMembers {
+            emails: Vec::new(),
+            events: Vec::new(),
+            notes: Vec::new(),
+        });
+
+        let member_emails =
+            map_labels(&members.emails, &label_maps.emails, "email");
+        let member_events =
+            map_labels(&members.events, &label_maps.events, "event");
+        let member_notes = map_labels(&members.notes, &label_maps.notes, "note");
+
+        let actions = raw
+            .actions
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|a| {
+                let text = match a.text.as_deref().map(str::trim) {
+                    Some(t) if !t.is_empty() => t.to_string(),
+                    _ => return None,
+                };
+                let kind = a.source_kind.unwrap_or_default();
+                let label = a.source_label.unwrap_or_default();
+                let source_id = match kind.as_str() {
+                    "email" => label_maps.emails.get(&label).cloned(),
+                    "event" => label_maps.events.get(&label).cloned(),
+                    "note" => label_maps.notes.get(&label).cloned(),
+                    _ => None,
+                };
+                let source_id = match source_id {
+                    Some(s) => s,
+                    None => {
+                        eprintln!(
+                            "[workstreams] dropping action with unknown label {label} kind {kind}: {text}"
+                        );
+                        return None;
+                    }
+                };
+                Some(SynthesizedAction {
+                    text,
+                    due_ms: a.due_ms,
+                    source_kind: kind,
+                    source_id,
+                })
+            })
+            .collect();
+
+        out.push(SynthesizedWorkstream {
+            id,
+            title,
+            summary,
+            member_emails,
+            member_events,
+            member_notes,
+            actions,
+        });
+    }
+    out
+}
+
+fn map_labels(
+    labels: &[String],
+    map: &HashMap<String, String>,
+    kind: &str,
+) -> Vec<String> {
+    let mut out = Vec::with_capacity(labels.len());
+    let mut seen = HashSet::new();
+    for label in labels {
+        match map.get(label.trim()) {
+            Some(id) => {
+                if seen.insert(id.clone()) {
+                    out.push(id.clone());
+                }
+            }
+            None => {
+                eprintln!("[workstreams] dropping unknown {kind} label {label}");
+            }
+        }
+    }
+    out
+}
+
+fn strip_json_fences(s: &str) -> String {
+    let trimmed = s.trim();
+    let without_fences = trimmed
+        .strip_prefix("```json")
+        .or_else(|| trimmed.strip_prefix("```"))
+        .unwrap_or(trimmed)
+        .trim_start();
+    let without_close = without_fences.strip_suffix("```").unwrap_or(without_fences);
+    without_close.trim().to_string()
+}
+
+// ----- Status events -------------------------------------------------------
+
+#[derive(Serialize, Clone)]
+struct StatusEvent<'a> {
+    state: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
+
+fn emit_status(app: &AppHandle, state: &str, message: Option<String>) {
+    let _ = app.emit("workstream-status", StatusEvent { state, message });
+}
+
+fn format_report_summary(r: &ClusterReport) -> String {
+    format!(
+        "+{}/~{} workstreams, +{}/~{} actions, {} items clustered",
+        r.workstreams_added,
+        r.workstreams_updated,
+        r.actions_added,
+        r.actions_updated,
+        r.items_clustered
+    )
+}
+
+fn current_unix_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+// ----- Tests ---------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn label_maps() -> LabelMaps {
+        let mut emails = HashMap::new();
+        emails.insert("M1".into(), "mg:test::msg-1".to_string());
+        emails.insert("M2".into(), "mg:test::msg-2".to_string());
+        let mut events = HashMap::new();
+        events.insert("E1".into(), "mg:test::ev-1".to_string());
+        let mut notes = HashMap::new();
+        notes.insert("N1".into(), "/notes/a.md".to_string());
+        LabelMaps { emails, events, notes }
+    }
+
+    #[test]
+    fn parse_synthesizer_response_handles_raw_json() {
+        let raw = r#"[
+            {
+                "id": null,
+                "title": "Hyundai POC",
+                "summary": "Final invoice + dismissals.",
+                "members": { "emails": ["M1","M2"], "events": ["E1"], "notes": ["N1"] },
+                "actions": [
+                    { "text": "Reply to invoice", "due_ms": null, "source_kind": "email", "source_label": "M1" }
+                ]
+            }
+        ]"#;
+        let parsed = parse_synthesizer_response(raw, &label_maps());
+        assert_eq!(parsed.len(), 1);
+        let ws = &parsed[0];
+        assert_eq!(ws.title, "Hyundai POC");
+        assert_eq!(ws.member_emails, vec!["mg:test::msg-1", "mg:test::msg-2"]);
+        assert_eq!(ws.member_events, vec!["mg:test::ev-1"]);
+        assert_eq!(ws.member_notes, vec!["/notes/a.md"]);
+        assert_eq!(ws.actions.len(), 1);
+        assert_eq!(ws.actions[0].source_id, "mg:test::msg-1");
+    }
+
+    #[test]
+    fn parse_synthesizer_response_handles_optional_json_fences() {
+        let raw = r#"```json
+        [{"title": "X", "summary": "y"}]
+        ```"#;
+        let parsed = parse_synthesizer_response(raw, &label_maps());
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].title, "X");
+
+        let raw2 = "```\n[{\"title\":\"Y\",\"summary\":\"z\"}]\n```";
+        let parsed2 = parse_synthesizer_response(raw2, &label_maps());
+        assert_eq!(parsed2.len(), 1);
+        assert_eq!(parsed2[0].title, "Y");
+    }
+
+    #[test]
+    fn parse_synthesizer_response_drops_unknown_label_refs() {
+        let raw = r#"[
+            {
+                "title": "Mixed",
+                "summary": "",
+                "members": { "emails": ["M1","M99"], "events": [], "notes": ["NX"] },
+                "actions": [
+                    { "text": "ok", "source_kind": "email", "source_label": "M1" },
+                    { "text": "drop", "source_kind": "email", "source_label": "M99" }
+                ]
+            }
+        ]"#;
+        let parsed = parse_synthesizer_response(raw, &label_maps());
+        assert_eq!(parsed.len(), 1);
+        // M1 keeps, M99 dropped.
+        assert_eq!(parsed[0].member_emails, vec!["mg:test::msg-1"]);
+        assert!(parsed[0].member_notes.is_empty(), "NX not in label map");
+        // Action whose source_label was unknown is dropped.
+        assert_eq!(parsed[0].actions.len(), 1);
+        assert_eq!(parsed[0].actions[0].text, "ok");
+    }
+
+    #[test]
+    fn parse_synthesizer_response_drops_empty_titles() {
+        let raw = r#"[
+            { "title": "  ", "summary": "" },
+            { "title": "Real", "summary": "" }
+        ]"#;
+        let parsed = parse_synthesizer_response(raw, &label_maps());
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].title, "Real");
+    }
+
+    #[test]
+    fn parse_synthesizer_response_returns_empty_on_malformed_json() {
+        let raw = "not json at all {{{ ";
+        let parsed = parse_synthesizer_response(raw, &label_maps());
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn strip_html_removes_tags_and_keeps_text() {
+        assert_eq!(strip_html("<p>hello <b>world</b></p>").trim(), "hello  world");
+    }
+
+    #[test]
+    fn collapse_ws_squashes_runs() {
+        assert_eq!(collapse_ws("  a   b\n\nc  "), "a b c");
+    }
+}

--- a/src/file.ts
+++ b/src/file.ts
@@ -484,6 +484,90 @@ export async function getEmailBody(messageId: string): Promise<string | null> {
   return invoke<string | null>("get_email_body", { messageId });
 }
 
+// ----- Workstreams (#70) ---------------------------------------------------
+
+export type WorkstreamStatus = "active" | "archived" | "snoozed";
+
+export type Workstream = {
+  id: string;
+  title: string;
+  summary: string;
+  status: WorkstreamStatus;
+  last_activity_ms: number;
+  created_ms: number;
+  updated_ms: number;
+  email_count: number;
+  event_count: number;
+  note_count: number;
+  open_action_count: number;
+};
+
+export type WorkstreamAction = {
+  id: string;
+  workstream_id: string;
+  text: string;
+  due_ms: number | null;
+  /** "email" | "event" | "note" */
+  source_kind: "email" | "event" | "note";
+  source_id: string;
+  done: boolean;
+  created_ms: number;
+};
+
+export type WorkstreamNoteRef = {
+  note_path: string;
+  title: string;
+  modified_ms: number;
+};
+
+export type WorkstreamDetail = Workstream & {
+  emails: EmailMessage[];
+  events: CalendarEvent[];
+  notes: WorkstreamNoteRef[];
+  actions: WorkstreamAction[];
+};
+
+export type ClusterReport = {
+  workstreams_added: number;
+  workstreams_updated: number;
+  actions_added: number;
+  actions_updated: number;
+  items_clustered: number;
+  model: string;
+  last_clustered_ms: number;
+  /** "synced" | "skipped" | "errored" | "clustering" */
+  state: string;
+};
+
+/** Trigger a synthesis pass. Honors a 6h stale window unless `force` is
+ *  true. Returns a no-op `ClusterReport { state: "skipped" }` when the
+ *  pass is suppressed by the stale check or by an in-flight call. */
+export async function synthesizeWorkstreams(force: boolean): Promise<ClusterReport> {
+  return invoke<ClusterReport>("synthesize_workstreams", { force });
+}
+
+export async function listWorkstreams(): Promise<Workstream[]> {
+  return invoke<Workstream[]>("list_workstreams");
+}
+
+export async function getWorkstreamDetails(id: string): Promise<WorkstreamDetail | null> {
+  return invoke<WorkstreamDetail | null>("get_workstream_details", { id });
+}
+
+export async function setWorkstreamActionDone(
+  actionId: string,
+  done: boolean,
+): Promise<void> {
+  await invoke<void>("set_workstream_action_done", { actionId, done });
+}
+
+export async function setWorkstreamStatus(
+  id: string,
+  status: WorkstreamStatus,
+): Promise<void> {
+  await invoke<void>("set_workstream_status", { id, status });
+}
+
 export type NoteMeta = { modified_ms: number };
 
 export async function noteMeta(notePath: string): Promise<NoteMeta> {


### PR DESCRIPTION
## Summary
- Claude-driven (Sonnet 4.6, single-shot JSON) clusters recent emails + events + notes into 3-15 named **workstreams** with action items
- Migration 012 adds `workstreams`, `workstream_emails`, `workstream_events`, `workstream_notes`, `workstream_actions` (schema → v12). `last_clustered_ms` stored in the existing `meta` table per migration 001 patterns
- New `workstreams/{mod,persist,synthesizer,commands}.rs` module
- Boot hook fires `maybe_cluster(false)` ~5s after launch; 6h TTL stale check + tokio `Mutex<()>` concurrency guard
- Lazy-fetches up to 100 missing email bodies per pass to improve clustering signal — bodies cached locally via the existing #69 layer
- 5 Tauri commands: `synthesize_workstreams`, `list_workstreams`, `get_workstream_details`, `set_workstream_action_done`, `set_workstream_status`
- Hash-based action ids (sha256 of `workstream_id\ntrim(text)`) keep re-runs idempotent and preserve user-set `done` flags

Second issue in [Connectors v2: Mail + Workstreams](https://github.com/tjruesch/margin/milestone/4). The data layer is callable end-to-end after this PR — Workstreams UI (#71) and AI ask integration (#72) consume what this lands.

## Notes
- Failure mode: log + bail, do **not** update `last_clustered_ms` so the next 6h tick (or manual Refresh from #71) retries automatically
- Anthropic constants (`ENDPOINT`, `ANTHROPIC_VERSION`, `DEFAULT_MODEL`) lifted to a tiny `anthropic.rs` module so `ask.rs` and the synthesizer stay in lockstep
- Workstreams the synthesizer doesn't return are deliberately left in place (better than auto-archiving on a Claude omission)
- `~$0.05 / pass` on Sonnet per the issue estimate; 6h TTL caps daily spend at ~$0.20 even with manual refreshes

## Test plan
- [x] `cargo check` clean
- [x] `bunx tsc --noEmit -p tsconfig.json` clean
- [x] `cargo test --lib workstreams::` — 16 new tests pass (persist round-trip, action_id stability, parser handling of fences / unknown labels / empty titles / malformed JSON)
- [x] Full `cargo test --lib` — 169 passing, no regressions
- [ ] Manual: with #69 emails populated, in DevTools `await invoke('synthesize_workstreams', { force: true })` → returns a `ClusterReport { state: 'synced', ... }`
- [ ] Manual: `sqlite3 ~/.margin/index.db "SELECT id, title, status FROM workstreams"` shows 3-15 rows
- [ ] Manual: toggle `set_workstream_action_done` → re-cluster → `done` flag survives