### PR TITLE
Owner + members on workstreams (#81)

### DIFF
--- a/src-tauri/src/ask.rs
+++ b/src-tauri/src/ask.rs
@@ -1115,7 +1115,7 @@ fn dispatch_read_workstream(
     let ws = &workstreams[n - 1];
     let label = format!("W{n}");
 
-    let detail = {
+    let (detail, team_by_id) = {
         let conn_state = app.state::<std::sync::Mutex<rusqlite::Connection>>();
         let c = match conn_state.lock() {
             Ok(g) => g,
@@ -1126,7 +1126,7 @@ fn dispatch_read_workstream(
                 };
             }
         };
-        match crate::workstreams::persist::get_workstream_detail(&c, &ws.id) {
+        let detail = match crate::workstreams::persist::get_workstream_detail(&c, &ws.id) {
             Ok(Some(d)) => d,
             Ok(None) => {
                 return ToolResult {
@@ -1143,11 +1143,17 @@ fn dispatch_read_workstream(
                     is_error: true,
                 };
             }
-        }
+        };
+        let team = crate::team::list_team_members_raw(&c).unwrap_or_default();
+        let team_by_id: std::collections::HashMap<String, String> = team
+            .into_iter()
+            .map(|m| (m.id, m.display_name))
+            .collect();
+        (detail, team_by_id)
     };
 
     ToolResult {
-        content: format_workstream_detail(&label, &detail),
+        content: format_workstream_detail(&label, &detail, &team_by_id),
         is_error: false,
     }
 }
@@ -1155,6 +1161,7 @@ fn dispatch_read_workstream(
 fn format_workstream_detail(
     label: &str,
     detail: &crate::workstreams::WorkstreamDetail,
+    team_by_id: &std::collections::HashMap<String, String>,
 ) -> String {
     let mut s = String::new();
     s.push_str(&format!(
@@ -1164,6 +1171,25 @@ fn format_workstream_detail(
     ));
     if !detail.workstream.summary.is_empty() {
         s.push_str(&format!("\n{}\n", detail.workstream.summary.trim()));
+    }
+
+    // Owner + members (#81). Both are user/derived data — show before
+    // user_notes so the model has the people first.
+    if let Some(owner_id) = detail.workstream.owner_member_id.as_deref() {
+        if let Some(name) = team_by_id.get(owner_id) {
+            s.push_str(&format!("\nOwner: {name}\n"));
+        }
+    }
+    if !detail.workstream.members.is_empty() {
+        let names: Vec<&str> = detail
+            .workstream
+            .members
+            .iter()
+            .filter_map(|id| team_by_id.get(id).map(String::as_str))
+            .collect();
+        if !names.is_empty() {
+            s.push_str(&format!("Members: {}\n", names.join(", ")));
+        }
     }
 
     // User-authored notes are ground truth (#77). Surface in full near
@@ -1488,7 +1514,11 @@ fn format_user_message(
     s.push_str(&format_schedule_section(schedule));
 
     if !workstreams.is_empty() {
-        s.push_str(&format_workstreams_section(workstreams));
+        let team_by_id: std::collections::HashMap<&str, &str> = profiles
+            .iter()
+            .map(|(m, _)| (m.id.as_str(), m.display_name.as_str()))
+            .collect();
+        s.push_str(&format_workstreams_section(workstreams, &team_by_id));
     }
 
     s.push_str("# Question\n\n");
@@ -1500,7 +1530,10 @@ fn format_user_message(
 /// Each workstream becomes one line with its `[W<N>]` label, title,
 /// one-line summary, and item counts. Empty input emits nothing — the
 /// caller decides whether to skip the section entirely.
-fn format_workstreams_section(workstreams: &[crate::workstreams::Workstream]) -> String {
+fn format_workstreams_section(
+    workstreams: &[crate::workstreams::Workstream],
+    team_by_id: &std::collections::HashMap<&str, &str>,
+) -> String {
     let mut s = String::new();
     s.push_str("# Workstreams\n\n");
     for (i, w) in workstreams.iter().enumerate() {
@@ -1534,6 +1567,33 @@ fn format_workstreams_section(workstreams: &[crate::workstreams::Workstream]) ->
                 counts = counts_suffix,
             ),
         );
+        // Owner + members (#81). One-line excerpts; the full lists are
+        // in `read_workstream` for richer reasoning.
+        if let Some(owner_id) = w.owner_member_id.as_deref() {
+            if let Some(name) = team_by_id.get(owner_id) {
+                s.push_str(&format!("    Owner: {name}\n"));
+            }
+        }
+        if !w.members.is_empty() {
+            let names: Vec<&str> = w
+                .members
+                .iter()
+                .filter_map(|id| team_by_id.get(id.as_str()).copied())
+                .take(8)
+                .collect();
+            if !names.is_empty() {
+                let suffix = if w.members.len() > names.len() {
+                    format!(" (+{} more)", w.members.len() - names.len())
+                } else {
+                    String::new()
+                };
+                s.push_str(&format!(
+                    "    Members: {names}{suffix}\n",
+                    names = names.join(", "),
+                    suffix = suffix
+                ));
+            }
+        }
         // User-authored ground truth (#77). Show a one-line excerpt
         // here so the model knows it exists; the full text is in the
         // `read_workstream` tool result.
@@ -1702,6 +1762,8 @@ mod tests {
             user_notes: None,
             archived_at_ms: None,
             reopened_at_ms: None,
+            owner_member_id: None,
+            members: Vec::new(),
             email_count: 0,
             event_count: 0,
             note_count: 0,
@@ -1718,7 +1780,8 @@ mod tests {
 
         let b = make_ws("ws_b", "Q3 hiring", "Sourcing two seniors.", 50);
 
-        let out = format_workstreams_section(&[a, b]);
+        let team_map: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+        let out = format_workstreams_section(&[a, b], &team_map);
         assert!(out.starts_with("# Workstreams\n\n"));
         assert!(out.contains("[W1] Hyundai POC"));
         assert!(out.contains("[W2] Q3 hiring"));
@@ -1735,7 +1798,8 @@ mod tests {
     fn format_workstreams_section_truncates_long_summary() {
         let long = "X".repeat(WORKSTREAM_SUMMARY_CAP + 50);
         let w = make_ws("ws", "Title", &long, 0);
-        let out = format_workstreams_section(&[w]);
+        let team_map: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+        let out = format_workstreams_section(&[w], &team_map);
         // Truncated with the …  marker from truncate_chars.
         assert!(out.contains('…'), "expected truncation marker in: {out}");
         // Doesn't contain the trailing portion (50 chars past the cap).
@@ -1789,6 +1853,8 @@ mod tests {
                 user_notes: None,
                 archived_at_ms: None,
                 reopened_at_ms: None,
+                owner_member_id: None,
+                members: Vec::new(),
                 email_count: 2,
                 event_count: 0,
                 note_count: 1,
@@ -1806,7 +1872,8 @@ mod tests {
             }],
             actions: vec![make_action("Reply to invoice", false), make_action("Send quote", true)],
         };
-        let out = format_workstream_detail("W1", &detail);
+        let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let out = format_workstream_detail("W1", &detail, &team_map);
         assert!(out.starts_with("# [W1] Hyundai POC\n"));
         assert!(out.contains("Invoicing in flight."));
         assert!(out.contains("Actions (1 open, 1 done)"));
@@ -1840,6 +1907,8 @@ mod tests {
                 user_notes: None,
                 archived_at_ms: None,
                 reopened_at_ms: None,
+                owner_member_id: None,
+                members: Vec::new(),
                 email_count: emails.len() as u32,
                 event_count: 0,
                 note_count: 0,
@@ -1850,7 +1919,8 @@ mod tests {
             notes: vec![],
             actions: vec![],
         };
-        let out = format_workstream_detail("W2", &detail);
+        let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let out = format_workstream_detail("W2", &detail, &team_map);
         let total = WORKSTREAM_DETAIL_TOP_N + 3;
         assert!(
             out.contains(&format!("Recent emails (top {} of {})", WORKSTREAM_DETAIL_TOP_N, total)),
@@ -1869,7 +1939,8 @@ mod tests {
     fn format_workstreams_section_one_line_excerpt_when_user_notes_present() {
         let mut a = make_ws("ws_a", "Hyundai POC", "Final invoice details.", 100);
         a.user_notes = Some("Real deadline May 30 (calendar shows June). TJ owns this internally.".into());
-        let out = format_workstreams_section(&[a]);
+        let team_map: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+        let out = format_workstreams_section(&[a], &team_map);
         assert!(out.contains("[W1] Hyundai POC"));
         assert!(
             out.contains("(user notes: Real deadline May 30"),
@@ -1891,6 +1962,8 @@ mod tests {
                 user_notes: Some("Real deadline May 30. New POC, not legacy contract.".into()),
                 archived_at_ms: None,
                 reopened_at_ms: None,
+                owner_member_id: None,
+                members: Vec::new(),
                 email_count: 0,
                 event_count: 0,
                 note_count: 0,
@@ -1901,7 +1974,8 @@ mod tests {
             notes: vec![],
             actions: vec![],
         };
-        let out = format_workstream_detail("W1", &detail);
+        let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let out = format_workstream_detail("W1", &detail, &team_map);
         assert!(out.contains("# [W1] Hyundai POC"));
         // Summary still rendered.
         assert!(out.contains("Invoicing in flight."));
@@ -1924,6 +1998,8 @@ mod tests {
                 user_notes: None,
                 archived_at_ms: None,
                 reopened_at_ms: None,
+                owner_member_id: None,
+                members: Vec::new(),
                 email_count: 0,
                 event_count: 0,
                 note_count: 0,
@@ -1934,7 +2010,8 @@ mod tests {
             notes: vec![],
             actions: vec![],
         };
-        let out = format_workstream_detail("W3", &detail);
+        let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let out = format_workstream_detail("W3", &detail, &team_map);
         assert_eq!(out, "# [W3] Bare\n");
     }
 }

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -45,7 +45,8 @@ const SCHEMA_V11: &str = include_str!("migrations/011_email.sql");
 const SCHEMA_V12: &str = include_str!("migrations/012_workstreams.sql");
 const SCHEMA_V13: &str = include_str!("migrations/013_workstream_user_notes.sql");
 const SCHEMA_V14: &str = include_str!("migrations/014_workstream_archive_resurface.sql");
-const SCHEMA_VERSION: i64 = 14;
+const SCHEMA_V15: &str = include_str!("migrations/015_workstream_owner.sql");
+const SCHEMA_VERSION: i64 = 15;
 
 /// Open the index DB at `db_path` (creating it if absent) and apply any
 /// pending migrations.
@@ -143,6 +144,10 @@ fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 13 {
         conn.execute_batch(SCHEMA_V14)?;
         version = 14;
+    }
+    if version == 14 {
+        conn.execute_batch(SCHEMA_V15)?;
+        version = 15;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -693,7 +693,8 @@ pub fn run() {
             workstreams::commands::set_workstream_status,
             workstreams::commands::set_workstream_user_notes,
             workstreams::commands::list_archived_workstreams,
-            workstreams::commands::mark_workstream_seen
+            workstreams::commands::mark_workstream_seen,
+            workstreams::commands::set_workstream_owner
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/migrations/015_workstream_owner.sql
+++ b/src-tauri/src/migrations/015_workstream_owner.sql
@@ -1,0 +1,4 @@
+ALTER TABLE workstreams ADD COLUMN owner_member_id TEXT REFERENCES team_members(id) ON DELETE SET NULL;
+CREATE INDEX idx_workstreams_owner ON workstreams(owner_member_id);
+
+UPDATE meta SET value = '15' WHERE key = 'schema_version';

--- a/src-tauri/src/workstreams/commands.rs
+++ b/src-tauri/src/workstreams/commands.rs
@@ -91,3 +91,15 @@ pub fn mark_workstream_seen(
     let c = conn.lock().map_err(|e| e.to_string())?;
     persist::mark_seen(&c, &id).map_err(|e| e.to_string())
 }
+
+/// Set or clear a workstream's owner (#81). Pass `None` to unassign.
+/// User-only authority — synthesizer never sets this.
+#[tauri::command]
+pub fn set_workstream_owner(
+    id: String,
+    owner_member_id: Option<String>,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<(), String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    persist::set_owner(&c, &id, owner_member_id.as_deref()).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/workstreams/mod.rs
+++ b/src-tauri/src/workstreams/mod.rs
@@ -33,7 +33,7 @@ pub fn cluster_lock() -> &'static Mutex<()> {
 }
 
 /// Persisted workstream row + joined counts for the list view.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct Workstream {
     pub id: String,
     pub title: String,
@@ -55,6 +55,16 @@ pub struct Workstream {
     /// detail-view unmount via `mark_workstream_seen`. The "Reopened"
     /// badge is just `reopened_at_ms.is_some() && status == "active"`.
     pub reopened_at_ms: Option<i64>,
+    /// User-set internal owner of the workstream (#81). Single
+    /// team_member id; `None` when unassigned. Synthesizer never sets
+    /// this — same authority pattern as user_notes.
+    pub owner_member_id: Option<String>,
+    /// Derived list of team_member ids involved in the workstream
+    /// (#81). Computed on read by joining the workstream's pivot
+    /// emails / events against `email_recipients` / `calendar_attendees`
+    /// where `team_member_id IS NOT NULL`. UI maps ids to names via
+    /// the existing `listTeamMembers` cache.
+    pub members: Vec<String>,
     pub email_count: u32,
     pub event_count: u32,
     pub note_count: u32,

--- a/src-tauri/src/workstreams/persist.rs
+++ b/src-tauri/src/workstreams/persist.rs
@@ -70,7 +70,7 @@ pub fn set_last_clustered_ms(conn: &Connection, ms: i64) -> rusqlite::Result<()>
 pub fn list_workstreams_active(conn: &Connection) -> rusqlite::Result<Vec<Workstream>> {
     let mut stmt = conn.prepare(
         "SELECT w.id, w.title, w.summary, w.status, w.last_activity_ms, w.created_ms, w.updated_ms, \
-                w.user_notes, w.archived_at_ms, w.reopened_at_ms, \
+                w.user_notes, w.archived_at_ms, w.reopened_at_ms, w.owner_member_id, \
                 COALESCE((SELECT COUNT(*) FROM workstream_emails WHERE workstream_id = w.id), 0) AS ec, \
                 COALESCE((SELECT COUNT(*) FROM workstream_events WHERE workstream_id = w.id), 0) AS evc, \
                 COALESCE((SELECT COUNT(*) FROM workstream_notes  WHERE workstream_id = w.id), 0) AS nc, \
@@ -91,16 +91,19 @@ pub fn list_workstreams_active(conn: &Connection) -> rusqlite::Result<Vec<Workst
             user_notes: r.get(7)?,
             archived_at_ms: r.get(8)?,
             reopened_at_ms: r.get(9)?,
-            email_count: r.get::<_, i64>(10)? as u32,
-            event_count: r.get::<_, i64>(11)? as u32,
-            note_count: r.get::<_, i64>(12)? as u32,
-            open_action_count: r.get::<_, i64>(13)? as u32,
+            owner_member_id: r.get(10)?,
+            members: Vec::new(),
+            email_count: r.get::<_, i64>(11)? as u32,
+            event_count: r.get::<_, i64>(12)? as u32,
+            note_count: r.get::<_, i64>(13)? as u32,
+            open_action_count: r.get::<_, i64>(14)? as u32,
         })
     })?;
     let mut out = Vec::new();
     for row in rows {
         out.push(row?);
     }
+    attach_members(conn, &mut out)?;
     Ok(out)
 }
 
@@ -111,7 +114,7 @@ pub fn list_workstreams_archived(
 ) -> rusqlite::Result<Vec<Workstream>> {
     let mut stmt = conn.prepare(
         "SELECT w.id, w.title, w.summary, w.status, w.last_activity_ms, w.created_ms, w.updated_ms, \
-                w.user_notes, w.archived_at_ms, w.reopened_at_ms, \
+                w.user_notes, w.archived_at_ms, w.reopened_at_ms, w.owner_member_id, \
                 COALESCE((SELECT COUNT(*) FROM workstream_emails WHERE workstream_id = w.id), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_events WHERE workstream_id = w.id), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_notes  WHERE workstream_id = w.id), 0), \
@@ -132,16 +135,19 @@ pub fn list_workstreams_archived(
             user_notes: r.get(7)?,
             archived_at_ms: r.get(8)?,
             reopened_at_ms: r.get(9)?,
-            email_count: r.get::<_, i64>(10)? as u32,
-            event_count: r.get::<_, i64>(11)? as u32,
-            note_count: r.get::<_, i64>(12)? as u32,
-            open_action_count: r.get::<_, i64>(13)? as u32,
+            owner_member_id: r.get(10)?,
+            members: Vec::new(),
+            email_count: r.get::<_, i64>(11)? as u32,
+            event_count: r.get::<_, i64>(12)? as u32,
+            note_count: r.get::<_, i64>(13)? as u32,
+            open_action_count: r.get::<_, i64>(14)? as u32,
         })
     })?;
     let mut out = Vec::new();
     for row in rows {
         out.push(row?);
     }
+    attach_members(conn, &mut out)?;
     Ok(out)
 }
 
@@ -157,7 +163,7 @@ pub fn list_workstreams_for_synthesis(
 ) -> rusqlite::Result<Vec<(Workstream, bool)>> {
     let mut stmt = conn.prepare(
         "SELECT w.id, w.title, w.summary, w.status, w.last_activity_ms, w.created_ms, w.updated_ms, \
-                w.user_notes, w.archived_at_ms, w.reopened_at_ms, \
+                w.user_notes, w.archived_at_ms, w.reopened_at_ms, w.owner_member_id, \
                 COALESCE((SELECT COUNT(*) FROM workstream_emails WHERE workstream_id = w.id), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_events WHERE workstream_id = w.id), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_notes  WHERE workstream_id = w.id), 0), \
@@ -183,10 +189,12 @@ pub fn list_workstreams_for_synthesis(
                 user_notes: r.get(7)?,
                 archived_at_ms: r.get(8)?,
                 reopened_at_ms: r.get(9)?,
-                email_count: r.get::<_, i64>(10)? as u32,
-                event_count: r.get::<_, i64>(11)? as u32,
-                note_count: r.get::<_, i64>(12)? as u32,
-                open_action_count: r.get::<_, i64>(13)? as u32,
+                owner_member_id: r.get(10)?,
+                members: Vec::new(),
+                email_count: r.get::<_, i64>(11)? as u32,
+                event_count: r.get::<_, i64>(12)? as u32,
+                note_count: r.get::<_, i64>(13)? as u32,
+                open_action_count: r.get::<_, i64>(14)? as u32,
             },
             is_archived,
         ))
@@ -194,6 +202,13 @@ pub fn list_workstreams_for_synthesis(
     let mut out = Vec::new();
     for row in rows {
         out.push(row?);
+    }
+    // Attach members to the workstreams (mutating in place via a
+    // throwaway view onto just the Workstream side of the tuple).
+    let mut just_ws: Vec<Workstream> = out.iter().map(|(w, _)| w.clone()).collect();
+    attach_members(conn, &mut just_ws)?;
+    for (i, (w, _)) in out.iter_mut().enumerate() {
+        w.members = std::mem::take(&mut just_ws[i].members);
     }
     Ok(out)
 }
@@ -278,32 +293,99 @@ pub fn get_workstream_detail(
 fn get_workstream_one(conn: &Connection, id: &str) -> rusqlite::Result<Option<Workstream>> {
     let mut stmt = conn.prepare(
         "SELECT w.id, w.title, w.summary, w.status, w.last_activity_ms, w.created_ms, w.updated_ms, \
-                w.user_notes, w.archived_at_ms, w.reopened_at_ms, \
+                w.user_notes, w.archived_at_ms, w.reopened_at_ms, w.owner_member_id, \
                 COALESCE((SELECT COUNT(*) FROM workstream_emails WHERE workstream_id = w.id), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_events WHERE workstream_id = w.id), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_notes  WHERE workstream_id = w.id), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0) \
          FROM workstreams w WHERE w.id = ?1",
     )?;
-    stmt.query_row(params![id], |r| {
-        Ok(Workstream {
-            id: r.get(0)?,
-            title: r.get(1)?,
-            summary: r.get(2)?,
-            status: r.get(3)?,
-            last_activity_ms: r.get(4)?,
-            created_ms: r.get(5)?,
-            updated_ms: r.get(6)?,
-            user_notes: r.get(7)?,
-            archived_at_ms: r.get(8)?,
-            reopened_at_ms: r.get(9)?,
-            email_count: r.get::<_, i64>(10)? as u32,
-            event_count: r.get::<_, i64>(11)? as u32,
-            note_count: r.get::<_, i64>(12)? as u32,
-            open_action_count: r.get::<_, i64>(13)? as u32,
+    let mut ws = stmt
+        .query_row(params![id], |r| {
+            Ok(Workstream {
+                id: r.get(0)?,
+                title: r.get(1)?,
+                summary: r.get(2)?,
+                status: r.get(3)?,
+                last_activity_ms: r.get(4)?,
+                created_ms: r.get(5)?,
+                updated_ms: r.get(6)?,
+                user_notes: r.get(7)?,
+                archived_at_ms: r.get(8)?,
+                reopened_at_ms: r.get(9)?,
+                owner_member_id: r.get(10)?,
+                members: Vec::new(),
+                email_count: r.get::<_, i64>(11)? as u32,
+                event_count: r.get::<_, i64>(12)? as u32,
+                note_count: r.get::<_, i64>(13)? as u32,
+                open_action_count: r.get::<_, i64>(14)? as u32,
+            })
         })
-    })
-    .optional()
+        .optional()?;
+    if let Some(ref mut w) = ws {
+        let mut single = vec![std::mem::take(w)];
+        attach_members(conn, &mut single)?;
+        *w = single.pop().unwrap();
+    }
+    Ok(ws)
+}
+
+/// Bulk-derive members for a slice of workstreams (#81). Members are
+/// the team_member ids that resolve from the workstream's email
+/// recipients and event attendees. One UNION query covers all rows in
+/// the slice — far cheaper than per-workstream fetches in the list
+/// view. No-op when the slice is empty.
+fn attach_members(
+    conn: &Connection,
+    workstreams: &mut [Workstream],
+) -> rusqlite::Result<()> {
+    if workstreams.is_empty() {
+        return Ok(());
+    }
+    let placeholders = std::iter::repeat("?")
+        .take(workstreams.len())
+        .collect::<Vec<_>>()
+        .join(",");
+    // Two halves UNION'd then DISTINCT'd at the (workstream, member) level.
+    // Each member appears once per workstream regardless of how many
+    // emails / events they're on.
+    let sql = format!(
+        "SELECT DISTINCT workstream_id, member_id FROM ( \
+            SELECT we.workstream_id, er.team_member_id AS member_id \
+            FROM workstream_emails we \
+            JOIN email_recipients er ON er.message_id = we.message_id \
+            WHERE we.workstream_id IN ({placeholders}) AND er.team_member_id IS NOT NULL \
+            UNION \
+            SELECT wev.workstream_id, ca.team_member_id AS member_id \
+            FROM workstream_events wev \
+            JOIN calendar_attendees ca ON ca.event_id = wev.event_id \
+            WHERE wev.workstream_id IN ({placeholders}) AND ca.team_member_id IS NOT NULL \
+         ) ORDER BY workstream_id"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    // The IN list appears twice in the UNION; bind both.
+    let mut params_vec: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(workstreams.len() * 2);
+    for w in workstreams.iter() {
+        params_vec.push(&w.id as &dyn rusqlite::ToSql);
+    }
+    for w in workstreams.iter() {
+        params_vec.push(&w.id as &dyn rusqlite::ToSql);
+    }
+    let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), |r| {
+        Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+    })?;
+    let mut by_id: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    for row in rows {
+        let (ws_id, member_id) = row?;
+        by_id.entry(ws_id).or_default().push(member_id);
+    }
+    for w in workstreams.iter_mut() {
+        if let Some(members) = by_id.remove(&w.id) {
+            w.members = members;
+        }
+    }
+    Ok(())
 }
 
 fn list_actions_for(
@@ -592,6 +674,22 @@ pub fn set_status(conn: &Connection, id: &str, status: &str) -> rusqlite::Result
     Ok(())
 }
 
+/// Set or clear a workstream's owner (#81). Pass `None` to unassign.
+/// `write_workstream` deliberately doesn't touch this column, so
+/// owner survives re-clusters — same pattern as `user_notes` and
+/// `linked_note_path`.
+pub fn set_owner(
+    conn: &Connection,
+    id: &str,
+    owner_member_id: Option<&str>,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE workstreams SET owner_member_id = ?2, updated_ms = ?3 WHERE id = ?1",
+        params![id, owner_member_id, now_ms()],
+    )?;
+    Ok(())
+}
+
 /// Synthesizer-driven resurrect: flip an archived workstream back to
 /// active, stamp `reopened_at_ms = now`, leave `archived_at_ms` as
 /// historical record. No-op if the workstream isn't currently
@@ -692,6 +790,10 @@ mod tests {
         conn.execute_batch(include_str!("../migrations/013_workstream_user_notes.sql"))
             .unwrap();
         conn.execute_batch(include_str!("../migrations/014_workstream_archive_resurface.sql"))
+            .unwrap();
+        // 015 references team_members; the test setup already has the
+        // table created above, so the FK reference resolves at migrate time.
+        conn.execute_batch(include_str!("../migrations/015_workstream_owner.sql"))
             .unwrap();
         conn
     }
@@ -1218,5 +1320,125 @@ mod tests {
         let res = lookup_pre_status(&tx, "ws_x").unwrap();
         tx.commit().unwrap();
         assert_eq!(res.as_deref(), Some("archived"));
+    }
+
+    // ----- owner + members (#81) -------------------------------------------
+
+    #[test]
+    fn set_owner_round_trips() {
+        let mut conn = open_test_db();
+        conn.execute("INSERT INTO team_members(id) VALUES ('tm:tj')", [])
+            .unwrap();
+        seed_workstream(&mut conn, "ws_o");
+        // Default: no owner.
+        assert_eq!(
+            list_workstreams_active(&conn).unwrap()[0].owner_member_id,
+            None
+        );
+
+        set_owner(&conn, "ws_o", Some("tm:tj")).unwrap();
+        assert_eq!(
+            list_workstreams_active(&conn).unwrap()[0].owner_member_id.as_deref(),
+            Some("tm:tj")
+        );
+
+        set_owner(&conn, "ws_o", None).unwrap();
+        assert_eq!(
+            list_workstreams_active(&conn).unwrap()[0].owner_member_id,
+            None
+        );
+    }
+
+    #[test]
+    fn write_workstream_does_not_overwrite_owner_on_resync() {
+        let mut conn = open_test_db();
+        conn.execute("INSERT INTO team_members(id) VALUES ('tm:tj')", [])
+            .unwrap();
+        seed_workstream(&mut conn, "ws_oo");
+        set_owner(&conn, "ws_oo", Some("tm:tj")).unwrap();
+
+        // Re-cluster pass refreshes title/summary; owner must survive.
+        let tx = conn.transaction().unwrap();
+        write_workstream(
+            &tx,
+            &make_ws(Some("ws_oo"), "Renamed", &[], &[], &[], vec![]),
+            2_000,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        assert_eq!(
+            list_workstreams_active(&conn).unwrap()[0].owner_member_id.as_deref(),
+            Some("tm:tj")
+        );
+    }
+
+    #[test]
+    fn members_derived_from_email_recipients_and_event_attendees() {
+        let mut conn = open_test_db();
+        // Seed two team members.
+        conn.execute("INSERT INTO team_members(id) VALUES ('tm:heike'), ('tm:tj')", [])
+            .unwrap();
+
+        // An email + event referencing both. seed_email/seed_event from
+        // the calendar tests above set up the rows; recipients/attendees
+        // we add manually.
+        seed_email(&conn, "mg:test::m1", 1_000);
+        seed_event(&conn, "mg:test::e1", 2_000);
+        conn.execute(
+            "INSERT INTO email_recipients(message_id, email, recipient_type, team_member_id) \
+             VALUES ('mg:test::m1', 'heike@e.com', 'to', 'tm:heike')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO calendar_attendees(event_id, email, team_member_id) \
+             VALUES ('mg:test::e1', 'tj@e.com', 'tm:tj')",
+            [],
+        )
+        .unwrap();
+
+        let tx = conn.transaction().unwrap();
+        write_workstream(
+            &tx,
+            &make_ws(
+                Some("ws_p"),
+                "WS",
+                &["mg:test::m1"],
+                &["mg:test::e1"],
+                &[],
+                vec![],
+            ),
+            1_000,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        let ws = &list_workstreams_active(&conn).unwrap()[0];
+        let mut members = ws.members.clone();
+        members.sort();
+        assert_eq!(members, vec!["tm:heike".to_string(), "tm:tj".to_string()]);
+    }
+
+    #[test]
+    fn members_excludes_unresolved_email_recipients() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+        // Recipient with no team_member_id (NULL) — must not show up.
+        conn.execute(
+            "INSERT INTO email_recipients(message_id, email, recipient_type, team_member_id) \
+             VALUES ('mg:test::m1', 'unknown@e.com', 'to', NULL)",
+            [],
+        )
+        .unwrap();
+        let tx = conn.transaction().unwrap();
+        write_workstream(
+            &tx,
+            &make_ws(Some("ws_q"), "WS", &["mg:test::m1"], &[], &[], vec![]),
+            1_000,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        assert!(list_workstreams_active(&conn).unwrap()[0].members.is_empty());
     }
 }

--- a/src-tauri/src/workstreams/synthesizer.rs
+++ b/src-tauri/src/workstreams/synthesizer.rs
@@ -22,6 +22,7 @@ use crate::anthropic::{ANTHROPIC_VERSION, DEFAULT_MODEL, ENDPOINT};
 use crate::connectors::{calendar, email, microsoft_graph, oauth};
 use crate::index;
 use crate::keychain;
+use crate::team;
 
 /// 6 hours. Boot tick + manual Refresh are no-ops if a successful pass
 /// landed within this window.
@@ -150,7 +151,7 @@ async fn run_cluster_pass(
     now_ms: i64,
 ) -> Result<ClusterReport, String> {
     // ---- 1. Snapshot inputs in a single lock window ---------------------
-    let (existing_active, existing_archived, mut emails, events, notes) = {
+    let (existing_active, existing_archived, mut emails, events, notes, team) = {
         let c = conn_state.lock().map_err(|e| e.to_string())?;
         // Pull both active and archived (snoozed excluded — they're
         // hidden from synthesis) and partition into separate sections
@@ -194,8 +195,13 @@ async fn run_cluster_pass(
                 modified_ms: d.modified_ms,
             })
             .collect();
-        (active, archived, emails, events, notes)
+        let team = team::list_team_members_raw(&c).unwrap_or_default();
+        (active, archived, emails, events, notes, team)
     };
+    let team_by_id: std::collections::HashMap<String, String> = team
+        .iter()
+        .map(|m| (m.id.clone(), m.display_name.clone()))
+        .collect();
 
     if emails.is_empty() && events.is_empty() && notes.is_empty() {
         eprintln!("[workstreams] no recent items to cluster; skipping");
@@ -260,6 +266,7 @@ async fn run_cluster_pass(
         &emails,
         &events,
         &notes,
+        &team_by_id,
     );
     let items_clustered = (emails.len() + events.len() + notes.len()) as u32;
 
@@ -420,6 +427,7 @@ fn build_user_message(
     emails: &[email::EmailMessage],
     events: &[calendar::CalendarEvent],
     notes: &[NoteRef],
+    team_by_id: &std::collections::HashMap<String, String>,
 ) -> (String, LabelMaps) {
     let mut s = String::new();
     s.push_str("# Existing workstreams (active)\n\n");
@@ -433,6 +441,31 @@ fn build_user_message(
                 w.title,
                 summarize_one_line(&w.summary)
             ));
+            if let Some(owner_id) = w.owner_member_id.as_deref() {
+                if let Some(name) = team_by_id.get(owner_id) {
+                    s.push_str(&format!("   Owner: {name}\n"));
+                }
+            }
+            if !w.members.is_empty() {
+                let names: Vec<&str> = w
+                    .members
+                    .iter()
+                    .filter_map(|id| team_by_id.get(id).map(String::as_str))
+                    .take(8)
+                    .collect();
+                if !names.is_empty() {
+                    let suffix = if w.members.len() > names.len() {
+                        format!(" (+{} more)", w.members.len() - names.len())
+                    } else {
+                        String::new()
+                    };
+                    s.push_str(&format!(
+                        "   Members: {names}{suffix}\n",
+                        names = names.join(", "),
+                        suffix = suffix
+                    ));
+                }
+            }
             if let Some(notes) = w.user_notes.as_deref().filter(|s| !s.trim().is_empty()) {
                 let collapsed = collapse_ws(notes);
                 let truncated = truncate_chars(&collapsed, USER_NOTES_PROMPT_CAP);

--- a/src/App.css
+++ b/src/App.css
@@ -4747,6 +4747,102 @@ input.nh-title {
   gap: 10px;
   opacity: 0.85;
 }
+
+/* ----- Owner + members (#81) ----- */
+
+.workstream-filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--fg-muted);
+}
+.workstream-filter select {
+  font: inherit;
+  font-size: 12.5px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: var(--home-chip);
+  color: var(--fg);
+  border: 0.5px solid var(--home-line);
+  cursor: pointer;
+}
+
+.workstream-owner-select {
+  font: inherit;
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: var(--home-chip);
+  color: var(--fg);
+  border: 0.5px solid var(--home-line);
+  cursor: pointer;
+  max-width: 180px;
+}
+
+.workstream-card-people {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+}
+.workstream-card-owner {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+.workstream-card-members {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--fg-muted);
+  padding: 2px 6px;
+  border-radius: 10px;
+  background: var(--home-chip);
+}
+
+.workstream-members-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 4px 0;
+}
+.workstream-member-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px 3px 3px;
+  border-radius: 14px;
+  background: var(--bg-elev);
+  border: 0.5px solid var(--home-line);
+  font-size: 12px;
+  color: var(--fg);
+}
+.workstream-member-chip.is-owner {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-elev));
+}
+.workstream-member-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  color: white;
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+.workstream-member-name {
+  padding-right: 2px;
+}
 .workstream-card-counts {
   font-size: 12px;
   color: var(--fg-muted);

--- a/src/App.css
+++ b/src/App.css
@@ -4780,31 +4780,74 @@ input.nh-title {
   max-width: 180px;
 }
 
+/* Card people row: owner + members rendered as chips (#81). Owner is
+   highlighted with the accent color; overflow collapses into a +N
+   pill when the workstream has more participants than the chip cap. */
 .workstream-card-people {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 2px 0 6px;
+}
+/* Owner chip: filled-accent treatment + star prefix, distinct from
+   participant chips (which are outlined with an avatar). Visually
+   communicates "primary / role-bearing person". */
+.workstream-card-owner-chip {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  white-space: nowrap;
+  gap: 4px;
+  padding: 2px 9px;
+  border-radius: 11px;
+  background: var(--accent);
+  border: 0.5px solid var(--accent);
+  color: white;
+  font-size: 11.5px;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
 }
-.workstream-card-owner {
+.workstream-card-owner-mark {
+  display: inline-flex;
+  font-size: 10px;
+  line-height: 1;
+}
+
+.workstream-card-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px 2px 2px;
+  border-radius: 11px;
+  background: var(--bg-elev);
+  border: 0.5px solid var(--home-line);
+  font-size: 11.5px;
+  color: var(--fg);
+  line-height: 1.2;
+}
+.workstream-card-chip-avatar {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
   color: white;
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 700;
   letter-spacing: 0.04em;
 }
-.workstream-card-members {
+.workstream-card-chip-name {
+  padding-right: 1px;
+}
+.workstream-card-overflow {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 11px;
+  background: var(--home-chip);
+  color: var(--fg-muted);
   font-size: 11px;
   font-weight: 600;
-  color: var(--fg-muted);
-  padding: 2px 6px;
-  border-radius: 10px;
-  background: var(--home-chip);
 }
 
 .workstream-members-strip {
@@ -4824,9 +4867,26 @@ input.nh-title {
   font-size: 12px;
   color: var(--fg);
 }
-.workstream-member-chip.is-owner {
-  border-color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 10%, var(--bg-elev));
+/* Detail-view owner chip — matches the list card's filled-accent
+   treatment so owner is visually distinct from participants both
+   places. */
+.workstream-member-owner-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 12px;
+  border-radius: 14px;
+  background: var(--accent);
+  border: 0.5px solid var(--accent);
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+.workstream-member-owner-mark {
+  display: inline-flex;
+  font-size: 10.5px;
+  line-height: 1;
 }
 .workstream-member-avatar {
   display: inline-flex;

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -237,6 +237,11 @@ function applyMemberFilter<T extends Workstream>(
   );
 }
 
+/// Max member chips rendered on the card before overflow collapses
+/// into a `+N` pill. Owner always shows when present; the cap covers
+/// owner + non-owner members combined.
+const CARD_CHIP_CAP = 4;
+
 function WorkstreamCard({
   workstream: w,
   nowMs,
@@ -249,11 +254,29 @@ function WorkstreamCard({
   teamById: Map<string, TeamMember>;
 }) {
   const isReopened = w.reopened_at_ms != null && w.status === "active";
-  const owner = w.owner_member_id ? teamById.get(w.owner_member_id) : null;
-  // +N badge counts members beyond the owner.
-  const otherMemberCount = w.members.filter(
-    (id) => id !== w.owner_member_id,
-  ).length;
+
+  // Build the ordered list: owner first (if resolvable), then other
+  // members (deduped), in the order persist returned them.
+  const ordered: TeamMember[] = [];
+  const seen = new Set<string>();
+  if (w.owner_member_id) {
+    const m = teamById.get(w.owner_member_id);
+    if (m) {
+      ordered.push(m);
+      seen.add(m.id);
+    }
+  }
+  for (const id of w.members) {
+    if (seen.has(id)) continue;
+    const m = teamById.get(id);
+    if (m) {
+      ordered.push(m);
+      seen.add(m.id);
+    }
+  }
+  const visible = ordered.slice(0, CARD_CHIP_CAP);
+  const overflow = ordered.length - visible.length;
+
   return (
     <button type="button" className="workstream-card" onClick={onClick}>
       <div className="workstream-card-head">
@@ -265,33 +288,66 @@ function WorkstreamCard({
             </span>
           ) : null}
         </span>
-        <span className="workstream-card-people">
-          {owner ? (
-            <span
-              className="workstream-card-owner"
-              title={`Owner: ${owner.display_name}`}
-              style={{ background: avatarColor(owner.display_name) }}
-            >
-              {initialsFromName(owner.display_name)}
-            </span>
-          ) : null}
-          {otherMemberCount > 0 ? (
-            <span
-              className="workstream-card-members"
-              title={`${otherMemberCount} other member${otherMemberCount === 1 ? "" : "s"}`}
-            >
-              +{otherMemberCount}
-            </span>
-          ) : null}
-          <span className="workstream-card-time">
-            {formatPast(w.last_activity_ms, nowMs)}
-          </span>
+        <span className="workstream-card-time">
+          {formatPast(w.last_activity_ms, nowMs)}
         </span>
       </div>
+      {ordered.length > 0 ? (
+        <div className="workstream-card-people">
+          {visible.map((m) => {
+            const isOwner = m.id === w.owner_member_id;
+            if (isOwner) {
+              return (
+                <span
+                  key={m.id}
+                  className="workstream-card-owner-chip"
+                  title={`${m.display_name} (owner)`}
+                >
+                  <span aria-hidden className="workstream-card-owner-mark">
+                    ★
+                  </span>
+                  {firstName(m.display_name)}
+                </span>
+              );
+            }
+            return (
+              <span
+                key={m.id}
+                className="workstream-card-chip"
+                title={m.display_name}
+              >
+                <span
+                  className="workstream-card-chip-avatar"
+                  style={{ background: avatarColor(m.display_name) }}
+                >
+                  {initialsFromName(m.display_name)}
+                </span>
+                <span className="workstream-card-chip-name">
+                  {firstName(m.display_name)}
+                </span>
+              </span>
+            );
+          })}
+          {overflow > 0 ? (
+            <span
+              className="workstream-card-overflow"
+              title={`${overflow} more member${overflow === 1 ? "" : "s"}`}
+            >
+              +{overflow}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
       <p className="workstream-card-summary">{w.summary}</p>
       <div className="workstream-card-counts">{countLine(w)}</div>
     </button>
   );
+}
+
+function firstName(displayName: string): string {
+  const trimmed = displayName.trim();
+  const space = trimmed.indexOf(" ");
+  return space === -1 ? trimmed : trimmed.slice(0, space);
 }
 
 /// Collapsed accordion at the bottom of the Workstreams list. Loads
@@ -800,11 +856,25 @@ function MembersStrip({
     <section className="workstream-members-strip">
       {ordered.map((m) => {
         const isOwner = m.id === ownerId;
+        if (isOwner) {
+          return (
+            <span
+              key={m.id}
+              className="workstream-member-owner-chip"
+              title={`${m.display_name} (owner)`}
+            >
+              <span aria-hidden className="workstream-member-owner-mark">
+                ★
+              </span>
+              {m.display_name}
+            </span>
+          );
+        }
         return (
           <span
             key={m.id}
-            className={`workstream-member-chip ${isOwner ? "is-owner" : ""}`}
-            title={isOwner ? `${m.display_name} (owner)` : m.display_name}
+            className="workstream-member-chip"
+            title={m.display_name}
           >
             <span
               className="workstream-member-avatar"

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -6,10 +6,11 @@
 //! pipeline added in #70 and listens for `workstream-status` to
 //! refetch.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   type EmailMessage,
+  type TeamMember,
   type Workstream,
   type WorkstreamAction,
   type WorkstreamDetail,
@@ -17,13 +18,16 @@ import {
   getEmailBody,
   getWorkstreamDetails,
   listArchivedWorkstreams,
+  listTeamMembers,
   markWorkstreamSeen,
   openOrCreateEventNote,
   setWorkstreamActionDone,
+  setWorkstreamOwner,
   setWorkstreamStatus,
   setWorkstreamUserNotes,
 } from "./file";
 import { IconChevLeft } from "./icons";
+import { avatarColor, initialsFromName } from "./initials";
 
 // ----- List view -----------------------------------------------------------
 
@@ -43,6 +47,37 @@ export function WorkstreamsView({
   onOpenNote: (path: string) => void;
 }) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  // Team-member cache for owner / member chips (#81). Loaded once and
+  // refreshed on `margin:team-changed` events.
+  const [teamMembers, setTeamMembers] = useState<TeamMember[]>([]);
+  // Filter-by-member dropdown (#81). null = no filter (default).
+  const [memberFilter, setMemberFilter] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const members = await listTeamMembers();
+        if (!cancelled) setTeamMembers(members);
+      } catch (e) {
+        console.error("[workstreams] listTeamMembers failed", e);
+      }
+    })();
+    const onChanged = () => {
+      void listTeamMembers().then((m) => setTeamMembers(m)).catch(() => {});
+    };
+    window.addEventListener("margin:team-changed", onChanged);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("margin:team-changed", onChanged);
+    };
+  }, []);
+
+  const teamById = useMemo(() => {
+    const m = new Map<string, TeamMember>();
+    for (const t of teamMembers) m.set(t.id, t);
+    return m;
+  }, [teamMembers]);
 
   // External open: the AI ask palette dispatches `margin:open-workstream`
   // when a `[W*]` citation chip is clicked (#72). This view is only
@@ -66,9 +101,16 @@ export function WorkstreamsView({
         id={selectedId}
         onBack={() => setSelectedId(null)}
         onOpenNote={onOpenNote}
+        teamMembers={teamMembers}
+        teamById={teamById}
       />
     );
   }
+
+  // Filter dropdown options: every team member referenced as owner or
+  // member on at least one active workstream. Sorted by display_name.
+  const filterCandidates = useFilterCandidates(workstreams, teamById);
+  const filteredActive = applyMemberFilter(workstreams, memberFilter);
 
   const nowMs = Date.now();
 
@@ -104,6 +146,24 @@ export function WorkstreamsView({
         </div>
       ) : null}
 
+      {!loading && filterCandidates.length > 0 ? (
+        <div className="workstream-filter">
+          <label htmlFor="workstream-member-filter">Filter by member</label>
+          <select
+            id="workstream-member-filter"
+            value={memberFilter ?? ""}
+            onChange={(e) => setMemberFilter(e.target.value || null)}
+          >
+            <option value="">All</option>
+            {filterCandidates.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.display_name}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : null}
+
       {loading ? (
         <p className="home-empty">Loading…</p>
       ) : workstreams.length === 0 ? (
@@ -114,14 +174,19 @@ export function WorkstreamsView({
             then click Refresh to synthesize.
           </p>
         </div>
+      ) : filteredActive.length === 0 ? (
+        <p className="home-empty">
+          No active workstreams match this filter.
+        </p>
       ) : (
         <div className="workstream-list">
-          {workstreams.map((w) => (
+          {filteredActive.map((w) => (
             <WorkstreamCard
               key={w.id}
               workstream={w}
               nowMs={nowMs}
               onClick={() => setSelectedId(w.id)}
+              teamById={teamById}
             />
           ))}
         </div>
@@ -132,9 +197,41 @@ export function WorkstreamsView({
           onSelect={(id) => setSelectedId(id)}
           nowMs={nowMs}
           synthInFlight={synthInFlight}
+          teamById={teamById}
+          memberFilter={memberFilter}
         />
       )}
     </div>
+  );
+}
+
+function useFilterCandidates(
+  workstreams: Workstream[],
+  teamById: Map<string, TeamMember>,
+): TeamMember[] {
+  return useMemo(() => {
+    const ids = new Set<string>();
+    for (const w of workstreams) {
+      if (w.owner_member_id) ids.add(w.owner_member_id);
+      for (const m of w.members) ids.add(m);
+    }
+    const out: TeamMember[] = [];
+    for (const id of ids) {
+      const m = teamById.get(id);
+      if (m) out.push(m);
+    }
+    out.sort((a, b) => a.display_name.localeCompare(b.display_name));
+    return out;
+  }, [workstreams, teamById]);
+}
+
+function applyMemberFilter<T extends Workstream>(
+  workstreams: T[],
+  memberId: string | null,
+): T[] {
+  if (!memberId) return workstreams;
+  return workstreams.filter(
+    (w) => w.owner_member_id === memberId || w.members.includes(memberId),
   );
 }
 
@@ -142,12 +239,19 @@ function WorkstreamCard({
   workstream: w,
   nowMs,
   onClick,
+  teamById,
 }: {
   workstream: Workstream;
   nowMs: number;
   onClick: () => void;
+  teamById: Map<string, TeamMember>;
 }) {
   const isReopened = w.reopened_at_ms != null && w.status === "active";
+  const owner = w.owner_member_id ? teamById.get(w.owner_member_id) : null;
+  // +N badge counts members beyond the owner.
+  const otherMemberCount = w.members.filter(
+    (id) => id !== w.owner_member_id,
+  ).length;
   return (
     <button type="button" className="workstream-card" onClick={onClick}>
       <div className="workstream-card-head">
@@ -159,8 +263,27 @@ function WorkstreamCard({
             </span>
           ) : null}
         </span>
-        <span className="workstream-card-time">
-          {formatPast(w.last_activity_ms, nowMs)}
+        <span className="workstream-card-people">
+          {owner ? (
+            <span
+              className="workstream-card-owner"
+              title={`Owner: ${owner.display_name}`}
+              style={{ background: avatarColor(owner.display_name) }}
+            >
+              {initialsFromName(owner.display_name)}
+            </span>
+          ) : null}
+          {otherMemberCount > 0 ? (
+            <span
+              className="workstream-card-members"
+              title={`${otherMemberCount} other member${otherMemberCount === 1 ? "" : "s"}`}
+            >
+              +{otherMemberCount}
+            </span>
+          ) : null}
+          <span className="workstream-card-time">
+            {formatPast(w.last_activity_ms, nowMs)}
+          </span>
         </span>
       </div>
       <p className="workstream-card-summary">{w.summary}</p>
@@ -179,10 +302,14 @@ function ArchivedSection({
   onSelect,
   nowMs,
   synthInFlight,
+  teamById,
+  memberFilter,
 }: {
   onSelect: (id: string) => void;
   nowMs: number;
   synthInFlight: boolean;
+  teamById: Map<string, TeamMember>;
+  memberFilter: string | null;
 }) {
   const [archived, setArchived] = useState<Workstream[]>([]);
   const [expanded, setExpanded] = useState(false);
@@ -207,6 +334,8 @@ function ArchivedSection({
     }
   }, [synthInFlight, reload]);
 
+  const filtered = applyMemberFilter(archived, memberFilter);
+
   if (archived.length === 0) return null;
   return (
     <section className="workstream-archived-section">
@@ -217,19 +346,24 @@ function ArchivedSection({
         aria-expanded={expanded}
       >
         <span>{expanded ? "▾" : "▸"}</span>
-        Archived ({archived.length})
+        Archived ({memberFilter ? `${filtered.length}/${archived.length}` : archived.length})
       </button>
       {expanded ? (
-        <div className="workstream-archived-list">
-          {archived.map((w) => (
-            <WorkstreamCard
-              key={w.id}
-              workstream={w}
-              nowMs={nowMs}
-              onClick={() => onSelect(w.id)}
-            />
-          ))}
-        </div>
+        filtered.length === 0 ? (
+          <p className="home-empty">No archived workstreams match this filter.</p>
+        ) : (
+          <div className="workstream-archived-list">
+            {filtered.map((w) => (
+              <WorkstreamCard
+                key={w.id}
+                workstream={w}
+                nowMs={nowMs}
+                onClick={() => onSelect(w.id)}
+                teamById={teamById}
+              />
+            ))}
+          </div>
+        )
       ) : null}
     </section>
   );
@@ -256,10 +390,14 @@ function WorkstreamDetailView({
   id,
   onBack,
   onOpenNote,
+  teamMembers,
+  teamById,
 }: {
   id: string;
   onBack: () => void;
   onOpenNote: (path: string) => void;
+  teamMembers: TeamMember[];
+  teamById: Map<string, TeamMember>;
 }) {
   const [detail, setDetail] = useState<WorkstreamDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -395,8 +533,29 @@ function WorkstreamDetailView({
         onBack={onBack}
         status={detail.status}
         onChangeStatus={onChangeStatus}
+        ownerId={detail.owner_member_id}
+        teamMembers={teamMembers}
+        onChangeOwner={async (ownerId) => {
+          // Optimistic local update; revert on error.
+          const prev = detail.owner_member_id;
+          setDetail((d) => (d ? { ...d, owner_member_id: ownerId } : d));
+          try {
+            await setWorkstreamOwner(detail.id, ownerId);
+          } catch (e) {
+            console.error("[workstreams] setWorkstreamOwner failed", e);
+            setDetail((d) => (d ? { ...d, owner_member_id: prev } : d));
+          }
+        }}
       />
       <p className="workstream-detail-summary">{detail.summary}</p>
+
+      {detail.members.length > 0 ? (
+        <MembersStrip
+          memberIds={detail.members}
+          ownerId={detail.owner_member_id}
+          teamById={teamById}
+        />
+      ) : null}
 
       <WorkstreamUserNotes
         workstreamId={detail.id}
@@ -552,11 +711,17 @@ function DetailHeader({
   onBack,
   status,
   onChangeStatus,
+  ownerId,
+  teamMembers,
+  onChangeOwner,
 }: {
   title: string;
   onBack: () => void;
   status: WorkstreamStatus | null;
   onChangeStatus: (s: WorkstreamStatus) => void | Promise<void>;
+  ownerId?: string | null;
+  teamMembers?: TeamMember[];
+  onChangeOwner?: (ownerId: string | null) => void | Promise<void>;
 }) {
   return (
     <header className="workstream-header workstream-detail-header">
@@ -570,6 +735,21 @@ function DetailHeader({
         Back
       </button>
       <h1 className="workstream-title">{title}</h1>
+      {teamMembers && onChangeOwner ? (
+        <select
+          className="workstream-owner-select"
+          value={ownerId ?? ""}
+          onChange={(e) => onChangeOwner(e.target.value || null)}
+          aria-label="Workstream owner"
+        >
+          <option value="">Unassigned</option>
+          {teamMembers.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.display_name}
+            </option>
+          ))}
+        </select>
+      ) : null}
       {status ? (
         <select
           className="workstream-status"
@@ -583,6 +763,58 @@ function DetailHeader({
         </select>
       ) : null}
     </header>
+  );
+}
+
+function MembersStrip({
+  memberIds,
+  ownerId,
+  teamById,
+}: {
+  memberIds: string[];
+  ownerId: string | null;
+  teamById: Map<string, TeamMember>;
+}) {
+  // Owner first (bigger chip), then everyone else.
+  const ordered: TeamMember[] = [];
+  const seen = new Set<string>();
+  if (ownerId) {
+    const m = teamById.get(ownerId);
+    if (m) {
+      ordered.push(m);
+      seen.add(m.id);
+    }
+  }
+  for (const id of memberIds) {
+    if (seen.has(id)) continue;
+    const m = teamById.get(id);
+    if (m) {
+      ordered.push(m);
+      seen.add(m.id);
+    }
+  }
+  if (ordered.length === 0) return null;
+  return (
+    <section className="workstream-members-strip">
+      {ordered.map((m) => {
+        const isOwner = m.id === ownerId;
+        return (
+          <span
+            key={m.id}
+            className={`workstream-member-chip ${isOwner ? "is-owner" : ""}`}
+            title={isOwner ? `${m.display_name} (owner)` : m.display_name}
+          >
+            <span
+              className="workstream-member-avatar"
+              style={{ background: avatarColor(m.display_name) }}
+            >
+              {initialsFromName(m.display_name)}
+            </span>
+            <span className="workstream-member-name">{m.display_name}</span>
+          </span>
+        );
+      })}
+    </section>
   );
 }
 

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -95,6 +95,11 @@ export function WorkstreamsView({
     return () => window.removeEventListener("margin:open-workstream", onOpen);
   }, []);
 
+  // Filter dropdown options: every team member referenced as owner or
+  // member on at least one active workstream. Computed via useMemo —
+  // must run before any early return to satisfy the Rules of Hooks.
+  const filterCandidates = useFilterCandidates(workstreams, teamById);
+
   if (selectedId) {
     return (
       <WorkstreamDetailView
@@ -107,9 +112,6 @@ export function WorkstreamsView({
     );
   }
 
-  // Filter dropdown options: every team member referenced as owner or
-  // member on at least one active workstream. Sorted by display_name.
-  const filterCandidates = useFilterCandidates(workstreams, teamById);
   const filteredActive = applyMemberFilter(workstreams, memberFilter);
 
   const nowMs = Date.now();

--- a/src/file.ts
+++ b/src/file.ts
@@ -512,6 +512,13 @@ export type Workstream = {
    *  markWorkstreamSeen. The "Reopened" badge shows when this is set
    *  and status === "active". */
   reopened_at_ms: number | null;
+  /** User-set internal owner of the workstream (#81). Single team_member
+   *  id; null when unassigned. */
+  owner_member_id: string | null;
+  /** Derived list of team_member ids involved in the workstream (#81)
+   *  via email recipients and event attendees. UI maps ids to display
+   *  names through the existing team-member cache. */
+  members: string[];
   email_count: number;
   event_count: number;
   note_count: number;
@@ -610,6 +617,15 @@ export async function listArchivedWorkstreams(): Promise<Workstream[]> {
  *  isn't set. */
 export async function markWorkstreamSeen(id: string): Promise<void> {
   await invoke<void>("mark_workstream_seen", { id });
+}
+
+/** Set or clear a workstream's owner (#81). Pass `null` to unassign.
+ *  User-only authority — the synthesizer never sets this. */
+export async function setWorkstreamOwner(
+  id: string,
+  ownerMemberId: string | null,
+): Promise<void> {
+  await invoke<void>("set_workstream_owner", { id, ownerMemberId });
 }
 
 export type NoteMeta = { modified_ms: number };


### PR DESCRIPTION
## Summary
- Workstreams gain a user-set **owner** (\`owner_member_id\`) and a derived **members** list (team_members resolved from email recipients + event attendees). Owner is authoritative-from-user; members compute on read with a single UNION query.
- Schema → v15 via single ALTER TABLE.
- Detail view: owner \`<select>\` in the header, members chip strip below the summary with owner highlighted distinctly (filled accent + ★ prefix).
- List card: chip row showing owner (filled accent + ★) and participants (outlined + avatar), capped at 4 visible with \`+N\` overflow.
- Filter-by-member dropdown above the list narrows both active and archived sections.
- Synthesizer prompt + \`read_workstream\` tool output surface owner + member display names so Claude can reason about ownership.

(Re-opened after #80 merged and auto-closed this PR's stacked base. Rebased onto main.)

## Notes
- No \`workstream_members\` table — members are derived on read. Manual add/remove is out of scope for v1; if needed later, an overrides table is straightforward to add.
- Same authority pattern as user_notes: synthesizer never sets owner; \`write_workstream\` doesn't touch the column so owner survives re-clusters.
- Owner-vs-participant distinction: owner uses solid-accent chip with ★ prefix and white text (no avatar); participants are outlined chips with colored avatars. Same treatment in the list card and the detail-view members strip.

## Test plan
- [x] \`cargo check\` clean
- [x] \`bunx tsc --noEmit -p tsconfig.json\` clean
- [x] \`cargo test --lib\` — 195 passing, 4 new (set_owner round-trip, write_workstream preserves owner, members derive from email/event participants, members exclude unresolved recipients)
- [x] Manual: open a workstream → DetailHeader shows the owner \`<select>\`; pick a member → \`owner_member_id\` updated, persists across reloads
- [x] Manual: workstream with team-member email recipients → members chip strip + list-card chips show them; owner is visually distinct (★ + accent fill)
- [ ] Manual: filter dropdown narrows active + archived; resetting to "All" restores