### PR TITLE
Manual context on workstreams (#77)

### DIFF
--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,9 +1,17 @@
-# Ad-hoc codesign the dev binary with a stable identifier (com.margin.app)
-# so macOS Keychain treats every `cargo run` as the same app and we don't
-# get an "Allow Access" prompt on every rebuild. Without this, Keychain's
-# ACL binds to the unsigned binary's hash, which changes every build.
+# Codesign the dev binary so macOS Keychain treats every `cargo run` as
+# the same app and "Always Allow" sticks across rebuilds.
+#
+# `--sign -` (ad-hoc) is the fallback. It produces a fresh code-designated-
+# requirement hash per build, which Keychain treats as a new principal —
+# so each launch re-prompts. To get sticky "Always Allow", create a
+# persistent self-signed code-signing certificate (Keychain Access →
+# Certificate Assistant → Create a Certificate, type Code Signing) and
+# put either the certificate name or its SHA1 in `MARGIN_DEV_SIGNING_IDENTITY`
+# (e.g. in `.env`). `security find-identity -v -p codesigning` will show
+# the SHA1 once the cert exists. cargo run then signs with that identity
+# every time, producing the same signature, and Keychain's ACL holds.
 [target.'cfg(target_os = "macos")']
-runner = ["sh", "-c", "codesign --force --sign - --identifier com.margin.app \"$0\" 2>/dev/null; exec \"$0\" \"$@\""]
+runner = ["sh", "-c", "codesign --force --sign \"${MARGIN_DEV_SIGNING_IDENTITY:--}\" --identifier com.margin.app \"$0\" 2>/dev/null; exec \"$0\" \"$@\""]
 
 # whisper-rs links against whisper.cpp's C++ object files; macOS needs libc++
 # and the Accelerate framework explicitly so the linker resolves

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -7,11 +7,17 @@
 # persistent self-signed code-signing certificate (Keychain Access →
 # Certificate Assistant → Create a Certificate, type Code Signing) and
 # put either the certificate name or its SHA1 in `MARGIN_DEV_SIGNING_IDENTITY`
-# (e.g. in `.env`). `security find-identity -v -p codesigning` will show
-# the SHA1 once the cert exists. cargo run then signs with that identity
-# every time, producing the same signature, and Keychain's ACL holds.
+# in `.env`. `security find-identity -v -p codesigning` will show the SHA1
+# once the cert exists. cargo run then signs with that identity every
+# time, producing the same signature, and Keychain's ACL holds.
+#
+# The runner sources `.env` directly because `bun run tauri dev` only
+# loads .env into Bun's JS runtime; it doesn't propagate to spawned
+# binaries (tauri → cargo → this runner shell). Quote values containing
+# spaces (e.g. `MARGIN_DEV_SIGNING_IDENTITY="Margin Dev"`) so the
+# POSIX-shell `set -a; . ../.env; set +a` parses them correctly.
 [target.'cfg(target_os = "macos")']
-runner = ["sh", "-c", "codesign --force --sign \"${MARGIN_DEV_SIGNING_IDENTITY:--}\" --identifier com.margin.app \"$0\" 2>/dev/null; exec \"$0\" \"$@\""]
+runner = ["sh", "-c", "if [ -f ../.env ]; then set -a; . ../.env; set +a; fi; codesign --force --sign \"${MARGIN_DEV_SIGNING_IDENTITY:--}\" --identifier com.margin.app \"$0\" 2>/dev/null; exec \"$0\" \"$@\""]
 
 # whisper-rs links against whisper.cpp's C++ object files; macOS needs libc++
 # and the Accelerate framework explicitly so the linker resolves

--- a/src-tauri/src/ask.rs
+++ b/src-tauri/src/ask.rs
@@ -69,6 +69,11 @@ const WORKSTREAM_CAP: usize = 30;
 const WORKSTREAM_DETAIL_TOP_N: usize = 5;
 /// Per-workstream summary cap when listed in the prompt section.
 const WORKSTREAM_SUMMARY_CAP: usize = 200;
+/// Cap on user_notes length when included in any prompt (#77). DB has
+/// no cap; this only protects the token budget. Mirrors the same
+/// constant in `workstreams::synthesizer` so the two consumers
+/// truncate identically.
+const USER_NOTES_PROMPT_CAP: usize = 4000;
 
 /// Emitted on the unified `ai-stream` channel. The frontend filters by
 /// `turn_id` so a stale stream that arrives after the user navigates
@@ -1161,6 +1166,20 @@ fn format_workstream_detail(
         s.push_str(&format!("\n{}\n", detail.workstream.summary.trim()));
     }
 
+    // User-authored notes are ground truth (#77). Surface in full near
+    // the top so the model reads them before reasoning about the
+    // synthesized summary or any inferred state.
+    if let Some(notes) = detail
+        .workstream
+        .user_notes
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+    {
+        s.push_str("\nUser notes (ground truth):\n");
+        s.push_str(&truncate_chars(notes.trim(), USER_NOTES_PROMPT_CAP));
+        s.push('\n');
+    }
+
     // Actions: open first, then recently done.
     if !detail.actions.is_empty() {
         let open: Vec<&crate::workstreams::WorkstreamAction> =
@@ -1515,6 +1534,13 @@ fn format_workstreams_section(workstreams: &[crate::workstreams::Workstream]) ->
                 counts = counts_suffix,
             ),
         );
