### PR TITLE
Workstreams UI polish (action items, upcoming strip, shared removal)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4997,44 +4997,19 @@ input.nh-title {
   color: var(--fg-muted);
 }
 
-/* Actions */
-.workstream-actions {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-.workstream-action-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 6px 8px;
-  border-radius: 6px;
-}
-.workstream-action-row:hover {
-  background: var(--home-chip);
-}
-.workstream-action-row.is-done .workstream-action-check span {
-  text-decoration: line-through;
-  color: var(--fg-muted);
-}
-.workstream-action-check {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-  font-size: 13.5px;
-  color: var(--fg);
-  flex: 1 1 auto;
-}
-.workstream-action-source {
-  font-size: 11px;
-  color: var(--fg-muted);
-  text-transform: uppercase;
+/* Actions — reuse home-action-row layout for visual parity with the
+   Home action items page (#81 follow-up). The only workstream-specific
+   touch is the small "from <kind>" source chip on the right, slotted
+   in the same column the home page uses for its AssigneeChip. */
+.workstream-action-source-chip {
+  font-size: 10.5px;
+  font-weight: 600;
   letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: var(--home-chip);
   white-space: nowrap;
 }
 

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -36,7 +36,6 @@ import {
   IconSidebar,
   IconStar,
   IconUser,
-  IconUsers,
 } from "./icons";
 
 type Props = {
@@ -99,13 +98,12 @@ type NavId =
   | "actions"
   | "meetings"
   | "workstreams"
-  | "shared"
   | "favorites"
   | "archive"
   | "team";
-type FilterId = "all" | "notes" | "meetings" | "shared";
+type FilterId = "all" | "notes" | "meetings";
 
-function DueChip({ dueMs }: { dueMs: number | null }) {
+export function DueChip({ dueMs }: { dueMs: number | null }) {
   if (dueMs == null) return null;
   // Recompute on each render so label flips at midnight when the user
   // returns to the page. Cheap; the home feed already re-renders often.
@@ -183,7 +181,7 @@ function useUpcomingEvents(): {
         // Cap at 5 cards. Events arrive sorted by start_ms, so this
         // keeps the soonest 5 — anything further out is past what the
         // strip is meant to surface.
-        .slice(0, 5)
+        .slice(0, 3)
         .map((e) => mapToUpcoming(e, tickMs)),
     [events, tickMs],
   );
@@ -396,7 +394,6 @@ export function Home({
       "actions",
       "meetings",
       "workstreams",
-      "shared",
       "favorites",
       "archive",
       "team",
@@ -432,8 +429,6 @@ export function Home({
         return list.filter((n) => n.duration_ms === null);
       case "meetings":
         return list.filter((n) => n.duration_ms !== null);
-      case "shared":
-        return [];
       default:
         return list;
     }
@@ -559,7 +554,7 @@ export function Home({
           onNewMeeting={onNewMeeting}
         />
 
-        {nav !== "workstreams" && upcoming.length > 0 && (
+        {(nav === "home" || nav === "meetings") && upcoming.length > 0 && (
           <UpcomingStrip events={upcoming} onOpen={openEventNote} />
         )}
 
@@ -700,12 +695,6 @@ function Sidebar({
           label="Team"
           active={active === "team"}
           onClick={() => onSelect("team")}
-        />
-        <NavItem
-          icon={<IconUsers size={14} sw={1.7} />}
-          label="Shared with me"
-          active={active === "shared"}
-          onClick={() => onSelect("shared")}
         />
         <NavItem
           icon={<IconStar size={14} sw={1.7} />}
@@ -1324,7 +1313,6 @@ function NotesFeed({
     { id: "all", label: "All" },
     { id: "notes", label: "Notes" },
     { id: "meetings", label: "Meetings" },
-    { id: "shared", label: "Shared" },
   ];
 
   return (
@@ -1380,11 +1368,7 @@ function NotesFeed({
               )}
         </p>
       ) : grouped.size === 0 ? (
-        <p className="home-empty">
-          {filter === "shared"
-            ? "Sharing is coming soon — see issue #15 / #32."
-            : "Nothing matches this filter."}
-        </p>
+        <p className="home-empty">Nothing matches this filter.</p>
       ) : (
         [...grouped.entries()].map(([dayKey, items]) => (
           <div key={dayKey} className="home-day-group">

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -26,7 +26,8 @@ import {
   setWorkstreamStatus,
   setWorkstreamUserNotes,
 } from "./file";
-import { IconChevLeft } from "./icons";
+import { DueChip } from "./Home";
+import { IconCheck, IconChevLeft } from "./icons";
 import { avatarColor, initialsFromName } from "./initials";
 
 // ----- List view -----------------------------------------------------------
@@ -607,7 +608,7 @@ function WorkstreamDetailView({
       />
       <p className="workstream-detail-summary">{detail.summary}</p>
 
-      {detail.members.length > 0 ? (
+      {detail.members.length > 0 || detail.owner_member_id ? (
         <MembersStrip
           memberIds={detail.members}
           ownerId={detail.owner_member_id}
@@ -623,7 +624,17 @@ function WorkstreamDetailView({
         }
       />
 
-      <ActionsSection actions={detail.actions} onToggle={onToggleAction} />
+      <ActionsSection
+        actions={detail.actions}
+        onToggle={onToggleAction}
+        onOpenSource={async (kind, sourceId) => {
+          if (kind === "note") {
+            onOpenNote(sourceId);
+          } else if (kind === "event") {
+            await onOpenEvent(sourceId);
+          }
+        }}
+      />
 
       <EmailsSection emails={detail.emails} />
 
@@ -895,34 +906,69 @@ function MembersStrip({
 function ActionsSection({
   actions,
   onToggle,
+  onOpenSource,
 }: {
   actions: WorkstreamAction[];
   onToggle: (actionId: string, nextDone: boolean) => void | Promise<void>;
+  onOpenSource: (sourceKind: string, sourceId: string) => void | Promise<void>;
 }) {
   if (actions.length === 0) return null;
   return (
     <section className="workstream-section">
       <h2 className="workstream-section-title">Actions ({actions.length})</h2>
-      <ul className="workstream-actions">
-        {actions.map((a) => (
-          <li
-            key={a.id}
-            className={`workstream-action-row ${a.done ? "is-done" : ""}`}
-          >
-            <label className="workstream-action-check">
-              <input
-                type="checkbox"
-                checked={a.done}
-                onChange={(e) => onToggle(a.id, e.target.checked)}
-              />
-              <span>{a.text}</span>
-            </label>
-            <span className="workstream-action-source">
-              from {a.source_kind}
-            </span>
-          </li>
-        ))}
-      </ul>
+      <div className="home-actions">
+        {actions.map((a) => {
+          const openable = a.source_kind === "note" || a.source_kind === "event";
+          return (
+            <div
+              key={a.id}
+              className="home-action-row"
+              role={openable ? "button" : undefined}
+              tabIndex={openable ? 0 : undefined}
+              onClick={
+                openable
+                  ? () => void onOpenSource(a.source_kind, a.source_id)
+                  : undefined
+              }
+              onKeyDown={
+                openable
+                  ? (e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        void onOpenSource(a.source_kind, a.source_id);
+                      }
+                    }
+                  : undefined
+              }
+              title={openable ? `Open ${a.source_kind} source` : undefined}
+            >
+              <button
+                type="button"
+                className={"home-checkbox" + (a.done ? " done" : "")}
+                aria-label={a.done ? "Mark as open" : "Mark as done"}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void onToggle(a.id, !a.done);
+                }}
+              >
+                {a.done && <IconCheck size={20} sw={3.6} />}
+              </button>
+              <div className="home-action-body">
+                <div className={"home-action-text" + (a.done ? " done" : "")}>
+                  {a.text}
+                </div>
+              </div>
+              <DueChip dueMs={a.due_ms} />
+              <span
+                className="workstream-action-source-chip"
+                title={`from ${a.source_kind}`}
+              >
+                from {a.source_kind}
+              </span>
+            </div>
+          );
+        })}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- **Action items in workstream detail** now match the Home action items page: same `home-action-row` layout, same `home-checkbox` + IconCheck, same DueChip. Source kind ("from email/event/note") shown as a small pill where the assignee chip would normally sit. Note/event sources are click-to-open (note → \`onOpenNote\`; event → \`openOrCreateEventNote\`); email sources are passthrough until we have a UI affordance to scroll to the email row.
- **DueChip** exported from `Home.tsx` for cross-module reuse.
- **MembersStrip** now renders as soon as an owner is set, even if derived members are still empty — fixes the "set owner, nothing visible changes" feedback.
- **UpcomingStrip** allowlist tightened: now only shown on Home and Meetings. Was leaking onto Action items, Team, and other role-based pages. Cap dropped to 3 meetings (was 5).
- **"Shared with me" removed entirely** — the feature was a stub returning an empty list. Sidebar entry, filter pill, `NavId`/`FilterId` enum members, dead `case "shared"`, stale empty-state message, and the now-unused `IconUsers` import all dropped.

## Test plan
- [x] `bunx tsc --noEmit -p tsconfig.json` clean
- [ ] Manual: Workstream detail → action items match Home styling; checking off persists; clicking a note-sourced action opens its note
- [ ] Manual: Workstream detail → set an owner → MembersStrip appears with the owner chip immediately (no other members yet)
- [ ] Manual: Sidebar shows no "Shared with me"; UpcomingStrip appears on Home and Meetings, hidden on Action items / Team / Workstreams
- [ ] Manual: Coming up strip shows max 3 meetings