### PR TITLE
AI ask: workstreams as citable context + read_workstream tool (#72)

### DIFF
--- a/src-tauri/src/ask.rs
+++ b/src-tauri/src/ask.rs
@@ -61,6 +61,14 @@ const SCHEDULE_FORWARD_MS: i64 = 14 * 24 * 3600 * 1000;
 const SCHEDULE_CAP: usize = 50;
 /// Per-event description cap when fetched via `read_event_details`.
 const EVENT_DESCRIPTION_CAP: usize = 1500;
+/// Hard cap on synthesized workstreams embedded in the prompt (#72).
+/// Recency-prioritized via `last_activity_ms desc`.
+const WORKSTREAM_CAP: usize = 30;
+/// Per-category top-N when expanding a workstream via `read_workstream`
+/// (emails / events / notes returned per call).
+const WORKSTREAM_DETAIL_TOP_N: usize = 5;
+/// Per-workstream summary cap when listed in the prompt section.
+const WORKSTREAM_SUMMARY_CAP: usize = 200;
 
 /// Emitted on the unified `ai-stream` channel. The frontend filters by
 /// `turn_id` so a stale stream that arrives after the user navigates
@@ -115,13 +123,15 @@ enum StreamEvent {
 }
 
 /// Discriminator for citation sources. Notes use `[N]` labels (e.g.
-/// `[3]`); events use `[E<N>]` labels (e.g. `[E2]`). The frontend
-/// picks chip styling and click destination based on this.
+/// `[3]`); events use `[E<N>]` labels (e.g. `[E2]`); workstreams use
+/// `[W<N>]` (e.g. `[W2]`). The frontend picks chip styling and click
+/// destination based on this.
 #[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AskSourceKind {
     Note,
     Event,
+    Workstream,
 }
 
 /// One source the model can cite. The full directory of notes plus
@@ -148,6 +158,10 @@ pub struct AskSource {
     /// `openOrCreateEventNote(event_id)` on chip click (#62).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_id: Option<String>,
+    /// Set when `kind == Workstream`. Frontend dispatches a
+    /// `margin:open-workstream` event with this id on chip click (#72).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workstream_id: Option<String>,
 }
 
 /// One past turn in the conversation, threaded back to the model.