+        // User-authored ground truth (#77). Show a one-line excerpt
+        // here so the model knows it exists; the full text is in the
+        // `read_workstream` tool result.
+        if let Some(notes) = w.user_notes.as_deref().filter(|s| !s.trim().is_empty()) {
+            let one_line = workstream_one_line_summary(notes);
+            s.push_str(&format!("    (user notes: {one_line})\n"));
+        }
     }
     s.push('\n');
     s
@@ -1673,6 +1699,7 @@ mod tests {
             last_activity_ms: last_activity,
             created_ms: 0,
             updated_ms: 0,
+            user_notes: None,
             email_count: 0,
             event_count: 0,
             note_count: 0,
@@ -1757,6 +1784,7 @@ mod tests {
                 last_activity_ms: 1000,
                 created_ms: 0,
                 updated_ms: 0,
+                user_notes: None,
                 email_count: 2,
                 event_count: 0,
                 note_count: 1,
@@ -1805,6 +1833,7 @@ mod tests {
                 last_activity_ms: 1000,
                 created_ms: 0,
                 updated_ms: 0,
+                user_notes: None,
                 email_count: emails.len() as u32,
                 event_count: 0,
                 note_count: 0,
@@ -1831,6 +1860,49 @@ mod tests {
     }
 
     #[test]
+    fn format_workstreams_section_one_line_excerpt_when_user_notes_present() {
+        let mut a = make_ws("ws_a", "Hyundai POC", "Final invoice details.", 100);
+        a.user_notes = Some("Real deadline May 30 (calendar shows June). TJ owns this internally.".into());
+        let out = format_workstreams_section(&[a]);
+        assert!(out.contains("[W1] Hyundai POC"));
+        assert!(
+            out.contains("(user notes: Real deadline May 30"),
+            "expected one-line user notes excerpt, got: {out}"
+        );
+    }
+
+    #[test]
+    fn format_workstream_detail_includes_user_notes_block() {
+        let detail = WorkstreamDetail {
+            workstream: Workstream {
+                id: "ws_n".into(),
+                title: "Hyundai POC".into(),
+                summary: "Invoicing in flight.".into(),
+                status: "active".into(),
+                last_activity_ms: 1000,
+                created_ms: 0,
+                updated_ms: 0,
+                user_notes: Some("Real deadline May 30. New POC, not legacy contract.".into()),
+                email_count: 0,
+                event_count: 0,
+                note_count: 0,
+                open_action_count: 0,
+            },
+            emails: vec![],
+            events: vec![],
+            notes: vec![],
+            actions: vec![],
+        };
+        let out = format_workstream_detail("W1", &detail);
+        assert!(out.contains("# [W1] Hyundai POC"));
+        // Summary still rendered.
+        assert!(out.contains("Invoicing in flight."));
+        // User notes block present, full text (under the cap).
+        assert!(out.contains("User notes (ground truth):"));
+        assert!(out.contains("Real deadline May 30. New POC, not legacy contract."));
+    }
+
+    #[test]
     fn format_workstream_detail_handles_empty_summary_and_actions() {
         let detail = WorkstreamDetail {
             workstream: Workstream {
@@ -1841,6 +1913,7 @@ mod tests {
                 last_activity_ms: 0,
                 created_ms: 0,
                 updated_ms: 0,
+                user_notes: None,
                 email_count: 0,
                 event_count: 0,
                 note_count: 0,

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -43,7 +43,8 @@ const SCHEMA_V9: &str = include_str!("migrations/009_calendar.sql");
 const SCHEMA_V10: &str = include_str!("migrations/010_event_note_link.sql");
 const SCHEMA_V11: &str = include_str!("migrations/011_email.sql");
 const SCHEMA_V12: &str = include_str!("migrations/012_workstreams.sql");
-const SCHEMA_VERSION: i64 = 12;
+const SCHEMA_V13: &str = include_str!("migrations/013_workstream_user_notes.sql");
+const SCHEMA_VERSION: i64 = 13;
 
 /// Open the index DB at `db_path` (creating it if absent) and apply any
 /// pending migrations.
@@ -133,6 +134,10 @@ fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 11 {
         conn.execute_batch(SCHEMA_V12)?;
         version = 12;
+    }
+    if version == 12 {
+        conn.execute_batch(SCHEMA_V13)?;
+        version = 13;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -690,7 +690,8 @@ pub fn run() {
             workstreams::commands::list_workstreams,
             workstreams::commands::get_workstream_details,
             workstreams::commands::set_workstream_action_done,
-            workstreams::commands::set_workstream_status
+            workstreams::commands::set_workstream_status,
+            workstreams::commands::set_workstream_user_notes
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/migrations/013_workstream_user_notes.sql
+++ b/src-tauri/src/migrations/013_workstream_user_notes.sql
@@ -1,0 +1,3 @@
+ALTER TABLE workstreams ADD COLUMN user_notes TEXT;
+
+UPDATE meta SET value = '13' WHERE key = 'schema_version';

--- a/src-tauri/src/workstreams/commands.rs
+++ b/src-tauri/src/workstreams/commands.rs
@@ -54,3 +54,17 @@ pub fn set_workstream_status(
     let c = conn.lock().map_err(|e| e.to_string())?;
     persist::set_status(&c, &id, &status).map_err(|e| e.to_string())
 }
+
+/// Update a workstream's user-authored context (#77). Whitespace-only
+/// input is treated as a clear (persists `NULL`) so the prompt-omission
+/// logic downstream can `filter(|s| !s.is_empty())` cleanly.
+#[tauri::command]
+pub fn set_workstream_user_notes(
+    id: String,
+    notes: Option<String>,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<(), String> {
+    let trimmed = notes.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    persist::set_user_notes(&c, &id, trimmed).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/workstreams/mod.rs
+++ b/src-tauri/src/workstreams/mod.rs
@@ -42,6 +42,10 @@ pub struct Workstream {
     pub last_activity_ms: i64,
     pub created_ms: i64,
     pub updated_ms: i64,
+    /// User-authored ground-truth context (#77). Treated as
+    /// authoritative by the synthesizer prompt and surfaced in
+    /// `read_workstream` tool output. `None` when empty.
+    pub user_notes: Option<String>,
     pub email_count: u32,
     pub event_count: u32,
     pub note_count: u32,

--- a/src-tauri/src/workstreams/persist.rs
+++ b/src-tauri/src/workstreams/persist.rs
@@ -65,6 +65,7 @@ pub fn set_last_clustered_ms(conn: &Connection, ms: i64) -> rusqlite::Result<()>
 pub fn list_workstreams_active(conn: &Connection) -> rusqlite::Result<Vec<Workstream>> {
     let mut stmt = conn.prepare(
         "SELECT w.id, w.title, w.summary, w.status, w.last_activity_ms, w.created_ms, w.updated_ms, \
+                w.user_notes, \
                 COALESCE((SELECT COUNT(*) FROM workstream_emails WHERE workstream_id = w.id), 0) AS ec, \
                 COALESCE((SELECT COUNT(*) FROM workstream_events WHERE workstream_id = w.id), 0) AS evc, \
                 COALESCE((SELECT COUNT(*) FROM workstream_notes  WHERE workstream_id = w.id), 0) AS nc, \
@@ -82,10 +83,11 @@ pub fn list_workstreams_active(conn: &Connection) -> rusqlite::Result<Vec<Workst
             last_activity_ms: r.get(4)?,
             created_ms: r.get(5)?,
             updated_ms: r.get(6)?,
-            email_count: r.get::<_, i64>(7)? as u32,
-            event_count: r.get::<_, i64>(8)? as u32,
-            note_count: r.get::<_, i64>(9)? as u32,
-            open_action_count: r.get::<_, i64>(10)? as u32,
+            user_notes: r.get(7)?,
+            email_count: r.get::<_, i64>(8)? as u32,
+            event_count: r.get::<_, i64>(9)? as u32,
+            note_count: r.get::<_, i64>(10)? as u32,
+            open_action_count: r.get::<_, i64>(11)? as u32,
         })
     })?;
     let mut out = Vec::new();
@@ -162,6 +164,7 @@ pub fn get_workstream_detail(
 fn get_workstream_one(conn: &Connection, id: &str) -> rusqlite::Result<Option<Workstream>> {
     let mut stmt = conn.prepare(
         "SELECT w.id, w.title, w.summary, w.status, w.last_activity_ms, w.created_ms, w.updated_ms, \
+                w.user_notes, \
                 COALESCE((SELECT COUNT(*) FROM workstream_emails WHERE workstream_id = w.id), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_events WHERE workstream_id = w.id), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_notes  WHERE workstream_id = w.id), 0), \
@@ -177,10 +180,11 @@ fn get_workstream_one(conn: &Connection, id: &str) -> rusqlite::Result<Option<Wo
             last_activity_ms: r.get(4)?,
             created_ms: r.get(5)?,
             updated_ms: r.get(6)?,
-            email_count: r.get::<_, i64>(7)? as u32,
-            event_count: r.get::<_, i64>(8)? as u32,
-            note_count: r.get::<_, i64>(9)? as u32,
-            open_action_count: r.get::<_, i64>(10)? as u32,
+            user_notes: r.get(7)?,
+            email_count: r.get::<_, i64>(8)? as u32,
+            event_count: r.get::<_, i64>(9)? as u32,
+            note_count: r.get::<_, i64>(10)? as u32,
+            open_action_count: r.get::<_, i64>(11)? as u32,
         })
     })
     .optional()
@@ -442,6 +446,22 @@ pub fn set_status(conn: &Connection, id: &str, status: &str) -> rusqlite::Result
     Ok(())
 }
 
+/// Update a workstream's user-authored context notes (#77). `None`
+/// clears the field. Caller is responsible for trimming whitespace
+/// and mapping empty strings to `None` so the prompt-omission logic
+/// downstream stays simple.
+pub fn set_user_notes(
+    conn: &Connection,
+    id: &str,
+    notes: Option<&str>,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE workstreams SET user_notes = ?2, updated_ms = ?3 WHERE id = ?1",
+        params![id, notes, now_ms()],
+    )?;
+    Ok(())
+}
+
 fn now_ms() -> i64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
@@ -491,6 +511,8 @@ mod tests {
         conn.execute_batch(include_str!("../migrations/011_email.sql"))
             .unwrap();
         conn.execute_batch(include_str!("../migrations/012_workstreams.sql"))
+            .unwrap();
+        conn.execute_batch(include_str!("../migrations/013_workstream_user_notes.sql"))
             .unwrap();
         conn
     }
@@ -794,5 +816,76 @@ mod tests {
         // But internal whitespace still matters (different action).
         let id3 = action_id("ws1", "Do  thing");
         assert_ne!(id1, id3);
+    }
+
+    // ----- user_notes (#77) ------------------------------------------------
+
+    #[test]
+    fn set_user_notes_round_trips() {
+        let mut conn = open_test_db();
+        let tx = conn.transaction().unwrap();
+        write_workstream(&tx, &make_ws(Some("ws_n"), "WS", &[], &[], &[], vec![]), 1_000)
+            .unwrap();
+        tx.commit().unwrap();
+
+        // Default: no notes.
+        let active = list_workstreams_active(&conn).unwrap();
+        assert_eq!(active[0].user_notes, None);
+
+        // Set, read back.
+        set_user_notes(&conn, "ws_n", Some("Real deadline May 30")).unwrap();
+        let active = list_workstreams_active(&conn).unwrap();
+        assert_eq!(active[0].user_notes.as_deref(), Some("Real deadline May 30"));
+
+        // Detail view returns it too.
+        let detail = get_workstream_detail(&conn, "ws_n").unwrap().unwrap();
+        assert_eq!(
+            detail.workstream.user_notes.as_deref(),
+            Some("Real deadline May 30")
+        );
+    }
+
+    #[test]
+    fn set_user_notes_with_none_clears_field() {
+        let mut conn = open_test_db();
+        let tx = conn.transaction().unwrap();
+        write_workstream(&tx, &make_ws(Some("ws_c"), "WS", &[], &[], &[], vec![]), 1_000)
+            .unwrap();
+        tx.commit().unwrap();
+        set_user_notes(&conn, "ws_c", Some("placeholder")).unwrap();
+        set_user_notes(&conn, "ws_c", None).unwrap();
+        let active = list_workstreams_active(&conn).unwrap();
+        assert_eq!(active[0].user_notes, None);
+    }
+
+    #[test]
+    fn write_workstream_does_not_overwrite_user_notes_on_resync() {
+        let mut conn = open_test_db();
+        let tx = conn.transaction().unwrap();
+        write_workstream(&tx, &make_ws(Some("ws_r"), "Hyundai", &[], &[], &[], vec![]), 1_000)
+            .unwrap();
+        tx.commit().unwrap();
+        set_user_notes(&conn, "ws_r", Some("This is the new POC.")).unwrap();
+
+        // Re-sync the same workstream (fresh title, no carry-over of
+        // user_notes from the synthesizer side — the SynthesizedWorkstream
+        // shape doesn't have user_notes at all).
+        let tx = conn.transaction().unwrap();
+        write_workstream(
+            &tx,
+            &make_ws(Some("ws_r"), "Hyundai (renamed)", &[], &[], &[], vec![]),
+            2_000,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        // Title updated, but user_notes survived.
+        let detail = get_workstream_detail(&conn, "ws_r").unwrap().unwrap();
+        assert_eq!(detail.workstream.title, "Hyundai (renamed)");
+        assert_eq!(
+            detail.workstream.user_notes.as_deref(),
+            Some("This is the new POC."),
+            "user_notes must survive a re-sync that doesn't carry it"
+        );
     }
 }

--- a/src-tauri/src/workstreams/synthesizer.rs
+++ b/src-tauri/src/workstreams/synthesizer.rs
@@ -38,6 +38,10 @@ const MAX_BODY_FETCHES: usize = 100;
 
 const MAX_TOKENS: u32 = 8192;
 
+/// Cap on user_notes length when included in the synthesizer prompt
+/// (#77). DB has no cap; this only protects the token budget.
+const USER_NOTES_PROMPT_CAP: usize = 4000;
+
 const SYSTEM_PROMPT: &str = "You are a workstream synthesizer. Given a user's recent emails, calendar events, \
 and notes, group them into 3-15 active workstreams: ongoing efforts the user is participating in \
 (projects, hiring loops, vendor evaluations, support escalations, etc.).
@@ -45,6 +49,11 @@ and notes, group them into 3-15 active workstreams: ongoing efforts the user is 
 Stickiness: an \"Existing workstreams\" section lists workstream ids already in the database. When new \
 items naturally extend one of those, REUSE its id verbatim. Spawn a new workstream only when no \
 existing one is a clean fit.
+
+Some existing workstreams may carry an indented \"Notes:\" line — these are user-authored ground truth. \
+Treat them as authoritative: prefer them when reconciling new evidence, never write a summary that \
+contradicts them. If the notes describe scope, ownership, deadlines, or identity that conflicts \
+with what the recent items suggest, the notes win.
 
 Titles: short, specific, proper-noun-leaning (\"Hyundai POC review\", \"Q3 sourcing\", \
 \"Bridge integration\") — not generic (\"Project work\", \"Various meetings\").
@@ -361,6 +370,13 @@ fn build_user_message(
                 w.title,
                 summarize_one_line(&w.summary)
             ));
+            if let Some(notes) = w.user_notes.as_deref().filter(|s| !s.trim().is_empty()) {
+                let collapsed = collapse_ws(notes);
+                let truncated = truncate_chars(&collapsed, USER_NOTES_PROMPT_CAP);
+                s.push_str(&format!(
+                    "   Notes (user-authored, ground truth): {truncated}\n"
+                ));
+            }
         }
     }
 
@@ -505,6 +521,16 @@ fn summarize_one_line(s: &str) -> String {
         let truncated: String = collapsed.chars().take(200).collect();
         format!("{}…", truncated)
     }
+}
+
+/// Char-aware truncation with a `…` suffix when over the cap. Preserves
+/// UTF-8 boundaries.
+fn truncate_chars(s: &str, cap: usize) -> String {
+    if s.chars().count() <= cap {
+        return s.to_string();
+    }
+    let truncated: String = s.chars().take(cap).collect();
+    format!("{truncated}…")
 }
 
 fn format_from(email: &str, name: Option<&str>) -> String {

--- a/src/App.css
+++ b/src/App.css
@@ -4706,6 +4706,73 @@ input.nh-title {
   color: var(--fg);
   margin: 0;
 }
+
+/* ----- User notes (#77) ----- */
+.workstream-user-notes {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.workstream-user-notes.is-empty {
+  margin: 0;
+}
+.workstream-user-notes-add-link {
+  align-self: flex-start;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12.5px;
+  color: var(--fg-muted);
+  padding: 4px 0;
+  border-bottom: 1px dashed var(--home-line);
+}
+.workstream-user-notes-add-link:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+.workstream-user-notes-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.workstream-user-notes-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.workstream-user-notes-status {
+  font-size: 11px;
+  color: var(--fg-muted);
+  transition: opacity 200ms ease;
+}
+.workstream-user-notes-status.status-idle {
+  opacity: 0;
+}
+.workstream-user-notes-status.status-error {
+  color: #c44a1f;
+}
+.workstream-user-notes-textarea {
+  width: 100%;
+  min-height: 80px;
+  resize: vertical;
+  font: inherit;
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--fg);
+  background: var(--bg-elev);
+  border: 0.5px solid var(--home-line);
+  border-radius: 6px;
+  padding: 8px 10px;
+  box-sizing: border-box;
+}
+.workstream-user-notes-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
 .workstream-section {
   display: flex;
   flex-direction: column;

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -6,7 +6,7 @@
 //! pipeline added in #70 and listens for `workstream-status` to
 //! refetch.
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   type EmailMessage,
@@ -19,6 +19,7 @@ import {
   openOrCreateEventNote,
   setWorkstreamActionDone,
   setWorkstreamStatus,
+  setWorkstreamUserNotes,
 } from "./file";
 import { IconChevLeft } from "./icons";
 
@@ -271,6 +272,14 @@ function WorkstreamDetailView({
       />
       <p className="workstream-detail-summary">{detail.summary}</p>
 
+      <WorkstreamUserNotes
+        workstreamId={detail.id}
+        initialNotes={detail.user_notes}
+        onSaved={(notes) =>
+          setDetail((d) => (d ? { ...d, user_notes: notes } : d))
+        }
+      />
+
       <ActionsSection actions={detail.actions} onToggle={onToggleAction} />
 
       <EmailsSection emails={detail.emails} />
@@ -282,6 +291,133 @@ function WorkstreamDetailView({
 
       <NotesSection notes={detail.notes} onOpenNote={onOpenNote} />
     </div>
+  );
+}
+
+// ----- User notes (#77) ----------------------------------------------------
+
+type SaveStatus = "idle" | "saving" | "saved" | "error";
+
+function WorkstreamUserNotes({
+  workstreamId,
+  initialNotes,
+  onSaved,
+}: {
+  workstreamId: string;
+  initialNotes: string | null;
+  onSaved: (notes: string | null) => void;
+}) {
+  const [draft, setDraft] = useState<string>(initialNotes ?? "");
+  const [editing, setEditing] = useState<boolean>(!!initialNotes);
+  const [status, setStatus] = useState<SaveStatus>("idle");
+
+  // Re-seed when navigating between workstreams. The detail view
+  // unmount/remounts on selectedId change, but useState keeps initial
+  // values across renders — guard by id.
+  const seededIdRef = useRef<string>(workstreamId);
+  useEffect(() => {
+    if (seededIdRef.current !== workstreamId) {
+      seededIdRef.current = workstreamId;
+      setDraft(initialNotes ?? "");
+      setEditing(!!initialNotes);
+      setStatus("idle");
+    }
+  }, [workstreamId, initialNotes]);
+
+  // Latest persisted text — used for revert-on-error and to detect
+  // no-op saves.
+  const persistedRef = useRef<string | null>(initialNotes);
+  // Latest workstream id at fire time so a debounced save that resolves
+  // after the user navigates away doesn't mis-patch a different
+  // workstream.
+  const idRef = useRef<string>(workstreamId);
+  useEffect(() => {
+    idRef.current = workstreamId;
+  }, [workstreamId]);
+
+  const save = useCallback(
+    async (text: string) => {
+      const idAtFire = idRef.current;
+      const normalized = text.trim().length === 0 ? null : text;
+      if (normalized === persistedRef.current) {
+        return; // no-op, draft matches DB
+      }
+      setStatus("saving");
+      try {
+        await setWorkstreamUserNotes(idAtFire, normalized);
+        // If the user navigated to a different workstream while this
+        // was in flight, drop the patch on the floor.
+        if (idAtFire !== idRef.current) return;
+        persistedRef.current = normalized;
+        onSaved(normalized);
+        setStatus("saved");
+      } catch (e) {
+        console.error("[workstreams] save user notes failed", e);
+        if (idAtFire !== idRef.current) return;
+        setStatus("error");
+      }
+    },
+    [onSaved],
+  );
+
+  // 600ms debounce on draft change. Fires when the user pauses typing.
+  useEffect(() => {
+    if (!editing) return;
+    if ((draft || "") === (persistedRef.current ?? "")) return;
+    const t = window.setTimeout(() => {
+      void save(draft);
+    }, 600);
+    return () => window.clearTimeout(t);
+  }, [draft, editing, save]);
+
+  // Auto-clear the "saved" indicator after a beat so it doesn't sit
+  // there permanently.
+  useEffect(() => {
+    if (status !== "saved") return;
+    const t = window.setTimeout(() => setStatus("idle"), 1500);
+    return () => window.clearTimeout(t);
+  }, [status]);
+
+  if (!editing) {
+    return (
+      <section className="workstream-user-notes is-empty">
+        <button
+          type="button"
+          className="workstream-user-notes-add-link"
+          onClick={() => setEditing(true)}
+        >
+          Add context…
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section className="workstream-user-notes">
+      <div className="workstream-user-notes-head">
+        <span className="workstream-user-notes-label">Your notes</span>
+        <span
+          className={`workstream-user-notes-status status-${status}`}
+          aria-live="polite"
+        >
+          {status === "saving"
+            ? "Saving…"
+            : status === "saved"
+            ? "Saved"
+            : status === "error"
+            ? "Couldn't save — try again"
+            : ""}
+        </span>
+      </div>
+      <textarea
+        className="workstream-user-notes-textarea"
+        value={draft}
+        placeholder="Real deadline, internal owner, dollar value, scope clarifications…"
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => void save(draft)}
+        rows={4}
+      />
+    </section>
   );
 }
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -501,6 +501,9 @@ export type Workstream = {
   last_activity_ms: number;
   created_ms: number;
   updated_ms: number;
+  /** User-authored ground-truth context (#77). The synthesizer treats
+   *  this as authoritative; AI ask surfaces it via read_workstream. */
+  user_notes: string | null;
   email_count: number;
   event_count: number;
   note_count: number;
@@ -571,6 +574,17 @@ export async function setWorkstreamStatus(
   status: WorkstreamStatus,
 ): Promise<void> {
   await invoke<void>("set_workstream_status", { id, status });
+}
+
+/** Update a workstream's user-authored context (#77). Pass `null` to
+ *  clear. Whitespace-only strings are treated as a clear by the
+ *  backend, which persists `NULL` so the prompt-omission downstream
+ *  stays simple. */
+export async function setWorkstreamUserNotes(
+  id: string,
+  notes: string | null,
+): Promise<void> {
+  await invoke<void>("set_workstream_user_notes", { id, notes });
 }
 
 export type NoteMeta = { modified_ms: number };


### PR DESCRIPTION
## Summary
- Adds a free-form `user_notes TEXT` column on \`workstreams\` so the user can pin context the synthesizer can't infer (real deadlines, internal owners, scope clarifications, dollar value, "this is the new POC, not the legacy contract")
- Synthesizer treats user_notes as ground truth: explicit instruction in the system prompt, indented \`Notes:\` line under each existing-workstream entry in the cluster prompt, never overwritten on re-sync
- AI ask: one-line excerpt in the \`# Workstreams\` section so the model knows the notes exist; full text in \`read_workstream\` output near the top of the structured block
- Frontend: \`WorkstreamUserNotes\` component with debounced autosave (600ms), blur flush, race guard for cross-workstream navigation. Empty state is a dashed-link "Add context…" affordance; non-empty shows a textarea with status indicator
- Schema → v13 via single \`ALTER TABLE\`; \`write_workstream\` deliberately omits \`user_notes\` from its UPDATE clause so user state survives re-clusters (same pattern as \`linked_note_path\` on calendar events)

First half of the manual-curation pair on top of the v1 milestone. #78 (archive + resurface) is the other half.

## Notes
- 4000-char cap when included in any prompt; storage is unbounded
- Whitespace-only input is trimmed and persisted as \`NULL\` by the Tauri command so the prompt-omission \`filter(|s| !s.is_empty())\` downstream stays simple
- The existing-workstreams section in the synthesizer prompt is the load-bearing place — that's where Claude reconciles new evidence against past state, so user_notes there carry the most weight

## Test plan
- [x] \`cargo check\` clean
- [x] \`bunx tsc --noEmit -p tsconfig.json\` clean
- [x] \`cargo test --lib\` — 180 passing, 5 new (3 persist, 2 ask)
- [ ] Manual: open a workstream → click "Add context…" → type "real deadline May 30" → blur → "Saved" indicator → reload app → notes survived
- [ ] Manual: \`sqlite3 ~/.margin/index.db "SELECT title, user_notes FROM workstreams WHERE user_notes IS NOT NULL"\` returns the row
- [ ] Manual: force a re-cluster → the \`Notes:\` line appears in the synthesizer prompt; the cluster pass produces a summary that respects the notes (test by writing a contradiction and observing it doesn't propagate)
- [ ] Manual: ask AI "what's happening with X?" where X has notes → response reflects them; tool pill shows "Reading workstream …"
- [ ] Manual: clear textarea → blur → DB goes back to NULL, UI returns to empty affordance
- [ ] Manual: type 5000 chars → save succeeds, prompt truncates with \`…\` marker