### PR TITLE
Workstreams UI (#71)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4514,3 +4514,323 @@ input.nh-title {
   color: var(--fg-muted);
   margin: 0 2px;
 }
+
+/* ----- Workstreams (#71) ------------------------------------------------- */
+
+.workstream-view {
+  padding: 22px 32px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.workstream-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 0.5px solid var(--home-line);
+  padding-bottom: 14px;
+}
+.workstream-detail-header {
+  align-items: center;
+  gap: 12px;
+}
+.workstream-title {
+  margin: 0;
+  font-family: "Fraunces", Georgia, serif;
+  font-size: 26px;
+  font-weight: 500;
+  font-variation-settings: "opsz" 144;
+  letter-spacing: -0.012em;
+  color: var(--fg);
+  flex: 1 1 auto;
+}
+.workstream-subtitle {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--fg-muted);
+}
+.workstream-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--fg-muted);
+  font: inherit;
+  font-size: 13px;
+  padding: 4px 8px;
+  border-radius: 6px;
+}
+.workstream-back:hover {
+  color: var(--accent);
+  background: var(--home-chip);
+}
+.workstream-status {
+  font: inherit;
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: var(--home-chip);
+  color: var(--fg);
+  border: 0.5px solid var(--home-line);
+  cursor: pointer;
+}
+.workstream-refresh {
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 14px;
+  border-radius: 6px;
+  background: var(--accent);
+  color: white;
+  border: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+.workstream-refresh:disabled {
+  background: var(--home-chip);
+  color: var(--fg-muted);
+  cursor: progress;
+}
+.workstream-spinner {
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: workstream-spin 0.7s linear infinite;
+}
+@keyframes workstream-spin {
+  to { transform: rotate(360deg); }
+}
+.workstream-toast {
+  padding: 8px 12px;
+  border-radius: 6px;
+  background: var(--home-chip);
+  color: var(--fg-muted);
+  font-size: 13px;
+}
+.workstream-empty {
+  padding: 30px 0;
+  text-align: center;
+  color: var(--fg-muted);
+  font-size: 13.5px;
+}
+.workstream-empty p {
+  margin: 4px 0;
+}
+
+.workstream-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.workstream-card {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: var(--bg-elev);
+  border: 0.5px solid var(--home-line);
+  border-radius: 8px;
+  padding: 14px 16px;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition: background 80ms ease, border-color 80ms ease;
+}
+.workstream-card:hover {
+  background: var(--home-chip);
+  border-color: var(--accent);
+}
+.workstream-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 4px;
+}
+.workstream-card-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.workstream-card-time {
+  font-size: 12px;
+  color: var(--fg-muted);
+  white-space: nowrap;
+}
+.workstream-card-summary {
+  margin: 4px 0 8px;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--fg-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.workstream-card-counts {
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+
+/* ----- Detail sections ----- */
+
+.workstream-detail-summary {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--fg);
+  margin: 0;
+}
+.workstream-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.workstream-section-title {
+  margin: 12px 0 4px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+/* Actions */
+.workstream-actions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.workstream-action-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 8px;
+  border-radius: 6px;
+}
+.workstream-action-row:hover {
+  background: var(--home-chip);
+}
+.workstream-action-row.is-done .workstream-action-check span {
+  text-decoration: line-through;
+  color: var(--fg-muted);
+}
+.workstream-action-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 13.5px;
+  color: var(--fg);
+  flex: 1 1 auto;
+}
+.workstream-action-source {
+  font-size: 11px;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+/* Emails */
+.workstream-emails,
+.workstream-meetings,
+.workstream-notes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.workstream-email-row,
+.workstream-meeting-row,
+.workstream-note-row {
+  display: grid;
+  grid-template-columns: 90px 160px 1fr auto;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 6px 8px;
+  border-radius: 6px;
+  font: inherit;
+  color: inherit;
+}
+.workstream-meeting-row {
+  grid-template-columns: 130px 1fr 220px;
+}
+.workstream-note-row {
+  grid-template-columns: 90px 1fr;
+}
+.workstream-email-row:hover,
+.workstream-meeting-row:hover,
+.workstream-note-row:hover {
+  background: var(--home-chip);
+}
+.workstream-email-date,
+.workstream-meeting-date,
+.workstream-note-date {
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+.workstream-email-from {
+  font-size: 13px;
+  color: var(--fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.workstream-email-subject,
+.workstream-meeting-title,
+.workstream-note-title {
+  font-size: 13px;
+  color: var(--fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.workstream-email-chev {
+  font-size: 11px;
+  color: var(--fg-muted);
+}
+.workstream-meeting-attendees {
+  font-size: 12px;
+  color: var(--fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: right;
+}
+.workstream-email-body {
+  margin: 4px 0 12px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  background: var(--bg-elev);
+  border: 0.5px solid var(--home-line);
+}
+.workstream-email-iframe {
+  width: 100%;
+  min-height: 240px;
+  border: none;
+  background: white;
+  border-radius: 4px;
+}
+.workstream-email-loading {
+  margin: 0;
+  font-size: 13px;
+  color: var(--fg-muted);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,8 +54,11 @@ import {
   shareNote,
   listActions,
   listTeamMembers,
+  listWorkstreams,
+  synthesizeWorkstreams,
   type ActionListItem,
   type TeamMember,
+  type Workstream,
   startMeetingRecording,
   stopMeetingRecording,
   transcribe,
@@ -295,6 +298,15 @@ export default function App() {
   const [notes, setNotes] = useState<NoteListItem[]>([]);
   const [notesLoading, setNotesLoading] = useState<boolean>(true);
   const [actions, setActions] = useState<ActionListItem[]>([]);
+  // Synthesized workstreams (#71). Populated by listWorkstreams on
+  // mount; refreshed when the synthesizer emits `workstream-status`.
+  const [workstreams, setWorkstreams] = useState<Workstream[]>([]);
+  const [workstreamsLoading, setWorkstreamsLoading] = useState<boolean>(true);
+  // True while a synthesis pass is in flight (set on Refresh click and
+  // by `workstream-status: clustering` events from the boot tick).
+  const [synthInFlight, setSynthInFlight] = useState<boolean>(false);
+  // Toast slot below the Workstreams header. Auto-clears after 4s.
+  const [synthMessage, setSynthMessage] = useState<string | null>(null);
   // Team members for the assignee-chip dropdown on action rows (#51).
   // Loaded once at mount and refreshed on `margin:nav` events so adds /
   // edits / deletes done on the Team page are reflected next time the
@@ -432,6 +444,37 @@ export default function App() {
       setActions(items);
     } catch (err) {
       console.error("listActions failed:", err);
+    }
+  }, []);
+
+  const refreshWorkstreams = useCallback(async () => {
+    try {
+      const items = await listWorkstreams();
+      setWorkstreams(items);
+    } catch (err) {
+      console.error("listWorkstreams failed:", err);
+    } finally {
+      setWorkstreamsLoading(false);
+    }
+  }, []);
+
+  const triggerSynthesize = useCallback(async () => {
+    setSynthInFlight(true);
+    setSynthMessage(null);
+    try {
+      const report = await synthesizeWorkstreams(true);
+      if (report.state === "skipped") {
+        // The TTL skip path doesn't fire `workstream-status: synced`,
+        // so reset the spinner here.
+        setSynthInFlight(false);
+        setSynthMessage("Already up to date");
+      }
+      // For state === "synced" / "errored", the workstream-status
+      // listener flips synthInFlight off and refetches.
+    } catch (e) {
+      console.error("synthesizeWorkstreams failed:", e);
+      setSynthInFlight(false);
+      setSynthMessage(`Synthesis failed: ${String(e)}`);
     }
   }, []);
 
@@ -1213,6 +1256,46 @@ export default function App() {
     };
   }, []);
 
+  // Workstream synthesizer status (#71). Boot tick fires this with
+  // state "clustering" → "synced" / "errored" / "skipped". The boot
+  // happens ~5s after launch, so this listener has to be installed
+  // mount-first to catch it.
+  useEffect(() => {
+    const unlisten = listen<{ state: string; message?: string }>(
+      "workstream-status",
+      (e) => {
+        const s = e.payload.state;
+        if (s === "clustering") {
+          setSynthInFlight(true);
+          return;
+        }
+        if (s === "synced" || s === "errored" || s === "skipped") {
+          setSynthInFlight(false);
+          if (s === "errored" && e.payload.message) {
+            setSynthMessage(`Synthesis failed: ${e.payload.message}`);
+          }
+          void refreshWorkstreams();
+        }
+      },
+    );
+    return () => {
+      unlisten.then((u) => u());
+    };
+  }, [refreshWorkstreams]);
+
+  // Auto-clear the workstream toast after 4s.
+  useEffect(() => {
+    if (!synthMessage) return;
+    const t = setTimeout(() => setSynthMessage(null), 4000);
+    return () => clearTimeout(t);
+  }, [synthMessage]);
+
+  // Initial load + refetch when nav lands on workstreams via custom
+  // event (mirrors the team refetch pattern at the same handler).
+  useEffect(() => {
+    void refreshWorkstreams();
+  }, [refreshWorkstreams]);
+
   const onReloadFromDisk = useCallback(async () => {
     if (!externalChange) return;
     try {
@@ -1889,6 +1972,11 @@ export default function App() {
             onReassignAction={onReassignAction}
             notifications={notifications}
             onMarkAllNotificationsRead={markNotificationsRead}
+            workstreams={workstreams}
+            workstreamsLoading={workstreamsLoading}
+            synthInFlight={synthInFlight}
+            synthMessage={synthMessage}
+            onRefreshWorkstreams={() => void triggerSynthesize()}
           />
         )}
       </main>

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -18,9 +18,11 @@ import { type NotificationRecord, unreadCount } from "./notifications";
 import { NotificationsPanel } from "./NotificationsPanel";
 import { SearchPalette } from "./SearchPalette";
 import { TeamView, type EditorSettings as TeamEditorSettings } from "./Team";
+import { WorkstreamsView } from "./Workstreams";
 import {
   IconArchive,
   IconBell,
+  IconBriefcase,
   IconCalendar,
   IconCheck,
   IconChecklist,
@@ -83,12 +85,20 @@ type Props = {
   /** Stamp `read_at` on every unread notification. Called when the
    *  user opens the panel. */
   onMarkAllNotificationsRead: () => void;
+  /** Synthesized workstreams (#71). Cards in the Workstreams view. */
+  workstreams: import("./file").Workstream[];
+  workstreamsLoading: boolean;
+  synthInFlight: boolean;
+  synthMessage: string | null;
+  /** Force a synthesis pass via `synthesize_workstreams(true)`. */
+  onRefreshWorkstreams: () => void;
 };
 
 type NavId =
   | "home"
   | "actions"
   | "meetings"
+  | "workstreams"
   | "shared"
   | "favorites"
   | "archive"
@@ -289,6 +299,11 @@ export function Home({
   onReassignAction,
   notifications,
   onMarkAllNotificationsRead,
+  workstreams,
+  workstreamsLoading,
+  synthInFlight,
+  synthMessage,
+  onRefreshWorkstreams,
 }: Props) {
   const [nav, setNav] = useState<NavId>(
     scope === "archived" ? "archive" : scope === "favorites" ? "favorites" : "home",
@@ -380,6 +395,7 @@ export function Home({
       "home",
       "actions",
       "meetings",
+      "workstreams",
       "shared",
       "favorites",
       "archive",
@@ -476,6 +492,7 @@ export function Home({
           onSelect={setNav}
           actionCount={openActionCount}
           meetingCount={upcoming.length}
+          workstreamCount={workstreams.filter((w) => w.open_action_count > 0).length}
           tags={allTags}
           activeTag={tagFilter}
           onTagSelect={(t) => setTagFilter(t === tagFilter ? null : t)}
@@ -538,6 +555,15 @@ export function Home({
             onToggleAction={onToggleAction}
             onReassignAction={onReassignAction}
           />
+        ) : nav === "workstreams" ? (
+          <WorkstreamsView
+            workstreams={workstreams}
+            loading={workstreamsLoading}
+            synthInFlight={synthInFlight}
+            synthMessage={synthMessage}
+            onRefresh={onRefreshWorkstreams}
+            onOpenNote={onOpen}
+          />
         ) : nav === "actions" ? (
           <ActionsFeed
             actions={actions}
@@ -590,6 +616,7 @@ function Sidebar({
   onSelect,
   actionCount,
   meetingCount,
+  workstreamCount,
   tags,
   activeTag,
   onTagSelect,
@@ -600,6 +627,7 @@ function Sidebar({
   onSelect: (id: NavId) => void;
   actionCount: number;
   meetingCount: number;
+  workstreamCount: number;
   tags: string[];
   activeTag: string | null;
   onTagSelect: (tag: string) => void;
@@ -644,6 +672,13 @@ function Sidebar({
           badge={meetingCount > 0 ? String(meetingCount) : null}
           active={active === "meetings"}
           onClick={() => onSelect("meetings")}
+        />
+        <NavItem
+          icon={<IconBriefcase size={14} sw={1.7} />}
+          label="Workstreams"
+          badge={workstreamCount > 0 ? String(workstreamCount) : null}
+          active={active === "workstreams"}
+          onClick={() => onSelect("workstreams")}
         />
         <NavItem
           icon={<IconUser size={14} sw={1.7} />}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -546,7 +546,9 @@ export function Home({
           onNewMeeting={onNewMeeting}
         />
 
-        {upcoming.length > 0 && <UpcomingStrip events={upcoming} onOpen={openEventNote} />}
+        {nav !== "workstreams" && upcoming.length > 0 && (
+          <UpcomingStrip events={upcoming} onOpen={openEventNote} />
+        )}
 
         {nav === "team" ? (
           <TeamView

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -1,0 +1,576 @@
+//! Workstreams view (#71).
+//!
+//! Sidebar nav target. List of synthesized workstreams as cards;
+//! click → detail view with sections for actions, emails, meetings,
+//! notes. Refresh button forces a synthesis pass via the boot
+//! pipeline added in #70 and listens for `workstream-status` to
+//! refetch.
+
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  type EmailMessage,
+  type Workstream,
+  type WorkstreamAction,
+  type WorkstreamDetail,
+  type WorkstreamStatus,
+  getEmailBody,
+  getWorkstreamDetails,
+  openOrCreateEventNote,
+  setWorkstreamActionDone,
+  setWorkstreamStatus,
+} from "./file";
+import { IconChevLeft } from "./icons";
+
+// ----- List view -----------------------------------------------------------
+
+export function WorkstreamsView({
+  workstreams,
+  loading,
+  synthInFlight,
+  synthMessage,
+  onRefresh,
+  onOpenNote,
+}: {
+  workstreams: Workstream[];
+  loading: boolean;
+  synthInFlight: boolean;
+  synthMessage: string | null;
+  onRefresh: () => void;
+  onOpenNote: (path: string) => void;
+}) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  if (selectedId) {
+    return (
+      <WorkstreamDetailView
+        id={selectedId}
+        onBack={() => setSelectedId(null)}
+        onOpenNote={onOpenNote}
+      />
+    );
+  }
+
+  const nowMs = Date.now();
+
+  return (
+    <div className="workstream-view">
+      <header className="workstream-header">
+        <div>
+          <h1 className="workstream-title">Workstreams</h1>
+          <p className="workstream-subtitle">
+            Ongoing efforts synthesized from emails, meetings, and notes.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="workstream-refresh"
+          onClick={onRefresh}
+          disabled={synthInFlight}
+        >
+          {synthInFlight ? (
+            <>
+              <span className="workstream-spinner" aria-hidden />
+              Synthesizing…
+            </>
+          ) : (
+            "Refresh"
+          )}
+        </button>
+      </header>
+
+      {synthMessage ? (
+        <div className="workstream-toast" role="status">
+          {synthMessage}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <p className="home-empty">Loading…</p>
+      ) : workstreams.length === 0 ? (
+        <div className="workstream-empty">
+          <p>No workstreams yet.</p>
+          <p>
+            Connect Microsoft in Settings to ingest your inbox and calendar,
+            then click Refresh to synthesize.
+          </p>
+        </div>
+      ) : (
+        <div className="workstream-list">
+          {workstreams.map((w) => (
+            <button
+              type="button"
+              key={w.id}
+              className="workstream-card"
+              onClick={() => setSelectedId(w.id)}
+            >
+              <div className="workstream-card-head">
+                <span className="workstream-card-title">{w.title}</span>
+                <span className="workstream-card-time">
+                  {formatPast(w.last_activity_ms, nowMs)}
+                </span>
+              </div>
+              <p className="workstream-card-summary">{w.summary}</p>
+              <div className="workstream-card-counts">
+                {countLine(w)}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function countLine(w: Workstream): string {
+  const parts: string[] = [];
+  if (w.open_action_count > 0)
+    parts.push(plural(w.open_action_count, "open action", "open actions"));
+  if (w.email_count > 0) parts.push(plural(w.email_count, "email", "emails"));
+  if (w.event_count > 0)
+    parts.push(plural(w.event_count, "meeting", "meetings"));
+  if (w.note_count > 0) parts.push(plural(w.note_count, "note", "notes"));
+  return parts.length ? parts.join(" · ") : "No items yet";
+}
+
+function plural(n: number, singular: string, plural_: string): string {
+  return `${n} ${n === 1 ? singular : plural_}`;
+}
+
+// ----- Detail view ---------------------------------------------------------
+
+function WorkstreamDetailView({
+  id,
+  onBack,
+  onOpenNote,
+}: {
+  id: string;
+  onBack: () => void;
+  onOpenNote: (path: string) => void;
+}) {
+  const [detail, setDetail] = useState<WorkstreamDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [missing, setMissing] = useState(false);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    try {
+      const d = await getWorkstreamDetails(id);
+      if (!d) {
+        setMissing(true);
+        setDetail(null);
+      } else {
+        setMissing(false);
+        setDetail(d);
+      }
+    } catch (e) {
+      console.error("[workstreams] detail fetch failed", e);
+      setMissing(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  // Optimistic update for action toggle. On error, revert and refetch
+  // to reconcile.
+  const onToggleAction = useCallback(
+    async (actionId: string, nextDone: boolean) => {
+      setDetail((d) => {
+        if (!d) return d;
+        return {
+          ...d,
+          actions: d.actions.map((a) =>
+            a.id === actionId ? { ...a, done: nextDone } : a,
+          ),
+        };
+      });
+      try {
+        await setWorkstreamActionDone(actionId, nextDone);
+      } catch (e) {
+        console.error("[workstreams] toggle action failed", e);
+        await reload();
+      }
+    },
+    [reload],
+  );
+
+  const onChangeStatus = useCallback(
+    async (status: WorkstreamStatus) => {
+      try {
+        await setWorkstreamStatus(id, status);
+        if (status !== "active") {
+          // Archived/snoozed workstreams drop off the list, so go back.
+          onBack();
+        } else {
+          await reload();
+        }
+      } catch (e) {
+        console.error("[workstreams] set status failed", e);
+        await reload();
+      }
+    },
+    [id, onBack, reload],
+  );
+
+  const onOpenEvent = useCallback(
+    async (eventId: string) => {
+      try {
+        const path = await openOrCreateEventNote(eventId);
+        onOpenNote(path);
+      } catch (e) {
+        console.error("[workstreams] open event note failed", e);
+      }
+    },
+    [onOpenNote],
+  );
+
+  if (loading && !detail) {
+    return (
+      <div className="workstream-view">
+        <DetailHeader title="" onBack={onBack} status={null} onChangeStatus={() => {}} />
+        <p className="home-empty">Loading…</p>
+      </div>
+    );
+  }
+  if (missing || !detail) {
+    return (
+      <div className="workstream-view">
+        <DetailHeader title="Workstream" onBack={onBack} status={null} onChangeStatus={() => {}} />
+        <p className="home-empty">Workstream not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="workstream-view">
+      <DetailHeader
+        title={detail.title}
+        onBack={onBack}
+        status={detail.status}
+        onChangeStatus={onChangeStatus}
+      />
+      <p className="workstream-detail-summary">{detail.summary}</p>
+
+      <ActionsSection actions={detail.actions} onToggle={onToggleAction} />
+
+      <EmailsSection emails={detail.emails} />
+
+      <MeetingsSection
+        events={detail.events}
+        onOpenEvent={onOpenEvent}
+      />
+
+      <NotesSection notes={detail.notes} onOpenNote={onOpenNote} />
+    </div>
+  );
+}
+
+function DetailHeader({
+  title,
+  onBack,
+  status,
+  onChangeStatus,
+}: {
+  title: string;
+  onBack: () => void;
+  status: WorkstreamStatus | null;
+  onChangeStatus: (s: WorkstreamStatus) => void | Promise<void>;
+}) {
+  return (
+    <header className="workstream-header workstream-detail-header">
+      <button
+        type="button"
+        className="workstream-back"
+        onClick={onBack}
+        aria-label="Back to workstreams"
+      >
+        <IconChevLeft size={20} />
+        Back
+      </button>
+      <h1 className="workstream-title">{title}</h1>
+      {status ? (
+        <select
+          className="workstream-status"
+          value={status}
+          onChange={(e) => onChangeStatus(e.target.value as WorkstreamStatus)}
+          aria-label="Workstream status"
+        >
+          <option value="active">Active</option>
+          <option value="snoozed">Snoozed</option>
+          <option value="archived">Archived</option>
+        </select>
+      ) : null}
+    </header>
+  );
+}
+
+// ----- Sections ------------------------------------------------------------
+
+function ActionsSection({
+  actions,
+  onToggle,
+}: {
+  actions: WorkstreamAction[];
+  onToggle: (actionId: string, nextDone: boolean) => void | Promise<void>;
+}) {
+  if (actions.length === 0) return null;
+  return (
+    <section className="workstream-section">
+      <h2 className="workstream-section-title">Actions ({actions.length})</h2>
+      <ul className="workstream-actions">
+        {actions.map((a) => (
+          <li
+            key={a.id}
+            className={`workstream-action-row ${a.done ? "is-done" : ""}`}
+          >
+            <label className="workstream-action-check">
+              <input
+                type="checkbox"
+                checked={a.done}
+                onChange={(e) => onToggle(a.id, e.target.checked)}
+              />
+              <span>{a.text}</span>
+            </label>
+            <span className="workstream-action-source">
+              from {a.source_kind}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function EmailsSection({ emails }: { emails: EmailMessage[] }) {
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const [bodies, setBodies] = useState<Record<string, BodyState>>({});
+
+  if (emails.length === 0) return null;
+
+  const toggle = async (m: EmailMessage) => {
+    const isOpen = !!expanded[m.id];
+    setExpanded({ ...expanded, [m.id]: !isOpen });
+    if (isOpen) return;
+    if (bodies[m.id]) return; // already loaded or loading
+
+    if (m.body_html) {
+      setBodies((b) => ({ ...b, [m.id]: { kind: "loaded", html: m.body_html! } }));
+      return;
+    }
+    setBodies((b) => ({ ...b, [m.id]: { kind: "loading" } }));
+    try {
+      const html = await getEmailBody(m.id);
+      if (html) {
+        setBodies((b) => ({ ...b, [m.id]: { kind: "loaded", html } }));
+      } else {
+        setBodies((b) => ({
+          ...b,
+          [m.id]: { kind: "empty" },
+        }));
+      }
+    } catch (e) {
+      console.error("[workstreams] email body fetch failed", e);
+      setBodies((b) => ({
+        ...b,
+        [m.id]: { kind: "error" },
+      }));
+    }
+  };
+
+  return (
+    <section className="workstream-section">
+      <h2 className="workstream-section-title">Emails ({emails.length})</h2>
+      <ul className="workstream-emails">
+        {emails.map((m) => {
+          const open = !!expanded[m.id];
+          const body = bodies[m.id];
+          const date = formatShortDate(m.sent_at_ms);
+          const fromLabel = m.from_name || m.from_email;
+          return (
+            <li key={m.id} className="workstream-email">
+              <button
+                type="button"
+                className="workstream-email-row"
+                onClick={() => void toggle(m)}
+                aria-expanded={open}
+              >
+                <span className="workstream-email-date">{date}</span>
+                <span className="workstream-email-from">{fromLabel}</span>
+                <span className="workstream-email-subject">{m.subject}</span>
+                <span className="workstream-email-chev">{open ? "▾" : "▸"}</span>
+              </button>
+              {open ? (
+                <div className="workstream-email-body">
+                  <EmailBodyPanel body={body} fallbackPreview={m.body_preview} />
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+type BodyState =
+  | { kind: "loading" }
+  | { kind: "loaded"; html: string }
+  | { kind: "empty" }
+  | { kind: "error" };
+
+function EmailBodyPanel({
+  body,
+  fallbackPreview,
+}: {
+  body: BodyState | undefined;
+  fallbackPreview: string | null;
+}) {
+  if (!body || body.kind === "loading") {
+    return <p className="workstream-email-loading">Loading…</p>;
+  }
+  if (body.kind === "loaded") {
+    // Render in a sandboxed iframe so any leftover script in the
+    // email's HTML can't reach Margin's main DOM. `allow-scripts` is
+    // deliberately omitted; outbound links are dead-ends in v1.
+    return (
+      <iframe
+        title="Email body"
+        className="workstream-email-iframe"
+        sandbox="allow-same-origin"
+        srcDoc={body.html}
+      />
+    );
+  }
+  if (body.kind === "error") {
+    return (
+      <p className="workstream-email-loading">
+        Couldn't load email body — it may have been deleted.
+        {fallbackPreview ? (
+          <>
+            <br />
+            <span>Preview: {fallbackPreview}</span>
+          </>
+        ) : null}
+      </p>
+    );
+  }
+  // empty
+  return (
+    <p className="workstream-email-loading">
+      {fallbackPreview ?? "(no body)"}
+    </p>
+  );
+}
+
+function MeetingsSection({
+  events,
+  onOpenEvent,
+}: {
+  events: WorkstreamDetail["events"];
+  onOpenEvent: (eventId: string) => void | Promise<void>;
+}) {
+  if (events.length === 0) return null;
+  return (
+    <section className="workstream-section">
+      <h2 className="workstream-section-title">Meetings ({events.length})</h2>
+      <ul className="workstream-meetings">
+        {events.map((e) => (
+          <li key={e.id}>
+            <button
+              type="button"
+              className="workstream-meeting-row"
+              onClick={() => void onOpenEvent(e.id)}
+            >
+              <span className="workstream-meeting-date">
+                {formatShortDateTime(e.start_ms)}
+              </span>
+              <span className="workstream-meeting-title">{e.title}</span>
+              {e.attendees.length > 0 ? (
+                <span className="workstream-meeting-attendees">
+                  {e.attendees
+                    .slice(0, 4)
+                    .map((a) => a.display_name || a.email)
+                    .join(", ")}
+                  {e.attendees.length > 4
+                    ? ` +${e.attendees.length - 4}`
+                    : ""}
+                </span>
+              ) : null}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function NotesSection({
+  notes,
+  onOpenNote,
+}: {
+  notes: WorkstreamDetail["notes"];
+  onOpenNote: (path: string) => void;
+}) {
+  if (notes.length === 0) return null;
+  return (
+    <section className="workstream-section">
+      <h2 className="workstream-section-title">Notes ({notes.length})</h2>
+      <ul className="workstream-notes">
+        {notes.map((n) => (
+          <li key={n.note_path}>
+            <button
+              type="button"
+              className="workstream-note-row"
+              onClick={() => onOpenNote(n.note_path)}
+            >
+              <span className="workstream-note-date">
+                {formatShortDate(n.modified_ms)}
+              </span>
+              <span className="workstream-note-title">
+                {n.title || n.note_path}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+// ----- Time helpers --------------------------------------------------------
+
+function formatPast(ms: number, nowMs: number): string {
+  const delta = nowMs - ms;
+  if (delta < 60_000) return "just now";
+  const min = Math.floor(delta / 60_000);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const days = Math.floor(hr / 24);
+  if (days === 1) return "yesterday";
+  if (days < 7) return `${days}d ago`;
+  return formatShortDate(ms);
+}
+
+function formatShortDate(ms: number): string {
+  if (!ms) return "";
+  return new Intl.DateTimeFormat([], {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(ms));
+}
+
+function formatShortDateTime(ms: number): string {
+  if (!ms) return "";
+  return new Intl.DateTimeFormat([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(ms));
+}
+

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -70,6 +70,13 @@ export const IconLink = (p: Props) => (
     <path d="M14 10a4 4 0 00-5.6 0l-3 3a4 4 0 105.6 5.6l1-1" />
   </Icon>
 );
+export const IconBriefcase = (p: Props) => (
+  <Icon {...p}>
+    <rect x="3" y="7" width="18" height="13" rx="2" />
+    <path d="M9 7V5a2 2 0 012-2h2a2 2 0 012 2v2" />
+    <path d="M3 12h18" />
+  </Icon>
+);
 export const IconMore = (p: Props) => (
   <Icon {...p}>
     <circle cx="5" cy="12" r="1.2" />


### PR DESCRIPTION
## Summary
- New "Workstreams" sidebar nav item between Action items and Meetings, with `IconBriefcase` and a count badge for workstreams with at least one open action
- New `src/Workstreams.tsx` — list view (cards sorted by `last_activity_ms`) and detail view (in-place toggle following the `Team.tsx` pattern) with sections for actions, emails, meetings, and notes
- Action checkboxes round-trip through `setWorkstreamActionDone` with optimistic local updates
- Email rows expand inline; bodies are lazy-fetched via `getEmailBody` and rendered inside a sandboxed iframe (`sandbox="allow-same-origin"` only — no scripts)
- Meeting rows route through `openOrCreateEventNote` (existing #62 path); note rows use the standard `onOpen`
- Status pill cycles between active / archived / snoozed via `setWorkstreamStatus`
- Refresh button triggers `synthesizeWorkstreams(true)`, disables with a spinner while syncing, and shows an "Already up to date" toast when the 6h TTL skips a pass
- App-level listener for `workstream-status` event flips the spinner off and refetches when the boot pipeline finishes

Third issue in [Connectors v2: Mail + Workstreams](https://github.com/tjruesch/margin/milestone/4). Only #72 (AI ask `[W*]` citation surface + `read_workstream` tool) remains in the milestone.

## Notes
- No new Tauri commands — everything wires onto the surface area shipped in #69 + #70
- No frontend tests; matches existing project convention (no UI test infra in repo)
- Email body iframe deliberately omits `allow-scripts` — outbound links are dead-ends in v1, which is fine

## Test plan
- [x] `bunx tsc --noEmit -p tsconfig.json` clean
- [x] Dev server hot-reload picks up changes cleanly
- [ ] Manual: open the app → Workstreams nav item visible → click → list of cards from existing data
- [ ] Manual: click a card → detail view shows actions/emails/meetings/notes sections
- [ ] Manual: toggle an action checkbox → optimistic flip, persisted (verify by reloading)
- [ ] Manual: click an email row (after Microsoft is reconnected with Mail.Read) → body expands inline; second click on the same row reuses the cached body
- [ ] Manual: click Refresh → button disables + shows spinner → on completion, list refreshes
- [ ] Manual: click Refresh again immediately → "Already up to date" toast
- [ ] Manual: change a workstream's Status to "archived" → returns to list; archived row no longer present