@@ -162,7 +176,7 @@ pub struct ChatTurn {
 const SYSTEM_PROMPT: &str = "You are answering questions about the user's personal notes (meeting \
 notes, hand-typed notes, transcripts), their team profiles, and their calendar.
 
-The user's message contains four sections:
+The user's message contains up to five sections:
 
 1. **Notes directory** — every non-archived note, labeled `[1]`, `[2]`, etc., with title, date, and \
 a short preview. This is the master index; you may cite *any* `[N]` from this directory.
@@ -174,13 +188,19 @@ that came from a body, cite the directory `[N]`.
 3. **Team profiles** — short bios for each colleague: display name, aliases, role, profile text. \
 Use these to interpret references to people in the notes (e.g. \"Heike\" maps to a known team \
 member). You may cite directly attributable claims from a profile by the person's name in prose; \
-profiles aren't `[N]`-citable — only notes and events are.
+profiles aren't `[N]`-citable — only notes, events, and workstreams are.
 
 4. **Schedule** — calendar events from connected Microsoft / Google accounts, labeled `[E1]`, \
 `[E2]`, etc., covering the last 14 days and the next 14 days. Each entry: title, time range, \
 attendees, location. Cite events with their `[E<N>]` label inline, same shape as note `[N]`s.
 
-You have three tools for digging deeper:
+5. **Workstreams** — synthesized clusters of related emails, meetings, and notes labeled `[W1]`, \
+`[W2]`, etc. Each entry has a title, one-line summary, and item counts. Workstreams are the right \
+citation when the answer IS the ongoing thread itself (\"how's the Hyundai POC going?\"); when \
+citing a *specific* item within a workstream, prefer the underlying `[N]` / `[E<N>]` label if one \
+is available.
+
+You have four tools for digging deeper:
 - **`read_note(n)`** — returns the full markdown body of directory entry `[n]`. Use when a preview \
 hints at relevance but you need the body to answer.
 - **`read_transcript(n)`** — returns the meeting transcript text for `[n]`, if it has audio. Use \
@@ -188,6 +208,10 @@ when the question is likely about something said in a meeting but not captured i
 - **`read_event_details(n)`** — returns the full attendee list, description, location, and exact \
 times for event `[E<n>]`. Use when answering questions about meeting participants or content. \
 Pass the integer after the `E` as `n` (e.g. for `[E3]` call `read_event_details(3)`).
+- **`read_workstream(n)`** — returns the workstream's full summary, all open + recently completed \
+actions, and the most recent emails / events / notes that belong to it. Use for status questions \
+(\"what's happening with X?\"). Pass the integer after the `W` as `n` (e.g. for `[W2]` call \
+`read_workstream(2)`).
 
 Use tools sparingly — most questions can be answered from the directory + top candidates + schedule \
 already in context. Don't speculate; call a tool if you genuinely need the content. Up to 6 tool \
@@ -196,9 +220,9 @@ calls per question; after that you must answer with what you have.
 Rules:
 - Answer in natural prose. Be specific and concise — 1-4 short paragraphs unless the question asks \
 for a list.
-- Cite sources inline with `[N]` (notes) or `[E<N>]` (events) immediately after each claim that \
-came from one. Multiple citations: `[1][3]` or `[E1][E2]` or mixed `[3][E2]`. Never make up \
-citation labels — only use ones you actually received.
+- Cite sources inline with `[N]` (notes), `[E<N>]` (events), or `[W<N>]` (workstreams) \
+immediately after each claim that came from one. Multiple citations: `[1][3]` or `[E1][E2]` or \
+`[W2][N1]` or any mix. Never make up citation labels — only use ones you actually received.
 - For \"when did we first…\" questions, identify the *earliest* dated note that matches and cite it.
 - If neither the notes nor the profiles nor the schedule contain the answer, say so clearly. \
 Don't speculate.
@@ -222,11 +246,11 @@ pub async fn start(
     })?;
 
     // Pull the all-notes directory + retrieval set + team roster +
-    // schedule window in one lock. Profile.md content is read off-lock
-    // below.
+    // schedule window + active workstreams in one lock. Profile.md
+    // content is read off-lock below.
     let conn_state = app.state::<std::sync::Mutex<rusqlite::Connection>>();
     let now_ms = current_unix_ms();
-    let (directory, retrieved_paths, team, schedule) = {
+    let (directory, retrieved_paths, team, schedule, workstreams) = {
         let c = conn_state.lock().map_err(|e| e.to_string())?;
         let directory = crate::index::list_directory(&c, DIRECTORY_CAP)
             .map_err(|e| e.to_string())?;
@@ -243,13 +267,17 @@ pub async fn start(
         )
         .map_err(|e| e.to_string())?;
         schedule.truncate(SCHEDULE_CAP);
-        (directory, retrieved_paths, team, schedule)
+        let mut workstreams =
+            crate::workstreams::persist::list_workstreams_active(&c).unwrap_or_default();
+        workstreams.truncate(WORKSTREAM_CAP);
+        (directory, retrieved_paths, team, schedule, workstreams)
     };
 
     // Build the citation surface: every directory entry gets a 1-based
-    // [N] label, every schedule entry gets an [E<N>] label.
+    // [N] label, every schedule entry gets an [E<N>] label, every
+    // workstream gets a [W<N>] label.
     let mut sources: Vec<AskSource> =
-        Vec::with_capacity(directory.len() + schedule.len());
+        Vec::with_capacity(directory.len() + schedule.len() + workstreams.len());
     for (i, e) in directory.iter().enumerate() {
         sources.push(AskSource {
             kind: AskSourceKind::Note,
@@ -257,6 +285,7 @@ pub async fn start(
             note_path: Some(e.note_path.clone()),
             bundle_id: Some(e.bundle_id.clone()),
             event_id: None,
+            workstream_id: None,
             title: e.title.clone(),
             modified_ms: e.modified_ms,
         });
@@ -268,8 +297,21 @@ pub async fn start(
             note_path: e.linked_note_path.clone(),
             bundle_id: None,
             event_id: Some(e.id.clone()),
+            workstream_id: None,
             title: e.title.clone(),
             modified_ms: e.start_ms,
+        });
+    }
+    for (i, w) in workstreams.iter().enumerate() {
+        sources.push(AskSource {
+            kind: AskSourceKind::Workstream,
+            label: format!("W{}", i + 1),
+            note_path: None,
+            bundle_id: None,
+            event_id: None,
+            workstream_id: Some(w.id.clone()),
+            title: w.title.clone(),
+            modified_ms: w.last_activity_ms,
         });
     }
 
@@ -328,6 +370,7 @@ pub async fn start(
         &retrieved_paths,
         &profile_excerpts,
         &schedule,
+        &workstreams,
     );
 
     // Compose `messages[]`: prior history first, then this turn's user
@@ -365,6 +408,7 @@ pub async fn start(
             messages,
             &directory,
             &schedule,
+            &workstreams,
         )
         .await
         {
@@ -451,6 +495,7 @@ async fn run_loop(
     mut messages: Vec<ApiMessage>,
     directory: &[DirectoryEntry],
     schedule: &[crate::connectors::calendar::CalendarEvent],
+    workstreams: &[crate::workstreams::Workstream],
 ) -> Result<(), String> {
     let tools = tool_definitions();
 
@@ -503,6 +548,14 @@ async fn run_loop(
                     format!("E{}", target_n),
                     AskSourceKind::Event,
                 ),
+                "read_workstream" => (
+                    workstreams
+                        .get(idx)
+                        .map(|w| w.title.clone())
+                        .unwrap_or_default(),
+                    format!("W{}", target_n),
+                    AskSourceKind::Workstream,
+                ),
                 _ => (
                     directory.get(idx).map(|e| e.title.clone()).unwrap_or_default(),
                     target_n.to_string(),
@@ -523,7 +576,7 @@ async fn run_loop(
                 },
             );
 
-            let result = dispatch_tool(&tc.name, &tc.input, directory, schedule);
+            let result = dispatch_tool(app, &tc.name, &tc.input, directory, schedule, workstreams);
 
             let _ = app.emit(
                 "ai-stream",
@@ -615,6 +668,21 @@ fn tool_definitions() -> serde_json::Value {
                         "type": "integer",
                         "minimum": 1,
                         "description": "The 1-based [E<N>] label from the Schedule section."
+                    }
+                },
+                "required": ["n"]
+            }
+        },
+        {
+            "name": "read_workstream",
+            "description": "Read the full details of a workstream by its label [W<N>]. Returns the summary, all open and recently completed actions, and the most recent emails / events / notes that belong to this workstream. Use when the user is asking about ongoing work, status updates, or 'what's happening with X'. NOTE: the `n` argument is the integer after the `W` (e.g. for `[W3]` pass `n: 3`).",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "n": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "The 1-based [W<N>] label from the Workstreams section."
                     }
                 },
                 "required": ["n"]
@@ -890,10 +958,12 @@ struct ToolResult {
 /// `is_error: true` results so the model sees them and can recover
 /// rather than the whole turn aborting.
 fn dispatch_tool(
+    app: &AppHandle,
     name: &str,
     input: &serde_json::Value,
     directory: &[DirectoryEntry],
     schedule: &[crate::connectors::calendar::CalendarEvent],
+    workstreams: &[crate::workstreams::Workstream],
 ) -> ToolResult {
     let n = match input.get("n").and_then(|v| v.as_u64()) {
         Some(v) if v >= 1 => v as usize,
@@ -910,6 +980,11 @@ fn dispatch_tool(
     // event call gives the model a useful error.
     if name == "read_event_details" {
         return dispatch_read_event_details(n, schedule);
+    }
+    // read_workstream indexes the workstreams slice; needs the conn
+    // mutex to load the joined detail.
+    if name == "read_workstream" {
+        return dispatch_read_workstream(app, n, workstreams);
     }
 
     if n > directory.len() {
@@ -1008,10 +1083,190 @@ fn dispatch_tool(
             }
         }
         _ => ToolResult {
-            content: format!("Unknown tool: {name}. Available tools: read_note, read_transcript, read_event_details."),
+            content: format!("Unknown tool: {name}. Available tools: read_note, read_transcript, read_event_details, read_workstream."),
             is_error: true,
         },
     }
+}
+
+/// Format a single workstream into a structured text block the model
+/// can quote from. Includes the summary, all actions (open + recently
+/// completed), and the top-N most recent items per category.
+fn dispatch_read_workstream(
+    app: &AppHandle,
+    n: usize,
+    workstreams: &[crate::workstreams::Workstream],
+) -> ToolResult {
+    if n > workstreams.len() {
+        return ToolResult {
+            content: format!(
+                "[W{n}] is out of range. Workstreams section has {len} entries — valid range is [W1]..[W{len}].",
+                n = n,
+                len = workstreams.len()
+            ),
+            is_error: true,
+        };
+    }
+    let ws = &workstreams[n - 1];
+    let label = format!("W{n}");
+
+    let detail = {
+        let conn_state = app.state::<std::sync::Mutex<rusqlite::Connection>>();
+        let c = match conn_state.lock() {
+            Ok(g) => g,
+            Err(e) => {
+                return ToolResult {
+                    content: format!("[{label}] could not be loaded — db lock: {e}"),
+                    is_error: true,
+                };
+            }
+        };
+        match crate::workstreams::persist::get_workstream_detail(&c, &ws.id) {
+            Ok(Some(d)) => d,
+            Ok(None) => {
+                return ToolResult {
+                    content: format!(
+                        "[{label}] '{title}' was found in the index but has no detail row — it may have been archived between this turn and the last sync.",
+                        title = ws.title.trim()
+                    ),
+                    is_error: false,
+                };
+            }
+            Err(e) => {
+                return ToolResult {
+                    content: format!("[{label}] could not be loaded: {e}"),
+                    is_error: true,
+                };
+            }
+        }
+    };
+
+    ToolResult {
+        content: format_workstream_detail(&label, &detail),
+        is_error: false,
+    }
+}
+
+fn format_workstream_detail(
+    label: &str,
+    detail: &crate::workstreams::WorkstreamDetail,
+) -> String {
+    let mut s = String::new();
+    s.push_str(&format!(
+        "# [{label}] {title}\n",
+        label = label,
+        title = detail.workstream.title.trim()
+    ));
+    if !detail.workstream.summary.is_empty() {
+        s.push_str(&format!("\n{}\n", detail.workstream.summary.trim()));
+    }
+
+    // Actions: open first, then recently done.
+    if !detail.actions.is_empty() {
+        let open: Vec<&crate::workstreams::WorkstreamAction> =
+            detail.actions.iter().filter(|a| !a.done).collect();
+        let done: Vec<&crate::workstreams::WorkstreamAction> =
+            detail.actions.iter().filter(|a| a.done).collect();
+        s.push_str(&format!(
+            "\nActions ({open_n} open, {done_n} done):\n",
+            open_n = open.len(),
+            done_n = done.len()
+        ));
+        for a in &open {
+            s.push_str(&format!(
+                "- [ ] {text} (from {kind})\n",
+                text = a.text.trim(),
+                kind = a.source_kind
+            ));
+        }
+        for a in done.iter().take(WORKSTREAM_DETAIL_TOP_N) {
+            s.push_str(&format!(
+                "- [x] {text} (from {kind})\n",
+                text = a.text.trim(),
+                kind = a.source_kind
+            ));
+        }
+    }
+
+    if !detail.emails.is_empty() {
+        s.push_str(&format!(
+            "\nRecent emails (top {n} of {total}):\n",
+            n = detail.emails.len().min(WORKSTREAM_DETAIL_TOP_N),
+            total = detail.emails.len()
+        ));
+        for m in detail.emails.iter().take(WORKSTREAM_DETAIL_TOP_N) {
+            let date = format_date(m.sent_at_ms);
+            let from = m
+                .from_name
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .unwrap_or(m.from_email.as_str());
+            let preview = m
+                .body_preview
+                .as_deref()
+                .map(preview_one_line)
+                .unwrap_or_default();
+            let preview_suffix = if preview.is_empty() {
+                String::new()
+            } else {
+                format!(" — {preview}")
+            };
+            s.push_str(&format!(
+                "- {date} {from} — {subject}{preview_suffix}\n",
+                date = date,
+                from = from,
+                subject = m.subject.trim(),
+                preview_suffix = preview_suffix
+            ));
+        }
+    }
+
+    if !detail.events.is_empty() {
+        s.push_str(&format!(
+            "\nRecent meetings (top {n} of {total}):\n",
+            n = detail.events.len().min(WORKSTREAM_DETAIL_TOP_N),
+            total = detail.events.len()
+        ));
+        for e in detail.events.iter().take(WORKSTREAM_DETAIL_TOP_N) {
+            let when = format_date(e.start_ms);
+            let attendees: Vec<&str> =
+                e.attendees.iter().take(5).map(|a| a.email.as_str()).collect();
+            let attendees_suffix = if attendees.is_empty() {
+                String::new()
+            } else {
+                format!(" — {}", attendees.join(", "))
+            };
+            s.push_str(&format!(
+                "- {when} {title}{attendees_suffix}\n",
+                when = when,
+                title = e.title.trim(),
+                attendees_suffix = attendees_suffix
+            ));
+        }
+    }
+
+    if !detail.notes.is_empty() {
+        s.push_str(&format!(
+            "\nRecent notes (top {n} of {total}):\n",
+            n = detail.notes.len().min(WORKSTREAM_DETAIL_TOP_N),
+            total = detail.notes.len()
+        ));
+        for n_ref in detail.notes.iter().take(WORKSTREAM_DETAIL_TOP_N) {
+            let date = format_date(n_ref.modified_ms);
+            let title = if n_ref.title.is_empty() {
+                n_ref.note_path.as_str()
+            } else {
+                n_ref.title.as_str()
+            };
+            s.push_str(&format!(
+                "- {date} {title}\n",
+                date = date,
+                title = title.trim()
+            ));
+        }
+    }
+
+    s
 }
 
 /// Format a single calendar event into a structured text block the
@@ -1131,6 +1386,7 @@ fn format_user_message(
     retrieved_paths: &std::collections::HashSet<String>,
     profiles: &[(crate::team::TeamMember, String)],
     schedule: &[crate::connectors::calendar::CalendarEvent],
+    workstreams: &[crate::workstreams::Workstream],
 ) -> String {
     let mut s = String::new();
 
@@ -1212,9 +1468,78 @@ fn format_user_message(
 
     s.push_str(&format_schedule_section(schedule));
 
+    if !workstreams.is_empty() {
+        s.push_str(&format_workstreams_section(workstreams));
+    }
+
     s.push_str("# Question\n\n");
     s.push_str(query.trim());
     s
+}
+
+/// Render synthesized workstreams as a labeled prompt section.
+/// Each workstream becomes one line with its `[W<N>]` label, title,
+/// one-line summary, and item counts. Empty input emits nothing — the
+/// caller decides whether to skip the section entirely.
+fn format_workstreams_section(workstreams: &[crate::workstreams::Workstream]) -> String {
+    let mut s = String::new();
+    s.push_str("# Workstreams\n\n");
+    for (i, w) in workstreams.iter().enumerate() {
+        let label = format!("W{}", i + 1);
+        let summary = workstream_one_line_summary(&w.summary);
+        let mut counts: Vec<String> = Vec::new();
+        if w.open_action_count > 0 {
+            counts.push(format!("{} open", w.open_action_count));
+        }
+        if w.email_count > 0 {
+            counts.push(format!("{} emails", w.email_count));
+        }
+        if w.event_count > 0 {
+            counts.push(format!("{} meetings", w.event_count));
+        }
+        if w.note_count > 0 {
+            counts.push(format!("{} notes", w.note_count));
+        }
+        let counts_suffix = if counts.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", counts.join(" · "))
+        };
+        let _ = std::fmt::Write::write_fmt(
+            &mut s,
+            format_args!(
+                "[{label}] {title} — {summary}{counts}\n",
+                label = label,
+                title = w.title.trim(),
+                summary = summary,
+                counts = counts_suffix,
+            ),
+        );
+    }
+    s.push('\n');
+    s
+}
+
+fn workstream_one_line_summary(s: &str) -> String {
+    // Collapse whitespace so multi-line summaries render as a single
+    // entry; truncate at WORKSTREAM_SUMMARY_CAP chars.
+    let collapsed: String = {
+        let mut out = String::with_capacity(s.len());
+        let mut last_space = false;
+        for ch in s.chars() {
+            if ch.is_whitespace() {
+                if !last_space {
+                    out.push(' ');
+                    last_space = true;
+                }
+            } else {
+                out.push(ch);
+                last_space = false;
+            }
+        }
+        out.trim().to_string()
+    };
+    truncate_chars(&collapsed, WORKSTREAM_SUMMARY_CAP)
 }
 
 /// Render the upcoming/recent meeting list as a labeled prompt
@@ -1329,4 +1654,204 @@ fn format_date(modified_ms: i64) -> String {
     DateTime::<Utc>::from_timestamp(secs, nsec)
         .map(|dt| dt.format("%Y-%m-%d").to_string())
         .unwrap_or_else(|| "unknown date".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workstreams::{
+        NoteRef, Workstream, WorkstreamAction, WorkstreamDetail,
+    };
+    use crate::connectors::email::EmailMessage;
+
+    fn make_ws(id: &str, title: &str, summary: &str, last_activity: i64) -> Workstream {
+        Workstream {
+            id: id.to_string(),
+            title: title.to_string(),
+            summary: summary.to_string(),
+            status: "active".to_string(),
+            last_activity_ms: last_activity,
+            created_ms: 0,
+            updated_ms: 0,
+            email_count: 0,
+            event_count: 0,
+            note_count: 0,
+            open_action_count: 0,
+        }
+    }
+
+    #[test]
+    fn format_workstreams_section_renders_labels_and_counts() {
+        let mut a = make_ws("ws_a", "Hyundai POC", "Final invoice details.", 100);
+        a.open_action_count = 2;
+        a.email_count = 5;
+        a.event_count = 1;
+
+        let b = make_ws("ws_b", "Q3 hiring", "Sourcing two seniors.", 50);
+
+        let out = format_workstreams_section(&[a, b]);
+        assert!(out.starts_with("# Workstreams\n\n"));
+        assert!(out.contains("[W1] Hyundai POC"));
+        assert!(out.contains("[W2] Q3 hiring"));
+        assert!(out.contains("Final invoice details."));
+        assert!(
+            out.contains("(2 open · 5 emails · 1 meetings)"),
+            "expected counts pill in section, got: {out}"
+        );
+        // No counts when all zero — just the title-summary line.
+        assert!(out.contains("[W2] Q3 hiring — Sourcing two seniors.\n"));
+    }
+
+    #[test]
+    fn format_workstreams_section_truncates_long_summary() {
+        let long = "X".repeat(WORKSTREAM_SUMMARY_CAP + 50);
+        let w = make_ws("ws", "Title", &long, 0);
+        let out = format_workstreams_section(&[w]);
+        // Truncated with the …  marker from truncate_chars.
+        assert!(out.contains('…'), "expected truncation marker in: {out}");
+        // Doesn't contain the trailing portion (50 chars past the cap).
+        assert!(out.lines().any(|l| l.starts_with("[W1] Title — XXX")));
+    }
+
+    fn make_email(id: &str, subject: &str, sent_at_ms: i64) -> EmailMessage {
+        EmailMessage {
+            id: id.to_string(),
+            connector_id: "mg:test".into(),
+            external_id: id.to_string(),
+            thread_id: "t1".into(),
+            subject: subject.to_string(),
+            from_email: "alice@example.com".into(),
+            from_name: Some("Alice".into()),
+            sent_at_ms,
+            body_preview: Some("hello".into()),
+            body_html: None,
+            has_attachments: false,
+            is_read: false,
+            raw_etag: None,
+            modified_ms: sent_at_ms,
+            recipients: Vec::new(),
+        }
+    }
+
+    fn make_action(text: &str, done: bool) -> WorkstreamAction {
+        WorkstreamAction {
+            id: format!("wsa_{text}"),
+            workstream_id: "ws_x".into(),
+            text: text.into(),
+            due_ms: None,
+            source_kind: "email".into(),
+            source_id: "msg".into(),
+            done,
+            created_ms: 0,
+        }
+    }
+
+    #[test]
+    fn format_workstream_detail_renders_all_sections() {
+        let detail = WorkstreamDetail {
+            workstream: Workstream {
+                id: "ws_x".into(),
+                title: "Hyundai POC".into(),
+                summary: "Invoicing in flight.".into(),
+                status: "active".into(),
+                last_activity_ms: 1000,
+                created_ms: 0,
+                updated_ms: 0,
+                email_count: 2,
+                event_count: 0,
+                note_count: 1,
+                open_action_count: 1,
+            },
+            emails: vec![
+                make_email("m1", "Re: invoice", 1000),
+                make_email("m2", "Quote attached", 900),
+            ],
+            events: vec![],
+            notes: vec![NoteRef {
+                note_path: "/n/a.md".into(),
+                title: "Hyundai kickoff".into(),
+                modified_ms: 800,
+            }],
+            actions: vec![make_action("Reply to invoice", false), make_action("Send quote", true)],
+        };
+        let out = format_workstream_detail("W1", &detail);
+        assert!(out.starts_with("# [W1] Hyundai POC\n"));
+        assert!(out.contains("Invoicing in flight."));
+        assert!(out.contains("Actions (1 open, 1 done)"));
+        assert!(out.contains("- [ ] Reply to invoice (from email)"));
+        assert!(out.contains("- [x] Send quote (from email)"));
+        assert!(out.contains("Recent emails (top 2 of 2)"));
+        assert!(out.contains("Re: invoice"));
+        assert!(out.contains("Quote attached"));
+        // No events section when empty.
+        assert!(!out.contains("Recent meetings"));
+        assert!(out.contains("Recent notes (top 1 of 1)"));
+        assert!(out.contains("Hyundai kickoff"));
+    }
+
+    #[test]
+    fn format_workstream_detail_caps_emails_at_top_n() {
+        let mut emails: Vec<EmailMessage> = (0..(WORKSTREAM_DETAIL_TOP_N + 3))
+            .map(|i| make_email(&format!("m{i}"), &format!("Subject {i}"), 1000 - i as i64))
+            .collect();
+        // Ensure they're sorted desc as the loader returns.
+        emails.sort_by(|a, b| b.sent_at_ms.cmp(&a.sent_at_ms));
+        let detail = WorkstreamDetail {
+            workstream: Workstream {
+                id: "ws_y".into(),
+                title: "Many emails".into(),
+                summary: String::new(),
+                status: "active".into(),
+                last_activity_ms: 1000,
+                created_ms: 0,
+                updated_ms: 0,
+                email_count: emails.len() as u32,
+                event_count: 0,
+                note_count: 0,
+                open_action_count: 0,
+            },
+            emails,
+            events: vec![],
+            notes: vec![],
+            actions: vec![],
+        };
+        let out = format_workstream_detail("W2", &detail);
+        let total = WORKSTREAM_DETAIL_TOP_N + 3;
+        assert!(
+            out.contains(&format!("Recent emails (top {} of {})", WORKSTREAM_DETAIL_TOP_N, total)),
+            "got: {out}"
+        );
+        // First 5 subjects present; last 3 absent.
+        for i in 0..WORKSTREAM_DETAIL_TOP_N {
+            assert!(out.contains(&format!("Subject {i}")), "missing Subject {i}");
+        }
+        for i in WORKSTREAM_DETAIL_TOP_N..total {
+            assert!(!out.contains(&format!("Subject {i}")), "leaked Subject {i}");
+        }
+    }
+
+    #[test]
+    fn format_workstream_detail_handles_empty_summary_and_actions() {
+        let detail = WorkstreamDetail {
+            workstream: Workstream {
+                id: "ws_z".into(),
+                title: "Bare".into(),
+                summary: String::new(),
+                status: "active".into(),
+                last_activity_ms: 0,
+                created_ms: 0,
+                updated_ms: 0,
+                email_count: 0,
+                event_count: 0,
+                note_count: 0,
+                open_action_count: 0,
+            },
+            emails: vec![],
+            events: vec![],
+            notes: vec![],
+            actions: vec![],
+        };
+        let out = format_workstream_detail("W3", &detail);
+        assert_eq!(out, "# [W3] Bare\n");
+    }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -4280,6 +4280,25 @@ input.nh-title {
   border-color: color-mix(in srgb, #c44a1f 30%, transparent);
 }
 
+/* Workstream citation chips ([W*]) — workstreams are synthesized
+   clusters, distinct from notes (default accent) and events (orange).
+   A muted forest green reads as "ongoing thread". */
+.palette-cite.is-workstream {
+  border-color: color-mix(in srgb, #2f7a4d 30%, transparent);
+  background: color-mix(in srgb, #2f7a4d 12%, transparent);
+  color: #2f7a4d;
+}
+.palette-cite.is-workstream:hover {
+  background: color-mix(in srgb, #2f7a4d 22%, transparent);
+}
+.palette-source-chip.is-workstream .palette-source-num {
+  background: color-mix(in srgb, #2f7a4d 14%, transparent);
+  color: #2f7a4d;
+}
+.palette-source-chip.is-workstream:hover {
+  border-color: color-mix(in srgb, #2f7a4d 30%, transparent);
+}
+
 .palette-sources {
   margin-top: 8px;
   width: 100%;

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -485,6 +485,19 @@ export function Home({
           setPaletteOpen(false);
           onOpen(p);
         }}
+        onOpenWorkstream={(id) => {
+          setPaletteOpen(false);
+          setNav("workstreams");
+          // setNav is synchronous setState; the WorkstreamsView mounts
+          // on the next render. Defer the detail-open dispatch to the
+          // following microtask so the View's listener is wired up by
+          // the time the event fires.
+          queueMicrotask(() => {
+            window.dispatchEvent(
+              new CustomEvent("margin:open-workstream", { detail: id }),
+            );
+          });
+        }}
       />
       {sidebarOpen && (
         <Sidebar

--- a/src/SearchPalette.tsx
+++ b/src/SearchPalette.tsx
@@ -29,6 +29,10 @@ type Props = {
   open: boolean;
   onClose: () => void;
   onOpenNote: (path: string) => void;
+  /** Click-through for `[W*]` chips — switches the sidebar nav to
+   *  Workstreams and opens the specified workstream's detail view.
+   *  Provided by Home.tsx so it can flip its nav state directly. */
+  onOpenWorkstream: (workstreamId: string) => void;
 };
 
 const QUERY_DEBOUNCE_MS = 120;
@@ -79,7 +83,7 @@ type VoiceState =
   | { kind: "transcribing" }
   | { kind: "didnt-catch"; message?: string };
 
-export function SearchPalette({ open, onClose, onOpenNote }: Props) {
+export function SearchPalette({ open, onClose, onOpenNote, onOpenWorkstream }: Props) {
   const [mode, setMode] = useState<"search" | "chat">("search");
   const [query, setQuery] = useState("");
   const [hits, setHits] = useState<SearchHit[]>([]);
@@ -538,6 +542,10 @@ export function SearchPalette({ open, onClose, onOpenNote }: Props) {
               onOpenNote(path);
               onClose();
             }}
+            onOpenWorkstream={(id) => {
+              onOpenWorkstream(id);
+              onClose();
+            }}
           />
         )}
 
@@ -636,15 +644,22 @@ function Conversation({
   ref,
   messages,
   onOpenNote,
+  onOpenWorkstream,
 }: {
   ref: React.RefObject<HTMLDivElement | null>;
   messages: ChatMessage[];
   onOpenNote: (path: string) => void;
+  onOpenWorkstream: (workstreamId: string) => void;
 }) {
   return (
     <div className="palette-conversation" ref={ref}>
       {messages.map((m) => (
-        <MessageBubble key={m.id} message={m} onOpenNote={onOpenNote} />
+        <MessageBubble
+          key={m.id}
+          message={m}
+          onOpenNote={onOpenNote}
+          onOpenWorkstream={onOpenWorkstream}
+        />
       ))}
     </div>
   );
@@ -653,9 +668,11 @@ function Conversation({
 function MessageBubble({
   message,
   onOpenNote,
+  onOpenWorkstream,
 }: {
   message: ChatMessage;
   onOpenNote: (path: string) => void;
+  onOpenWorkstream: (workstreamId: string) => void;
 }) {
   if (message.role === "user") {
     return (
@@ -677,13 +694,14 @@ function MessageBubble({
   const sources = message.sources || [];
   const fullText = joinText(message.parts);
   // Render chips only for labels the model actually cited across all
-  // text parts. The full directory + schedule can be hundreds of
-  // entries — showing all of them would be a wall of chips. Both `[N]`
-  // (notes) and `[E<N>]` (events) match.
+  // text parts. The full directory + schedule + workstreams can be
+  // hundreds of entries — showing all of them would be a wall of
+  // chips. `[N]` (notes), `[E<N>]` (events), and `[W<N>]`
+  // (workstreams) all match.
   const citedSources = useMemo(() => {
     if (sources.length === 0) return [];
     const cited = new Set<string>();
-    const re = /\[(E?\d{1,3})\]/g;
+    const re = /\[([WE]?\d{1,3})\]/g;
     let m: RegExpExecArray | null;
     while ((m = re.exec(fullText)) !== null) {
       cited.add(m[1]);
@@ -711,6 +729,7 @@ function MessageBubble({
                 text={part.value}
                 sources={sources}
                 onOpenNote={onOpenNote}
+                onOpenWorkstream={onOpenWorkstream}
               />
             ) : (
               <ToolPill
@@ -718,12 +737,14 @@ function MessageBubble({
                 part={part}
                 onOpen={() => {
                   // Resolve the source by label and open the right
-                  // surface — note path for [N], or the linked event
-                  // bundle for [E<N>] (creating one if needed via
-                  // openOrCreateEventNote from #62).
+                  // surface — note path for [N], the linked event
+                  // bundle for [E<N>] (created on demand via
+                  // openOrCreateEventNote from #62), or the
+                  // Workstreams detail view for [W<N>] via the custom
+                  // event in onOpenWorkstream.
                   const src = sources.find((s) => s.label === part.targetLabel);
                   if (!src) return;
-                  void openSource(src, onOpenNote);
+                  void openSource(src, onOpenNote, onOpenWorkstream);
                 }}
               />
             ),
@@ -738,11 +759,9 @@ function MessageBubble({
               <button
                 key={s.label}
                 type="button"
-                className={`palette-source-chip ${
-                  s.kind === "event" ? "is-event" : "is-note"
-                }`}
+                className={`palette-source-chip ${chipVariant(s.kind)}`}
                 title={s.title}
-                onClick={() => void openSource(s, onOpenNote)}
+                onClick={() => void openSource(s, onOpenNote, onOpenWorkstream)}
               >
                 <span className="palette-source-num">{s.label}</span>
                 <span className="palette-source-title">{s.title}</span>
@@ -765,6 +784,8 @@ function ToolPill({
   const verb =
     part.name === "read_event_details"
       ? "Reading event"
+      : part.name === "read_workstream"
+      ? "Reading workstream"
       : part.name === "read_transcript"
       ? "Reading transcript"
       : "Reading";
@@ -797,12 +818,30 @@ function ToolPill({
   );
 }
 
+/// CSS variant class for a chip / inline citation, keyed off the
+/// source kind. Centralized so the inline `[N]` markers and the bottom
+/// "Sources" strip stay consistent.
+function chipVariant(kind: AskSource["kind"]): string {
+  switch (kind) {
+    case "event":
+      return "is-event";
+    case "workstream":
+      return "is-workstream";
+    case "note":
+    default:
+      return "is-note";
+  }
+}
+
 /// Open the surface a source points at. Notes go through `onOpenNote`
 /// directly. Events route through `openOrCreateEventNote` (#62) which
-/// creates the linked bundle on first click.
+/// creates the linked bundle on first click. Workstreams hand the id
+/// to `onOpenWorkstream`, which switches the sidebar nav and dispatches
+/// `margin:open-workstream` so the detail view selects this one (#72).
 async function openSource(
   source: AskSource,
   onOpenNote: (path: string) => void,
+  onOpenWorkstream: (workstreamId: string) => void,
 ): Promise<void> {
   if (source.kind === "note" && source.note_path) {
     onOpenNote(source.note_path);
@@ -815,6 +854,10 @@ async function openSource(
     } catch (e) {
       console.error("[ask] open event note failed:", e);
     }
+    return;
+  }
+  if (source.kind === "workstream" && source.workstream_id) {
+    onOpenWorkstream(source.workstream_id);
   }
 }
 
@@ -834,10 +877,12 @@ function CitedText({
   text,
   sources,
   onOpenNote,
+  onOpenWorkstream,
 }: {
   text: string;
   sources: AskSource[];
   onOpenNote: (path: string) => void;
+  onOpenWorkstream: (workstreamId: string) => void;
 }) {
   const sourceByLabel = useMemo(() => {
     const m = new Map<string, AskSource>();
@@ -846,13 +891,12 @@ function CitedText({
   }, [sources]);
 
   const html = useMemo(() => {
-    const withCitations = text.replace(/\[(E?\d{1,3})\]/g, (full, label) => {
+    const withCitations = text.replace(/\[([WE]?\d{1,3})\]/g, (full, label) => {
       const src = sourceByLabel.get(label);
       // Hallucinated citation label — leave the marker as plain text
       // rather than emitting a dead chip.
       if (!src) return full;
-      const variant = src.kind === "event" ? "is-event" : "is-note";
-      return `<button type="button" class="palette-cite ${variant}" data-cite-label="${label}">${label}</button>`;
+      return `<button type="button" class="palette-cite ${chipVariant(src.kind)}" data-cite-label="${label}">${label}</button>`;
     });
     return renderMarkdown(withCitations);
   }, [text, sourceByLabel]);
@@ -864,7 +908,7 @@ function CitedText({
     const label = cite.getAttribute("data-cite-label");
     if (!label) return;
     const source = sourceByLabel.get(label);
-    if (source) void openSource(source, onOpenNote);
+    if (source) void openSource(source, onOpenNote, onOpenWorkstream);
   };
 
   return (

--- a/src/SearchPalette.tsx
+++ b/src/SearchPalette.tsx
@@ -158,6 +158,32 @@ export function SearchPalette({ open, onClose, onOpenNote, onOpenWorkstream }: P
     return () => window.removeEventListener("mousedown", onMouseDown);
   }, [open, onClose]);
 
+  // Window-level Escape handler. The dialog's onKeyDown also handles
+  // Escape, but only when focus is inside the dialog. When voice mode
+  // is active the <input> is unmounted (replaced by VoiceComposer)
+  // and focus falls back to <body>, so dialog-level keydown stops
+  // firing and Esc would silently no-op. Listening on window covers
+  // every focus state.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      if (voiceState.kind === "recording") {
+        // Best-effort cancel; don't await.
+        void stopVoiceRecording().catch(() => {});
+      }
+      if (voiceState.kind !== "off") {
+        setVoiceState({ kind: "off" });
+        // Returns to whichever non-voice mode (search/chat) was active.
+        return;
+      }
+      onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose, voiceState.kind]);
+
   // Scroll the active search row into view when navigating with arrows.
   useEffect(() => {
     if (mode !== "search") return;

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -41,6 +41,22 @@ export function WorkstreamsView({
 }) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
+  // External open: the AI ask palette dispatches `margin:open-workstream`
+  // when a `[W*]` citation chip is clicked (#72). This view is only
+  // mounted when nav === "workstreams", so the dispatcher fires the
+  // event a microtask after switching nav so we're guaranteed to be
+  // listening by the time it lands.
+  useEffect(() => {
+    const onOpen = (e: Event) => {
+      const detail = (e as CustomEvent<unknown>).detail;
+      if (typeof detail === "string" && detail.length > 0) {
+        setSelectedId(detail);
+      }
+    };
+    window.addEventListener("margin:open-workstream", onOpen);
+    return () => window.removeEventListener("margin:open-workstream", onOpen);
+  }, []);
+
   if (selectedId) {
     return (
       <WorkstreamDetailView

--- a/src/file.ts
+++ b/src/file.ts
@@ -213,15 +213,17 @@ export async function searchNotes(query: string, limit = 20): Promise<SearchHit[
 
 // --- AI Q&A (#31 follow-up) ---------------------------------------------
 
-export type AskSourceKind = "note" | "event";
+export type AskSourceKind = "note" | "event" | "workstream";
 
 /** A single citation source the model can reference. Notes use `[N]`
- *  labels (e.g. `"3"`), events use `[E<N>]` labels (e.g. `"E2"`).
- *  Frontend picks chip styling and click destination from `kind`. */
+ *  labels (e.g. `"3"`), events use `[E<N>]` labels (e.g. `"E2"`),
+ *  workstreams use `[W<N>]` labels (e.g. `"W2"`). Frontend picks chip
+ *  styling and click destination from `kind`. */
 export type AskSource = {
   kind: AskSourceKind;
   /** Citation label as it appears between the brackets in the model's
-   *  output. Notes: `"3"` / `"12"`. Events: `"E1"` / `"E14"`. */
+   *  output. Notes: `"3"` / `"12"`. Events: `"E1"` / `"E14"`.
+   *  Workstreams: `"W1"` / `"W14"`. */
   label: string;
   title: string;
   modified_ms: number;
@@ -231,6 +233,9 @@ export type AskSource = {
   /** Set when `kind === "event"`. Click handler invokes
    *  `openOrCreateEventNote(event_id)` (#62). */
   event_id?: string;
+  /** Set when `kind === "workstream"`. Click handler dispatches
+   *  `margin:open-workstream` with this id (#72). */
+  workstream_id?: string;
 };
 
 export type ChatTurn = {


### PR DESCRIPTION
## Summary
- Adds `[W<N>]` workstreams as a first-class citation surface in AI ask, mirroring the `[E*]` events shape added in #64
- `# Workstreams` section in the user message (capped at 30, sorted by `last_activity_ms desc`) with title, one-line summary, and item counts per workstream
- New `read_workstream(n)` tool returns the workstream's summary, all open + recently completed actions, and the top 5 most recent items per category (emails / events / notes)
- Frontend regex now matches `[N]`, `[E<N>]`, and `[W<N>]`; chips render in three distinct colors; tool pill shows "Reading workstream …"
- Click-through: clicking a `[W*]` chip closes the palette, switches sidebar nav to Workstreams, and dispatches `margin:open-workstream` (with the id) so the detail view selects this one

Final issue in [Connectors v2: Mail + Workstreams](https://github.com/tjruesch/margin/milestone/4) — milestone complete after this lands.

## Notes
- Anthropic constants (`ENDPOINT`, `ANTHROPIC_VERSION`, `DEFAULT_MODEL`) reused via `crate::anthropic`
- System prompt lays out all three citation kinds explicitly + nudges the model to prefer underlying `[N]` / `[E*]` over `[W*]` when citing a specific item within a workstream
- Workstream chip uses muted forest green (#2f7a4d) to distinguish from notes (accent) and events (orange)
- `queueMicrotask` defers the open-workstream dispatch by one tick so `WorkstreamsView` is mounted with its event listener wired up before the event fires

## Test plan
- [x] `cargo check` clean
- [x] `bunx tsc --noEmit -p tsconfig.json` clean
- [x] `cargo test --lib ask::` — 5 new tests pass (format_workstreams_section labels + counts + truncation; format_workstream_detail sections + top-N cap + empty)
- [x] Full `cargo test --lib` — 175 passing, no regressions
- [ ] Manual: open AI ask palette, ask "what's happening with Hyundai?" → answer cites `[W*]` chip; click it → palette closes, sidebar switches to Workstreams, that workstream's detail view opens
- [ ] Manual: ask a status question that pulls multiple workstreams → multiple `[W*]` chips render in green, click-through works for each
- [ ] Manual: tool pill renders "Reading workstream [W2] 'Hyundai POC review'…" mid-stream
- [ ] Manual: hallucinated `[W99]` falls back to plain text (no chip, no broken click)