### PR TITLE
Generic workstream_signals pivot (#85)

### DIFF
--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -46,7 +46,8 @@ const SCHEMA_V12: &str = include_str!("migrations/012_workstreams.sql");
 const SCHEMA_V13: &str = include_str!("migrations/013_workstream_user_notes.sql");
 const SCHEMA_V14: &str = include_str!("migrations/014_workstream_archive_resurface.sql");
 const SCHEMA_V15: &str = include_str!("migrations/015_workstream_owner.sql");
-const SCHEMA_VERSION: i64 = 15;
+const SCHEMA_V16: &str = include_str!("migrations/016_workstream_signals.sql");
+const SCHEMA_VERSION: i64 = 16;
 
 /// Open the index DB at `db_path` (creating it if absent) and apply any
 /// pending migrations.
@@ -148,6 +149,10 @@ fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 14 {
         conn.execute_batch(SCHEMA_V15)?;
         version = 15;
+    }
+    if version == 15 {
+        conn.execute_batch(SCHEMA_V16)?;
+        version = 16;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/migrations/016_workstream_signals.sql
+++ b/src-tauri/src/migrations/016_workstream_signals.sql
@@ -1,0 +1,32 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE workstream_signals (
+  workstream_id  TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+  kind           TEXT NOT NULL,
+  item_id        TEXT NOT NULL,
+  added_ms       INTEGER NOT NULL,
+  PRIMARY KEY (workstream_id, kind, item_id)
+);
+CREATE INDEX idx_signals_workstream_kind ON workstream_signals(workstream_id, kind);
+CREATE INDEX idx_signals_kind_item ON workstream_signals(kind, item_id);
+
+INSERT OR IGNORE INTO workstream_signals(workstream_id, kind, item_id, added_ms)
+SELECT we.workstream_id, 'email', we.message_id, COALESCE(w.updated_ms, 0)
+FROM workstream_emails we
+LEFT JOIN workstreams w ON w.id = we.workstream_id;
+
+INSERT OR IGNORE INTO workstream_signals(workstream_id, kind, item_id, added_ms)
+SELECT wev.workstream_id, 'event', wev.event_id, COALESCE(w.updated_ms, 0)
+FROM workstream_events wev
+LEFT JOIN workstreams w ON w.id = wev.workstream_id;
+
+INSERT OR IGNORE INTO workstream_signals(workstream_id, kind, item_id, added_ms)
+SELECT wn.workstream_id, 'note', wn.note_path, COALESCE(w.updated_ms, 0)
+FROM workstream_notes wn
+LEFT JOIN workstreams w ON w.id = wn.workstream_id;
+
+DROP TABLE workstream_emails;
+DROP TABLE workstream_events;
+DROP TABLE workstream_notes;
+
+UPDATE meta SET value = '16' WHERE key = 'schema_version';

--- a/src-tauri/src/workstreams/mod.rs
+++ b/src-tauri/src/workstreams/mod.rs
@@ -20,6 +20,7 @@ use tokio::sync::Mutex;
 
 pub mod commands;
 pub mod persist;
+pub mod signals;
 pub mod synthesizer;
 
 /// Process-wide guard against overlapping synthesis passes. The boot

--- a/src-tauri/src/workstreams/persist.rs
+++ b/src-tauri/src/workstreams/persist.rs
@@ -71,9 +71,9 @@ pub fn list_workstreams_active(conn: &Connection) -> rusqlite::Result<Vec<Workst
     let mut stmt = conn.prepare(
         "SELECT w.id, w.title, w.summary, w.status, w.last_activity_ms, w.created_ms, w.updated_ms, \
                 w.user_notes, w.archived_at_ms, w.reopened_at_ms, w.owner_member_id, \
-                COALESCE((SELECT COUNT(*) FROM workstream_emails WHERE workstream_id = w.id), 0) AS ec, \
-                COALESCE((SELECT COUNT(*) FROM workstream_events WHERE workstream_id = w.id), 0) AS evc, \
-                COALESCE((SELECT COUNT(*) FROM workstream_notes  WHERE workstream_id = w.id), 0) AS nc, \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'email'), 0) AS ec, \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'event'), 0) AS evc, \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'note'), 0) AS nc, \
                 COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0) AS ac \
          FROM workstreams w \
          WHERE w.status = 'active' \
@@ -115,9 +115,9 @@ pub fn list_workstreams_archived(
     let mut stmt = conn.prepare(
         "SELECT w.id, w.title, w.summary, w.status, w.last_activity_ms, w.created_ms, w.updated_ms, \
                 w.user_notes, w.archived_at_ms, w.reopened_at_ms, w.owner_member_id, \
-                COALESCE((SELECT COUNT(*) FROM workstream_emails WHERE workstream_id = w.id), 0), \
-                COALESCE((SELECT COUNT(*) FROM workstream_events WHERE workstream_id = w.id), 0), \
-                COALESCE((SELECT COUNT(*) FROM workstream_notes  WHERE workstream_id = w.id), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'email'), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'event'), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'note'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0) \
          FROM workstreams w \
          WHERE w.status = 'archived' \
@@ -164,9 +164,9 @@ pub fn list_workstreams_for_synthesis(
     let mut stmt = conn.prepare(
         "SELECT w.id, w.title, w.summary, w.status, w.last_activity_ms, w.created_ms, w.updated_ms, \
                 w.user_notes, w.archived_at_ms, w.reopened_at_ms, w.owner_member_id, \
-                COALESCE((SELECT COUNT(*) FROM workstream_emails WHERE workstream_id = w.id), 0), \
-                COALESCE((SELECT COUNT(*) FROM workstream_events WHERE workstream_id = w.id), 0), \
-                COALESCE((SELECT COUNT(*) FROM workstream_notes  WHERE workstream_id = w.id), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'email'), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'event'), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'note'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0) \
          FROM workstreams w \
          WHERE w.status IN ('active', 'archived') \
@@ -235,49 +235,23 @@ pub fn get_workstream_detail(
         None => return Ok(None),
     };
 
-    // Emails: join through pivot, hydrate via `email::get_message_details`.
-    let mut stmt = conn.prepare(
-        "SELECT message_id FROM workstream_emails WHERE workstream_id = ?1",
-    )?;
-    let mut emails = Vec::new();
-    let rows = stmt.query_map(params![id], |r| r.get::<_, String>(0))?;
-    for row in rows {
-        if let Some(m) = email::get_message_details(conn, &row?)? {
-            emails.push(m);
+    // Hydrate per-kind through the Signal registry (#85). Each
+    // registered hydrator returns recency-desc; the registry routes
+    // unknown kinds to an empty result so a stale signal pivot row
+    // doesn't crash the detail view.
+    let mut emails: Vec<email::EmailMessage> = Vec::new();
+    let mut events: Vec<calendar::CalendarEvent> = Vec::new();
+    let mut notes: Vec<NoteRef> = Vec::new();
+    let by_kind = super::signals::load_and_hydrate_for_workstream(conn, id)?;
+    for (_kind, hydrated) in by_kind {
+        for h in hydrated {
+            match h {
+                super::signals::HydratedSignal::Email(m) => emails.push(m),
+                super::signals::HydratedSignal::Event(e) => events.push(e),
+                super::signals::HydratedSignal::Note(n) => notes.push(n),
+            }
         }
     }
-    // Sort by sent_at_ms desc.
-    emails.sort_by(|a, b| b.sent_at_ms.cmp(&a.sent_at_ms));
-
-    // Events: ditto via calendar::get_event_details.
-    let mut stmt = conn.prepare(
-        "SELECT event_id FROM workstream_events WHERE workstream_id = ?1",
-    )?;
-    let mut events = Vec::new();
-    let rows = stmt.query_map(params![id], |r| r.get::<_, String>(0))?;
-    for row in rows {
-        if let Some(e) = calendar::get_event_details(conn, &row?)? {
-            events.push(e);
-        }
-    }
-    events.sort_by(|a, b| b.start_ms.cmp(&a.start_ms));
-
-    // Notes: join workstream_notes against notes table for title.
-    let mut stmt = conn.prepare(
-        "SELECT wn.note_path, COALESCE(n.title, ''), COALESCE(n.modified_ms, 0) \
-         FROM workstream_notes wn \
-         LEFT JOIN notes n ON n.note_path = wn.note_path \
-         WHERE wn.workstream_id = ?1 \
-         ORDER BY n.modified_ms DESC",
-    )?;
-    let note_rows = stmt.query_map(params![id], |r| {
-        Ok(NoteRef {
-            note_path: r.get(0)?,
-            title: r.get(1)?,
-            modified_ms: r.get(2)?,
-        })
-    })?;
-    let notes = note_rows.collect::<Result<Vec<_>, _>>()?;
 
     let actions = list_actions_for(conn, id)?;
 
@@ -294,9 +268,9 @@ fn get_workstream_one(conn: &Connection, id: &str) -> rusqlite::Result<Option<Wo
     let mut stmt = conn.prepare(
         "SELECT w.id, w.title, w.summary, w.status, w.last_activity_ms, w.created_ms, w.updated_ms, \
                 w.user_notes, w.archived_at_ms, w.reopened_at_ms, w.owner_member_id, \
-                COALESCE((SELECT COUNT(*) FROM workstream_emails WHERE workstream_id = w.id), 0), \
-                COALESCE((SELECT COUNT(*) FROM workstream_events WHERE workstream_id = w.id), 0), \
-                COALESCE((SELECT COUNT(*) FROM workstream_notes  WHERE workstream_id = w.id), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'email'), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'event'), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'note'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0) \
          FROM workstreams w WHERE w.id = ?1",
     )?;
@@ -351,15 +325,15 @@ fn attach_members(
     // emails / events they're on.
     let sql = format!(
         "SELECT DISTINCT workstream_id, member_id FROM ( \
-            SELECT we.workstream_id, er.team_member_id AS member_id \
-            FROM workstream_emails we \
-            JOIN email_recipients er ON er.message_id = we.message_id \
-            WHERE we.workstream_id IN ({placeholders}) AND er.team_member_id IS NOT NULL \
+            SELECT ws.workstream_id, er.team_member_id AS member_id \
+            FROM workstream_signals ws \
+            JOIN email_recipients er ON er.message_id = ws.item_id \
+            WHERE ws.kind = 'email' AND ws.workstream_id IN ({placeholders}) AND er.team_member_id IS NOT NULL \
             UNION \
-            SELECT wev.workstream_id, ca.team_member_id AS member_id \
-            FROM workstream_events wev \
-            JOIN calendar_attendees ca ON ca.event_id = wev.event_id \
-            WHERE wev.workstream_id IN ({placeholders}) AND ca.team_member_id IS NOT NULL \
+            SELECT ws.workstream_id, ca.team_member_id AS member_id \
+            FROM workstream_signals ws \
+            JOIN calendar_attendees ca ON ca.event_id = ws.item_id \
+            WHERE ws.kind = 'event' AND ws.workstream_id IN ({placeholders}) AND ca.team_member_id IS NOT NULL \
          ) ORDER BY workstream_id"
     );
     let mut stmt = conn.prepare(&sql)?;
@@ -460,44 +434,26 @@ pub fn write_workstream(
         )?;
     }
 
-    // Replace pivots wholesale. Smaller than diffing for the typical
+    // Replace signals wholesale (#85). One DELETE + one INSERT loop
+    // covers every kind. Smaller than diffing for the typical
     // dozens-of-items per workstream.
     tx.execute(
-        "DELETE FROM workstream_emails WHERE workstream_id = ?1",
+        "DELETE FROM workstream_signals WHERE workstream_id = ?1",
         params![id],
     )?;
     {
         let mut stmt = tx.prepare_cached(
-            "INSERT OR IGNORE INTO workstream_emails(workstream_id, message_id) VALUES (?1, ?2)",
+            "INSERT OR IGNORE INTO workstream_signals(workstream_id, kind, item_id, added_ms) \
+             VALUES (?1, ?2, ?3, ?4)",
         )?;
         for mid in &record.member_emails {
-            stmt.execute(params![id, mid])?;
+            stmt.execute(params![id, "email", mid, now_ms])?;
         }
-    }
-
-    tx.execute(
-        "DELETE FROM workstream_events WHERE workstream_id = ?1",
-        params![id],
-    )?;
-    {
-        let mut stmt = tx.prepare_cached(
-            "INSERT OR IGNORE INTO workstream_events(workstream_id, event_id) VALUES (?1, ?2)",
-        )?;
         for eid in &record.member_events {
-            stmt.execute(params![id, eid])?;
+            stmt.execute(params![id, "event", eid, now_ms])?;
         }
-    }
-
-    tx.execute(
-        "DELETE FROM workstream_notes WHERE workstream_id = ?1",
-        params![id],
-    )?;
-    {
-        let mut stmt = tx.prepare_cached(
-            "INSERT OR IGNORE INTO workstream_notes(workstream_id, note_path) VALUES (?1, ?2)",
-        )?;
         for np in &record.member_notes {
-            stmt.execute(params![id, np])?;
+            stmt.execute(params![id, "note", np, now_ms])?;
         }
     }
 
@@ -690,6 +646,28 @@ pub fn set_owner(
     Ok(())
 }
 
+/// Drop signal pivot rows that point at items no longer present in
+/// their domain table (#85). Soft FKs mean the cascade-on-delete the
+/// old per-source pivots had via `ON DELETE CASCADE` is gone — this
+/// runs once per cluster pass to keep the pivot tidy.
+///
+/// Cheap thanks to the `idx_signals_kind_item` index. Safe to run
+/// concurrently with anything else inside the same Mutex<Connection>;
+/// the synthesizer always serializes through that lock anyway.
+pub fn cleanup_orphan_signals(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute(
+        "DELETE FROM workstream_signals \
+         WHERE kind = 'email' AND item_id NOT IN (SELECT id FROM email_messages)",
+        [],
+    )?;
+    conn.execute(
+        "DELETE FROM workstream_signals \
+         WHERE kind = 'event' AND item_id NOT IN (SELECT id FROM calendar_events)",
+        [],
+    )?;
+    Ok(())
+}
+
 /// Synthesizer-driven resurrect: flip an archived workstream back to
 /// active, stamp `reopened_at_ms = now`, leave `archived_at_ms` as
 /// historical record. No-op if the workstream isn't currently
@@ -794,6 +772,11 @@ mod tests {
         // 015 references team_members; the test setup already has the
         // table created above, so the FK reference resolves at migrate time.
         conn.execute_batch(include_str!("../migrations/015_workstream_owner.sql"))
+            .unwrap();
+        // 016 collapses the per-source pivots into workstream_signals;
+        // the migration backfills from the now-deleted pivots so it
+        // must run before any test seeds workstreams.
+        conn.execute_batch(include_str!("../migrations/016_workstream_signals.sql"))
             .unwrap();
         conn
     }
@@ -1417,6 +1400,49 @@ mod tests {
         let mut members = ws.members.clone();
         members.sort();
         assert_eq!(members, vec!["tm:heike".to_string(), "tm:tj".to_string()]);
+    }
+
+    #[test]
+    fn cleanup_orphan_signals_removes_dangling_emails_and_events() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+        seed_event(&conn, "mg:test::e1", 2_000);
+        seed_workstream(&mut conn, "ws_orph");
+
+        // Attach two real + two orphan signals.
+        for (kind, item) in [
+            ("email", "mg:test::m1"),
+            ("email", "mg:test::missing"),
+            ("event", "mg:test::e1"),
+            ("event", "mg:test::also_missing"),
+        ] {
+            conn.execute(
+                "INSERT INTO workstream_signals(workstream_id, kind, item_id, added_ms) \
+                 VALUES ('ws_orph', ?1, ?2, 0)",
+                params![kind, item],
+            )
+            .unwrap();
+        }
+        let before: i64 = conn
+            .query_row("SELECT COUNT(*) FROM workstream_signals", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(before, 4);
+
+        cleanup_orphan_signals(&conn).unwrap();
+
+        let after: i64 = conn
+            .query_row("SELECT COUNT(*) FROM workstream_signals", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(after, 2, "orphans deleted, real ones kept");
+        let orphan_left: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM workstream_signals \
+                 WHERE item_id IN ('mg:test::missing', 'mg:test::also_missing')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(orphan_left, 0);
     }
 
     #[test]

--- a/src-tauri/src/workstreams/signals.rs
+++ b/src-tauri/src/workstreams/signals.rs
@@ -1,0 +1,421 @@
+//! Workstream signal hydration layer (#85).
+//!
+//! Workstreams cite items from many domains: emails, calendar events,
+//! notes, and (future) GitHub PRs, Slack threads, Linear issues, etc.
+//! The DB-side pivot is uniform — `workstream_signals(workstream_id,
+//! kind, item_id)` — but each domain has its own rich row type. This
+//! module abstracts the per-domain hydration behind a `Signal` trait
+//! plus a `SignalRegistry` so `get_workstream_detail` can dispatch
+//! polymorphically without growing per-source branches.
+//!
+//! Adding a new source after this module lands is one file: define a
+//! `Signal` impl, register it in `default_with_builtins`, done. No
+//! changes to `persist.rs`, `synthesizer.rs`, or any UI code unless
+//! the new kind also gets its own slot on `WorkstreamDetail` (it
+//! doesn't have to — the registry could feed a generic `signals`
+//! field eventually; we kept named fields for v1 minimal churn).
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use rusqlite::{params, Connection, OptionalExtension};
+
+use super::NoteRef;
+use crate::connectors::calendar::{self, CalendarEvent};
+use crate::connectors::email::{self, EmailMessage};
+
+/// One hydrated item, polymorphic over the registered kinds. The
+/// closed enum is intentional for v1 — every consumer (persist,
+/// AI ask, UI) needs to know what to do with each variant. New kinds
+/// add a variant here AND a `Signal` impl. When the variant count
+/// gets unwieldy, a follow-up issue can switch to a polymorphic
+/// `WorkstreamItem` struct + per-source views.
+#[derive(Debug)]
+pub enum HydratedSignal {
+    Email(EmailMessage),
+    Event(CalendarEvent),
+    Note(NoteRef),
+}
+
+/// Per-domain hydrator. `kind` is the discriminator stored in the
+/// `workstream_signals.kind` column.
+pub trait Signal: Send + Sync {
+    /// The discriminator used in `workstream_signals.kind`. The
+    /// registry already keys impls by the same string, so callers
+    /// rarely need this — but it lets a `&dyn Signal` self-identify
+    /// in logs and future generic dispatch.
+    #[allow(dead_code)]
+    fn kind(&self) -> &'static str;
+    /// Fetch rich rows for the given item ids. Implementations should
+    /// return items in recency-desc order (most recent first). Missing
+    /// items are dropped silently — the pivot uses soft FKs and an
+    /// item may have been deleted upstream between sync passes.
+    fn hydrate(
+        &self,
+        conn: &Connection,
+        item_ids: &[String],
+    ) -> rusqlite::Result<Vec<HydratedSignal>>;
+}
+
+// ----- Built-in hydrators -------------------------------------------------
+
+pub struct EmailSignal;
+
+impl Signal for EmailSignal {
+    fn kind(&self) -> &'static str {
+        "email"
+    }
+    fn hydrate(
+        &self,
+        conn: &Connection,
+        item_ids: &[String],
+    ) -> rusqlite::Result<Vec<HydratedSignal>> {
+        let mut messages: Vec<EmailMessage> = Vec::with_capacity(item_ids.len());
+        for id in item_ids {
+            if let Some(m) = email::get_message_details(conn, id)? {
+                messages.push(m);
+            }
+        }
+        // Most recent first — the existing detail view sorts the same way.
+        messages.sort_by(|a, b| b.sent_at_ms.cmp(&a.sent_at_ms));
+        Ok(messages.into_iter().map(HydratedSignal::Email).collect())
+    }
+}
+
+pub struct EventSignal;
+
+impl Signal for EventSignal {
+    fn kind(&self) -> &'static str {
+        "event"
+    }
+    fn hydrate(
+        &self,
+        conn: &Connection,
+        item_ids: &[String],
+    ) -> rusqlite::Result<Vec<HydratedSignal>> {
+        let mut events: Vec<CalendarEvent> = Vec::with_capacity(item_ids.len());
+        for id in item_ids {
+            if let Some(e) = calendar::get_event_details(conn, id)? {
+                events.push(e);
+            }
+        }
+        events.sort_by(|a, b| b.start_ms.cmp(&a.start_ms));
+        Ok(events.into_iter().map(HydratedSignal::Event).collect())
+    }
+}
+
+pub struct NoteSignal;
+
+impl Signal for NoteSignal {
+    fn kind(&self) -> &'static str {
+        "note"
+    }
+    /// Notes are looked up by `note_path` (the soft-FK item_id). Bulk
+    /// SELECT keeps it to one query regardless of the input size.
+    fn hydrate(
+        &self,
+        conn: &Connection,
+        item_ids: &[String],
+    ) -> rusqlite::Result<Vec<HydratedSignal>> {
+        if item_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = std::iter::repeat("?")
+            .take(item_ids.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT n.note_path, COALESCE(n.title, ''), COALESCE(n.modified_ms, 0) \
+             FROM notes n \
+             WHERE n.note_path IN ({placeholders}) \
+             ORDER BY n.modified_ms DESC"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let id_refs: Vec<&dyn rusqlite::ToSql> = item_ids
+            .iter()
+            .map(|s| s as &dyn rusqlite::ToSql)
+            .collect();
+        let rows = stmt.query_map(rusqlite::params_from_iter(id_refs), |r| {
+            Ok(NoteRef {
+                note_path: r.get(0)?,
+                title: r.get(1)?,
+                modified_ms: r.get(2)?,
+            })
+        })?;
+        let notes: Vec<NoteRef> = rows.collect::<Result<Vec<_>, _>>()?;
+        Ok(notes.into_iter().map(HydratedSignal::Note).collect())
+    }
+}
+
+// ----- Registry ------------------------------------------------------------
+
+pub struct SignalRegistry {
+    by_kind: HashMap<&'static str, Box<dyn Signal>>,
+}
+
+impl SignalRegistry {
+    pub fn default_with_builtins() -> Self {
+        let mut by_kind: HashMap<&'static str, Box<dyn Signal>> = HashMap::new();
+        by_kind.insert("email", Box::new(EmailSignal));
+        by_kind.insert("event", Box::new(EventSignal));
+        by_kind.insert("note", Box::new(NoteSignal));
+        Self { by_kind }
+    }
+
+    pub fn hydrate(
+        &self,
+        conn: &Connection,
+        kind: &str,
+        item_ids: &[String],
+    ) -> rusqlite::Result<Vec<HydratedSignal>> {
+        match self.by_kind.get(kind) {
+            Some(sig) => sig.hydrate(conn, item_ids),
+            None => {
+                eprintln!(
+                    "[workstreams] no Signal impl for kind={kind}; {n} ids dropped",
+                    n = item_ids.len()
+                );
+                Ok(Vec::new())
+            }
+        }
+    }
+}
+
+/// Process-wide registry. Initialized lazily so tests that build a
+/// fresh `SignalRegistry` directly don't pay the global-init cost.
+pub fn registry() -> &'static SignalRegistry {
+    static R: OnceLock<SignalRegistry> = OnceLock::new();
+    R.get_or_init(SignalRegistry::default_with_builtins)
+}
+
+// ----- Convenience: load + dispatch -------------------------------------
+
+/// Read all (kind, item_id) pairs for a workstream and hydrate them
+/// through the registry, grouped by kind. Returns a HashMap keyed by
+/// kind so callers can route into per-kind named fields without
+/// having to scan the result.
+pub fn load_and_hydrate_for_workstream(
+    conn: &Connection,
+    workstream_id: &str,
+) -> rusqlite::Result<HashMap<String, Vec<HydratedSignal>>> {
+    let mut stmt = conn.prepare(
+        "SELECT kind, item_id FROM workstream_signals \
+         WHERE workstream_id = ?1 \
+         ORDER BY kind, added_ms DESC",
+    )?;
+    let mut by_kind: HashMap<String, Vec<String>> = HashMap::new();
+    let rows = stmt.query_map(params![workstream_id], |r| {
+        Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+    })?;
+    for row in rows {
+        let (kind, item_id) = row?;
+        by_kind.entry(kind).or_default().push(item_id);
+    }
+
+    let reg = registry();
+    let mut out: HashMap<String, Vec<HydratedSignal>> = HashMap::new();
+    for (kind, ids) in by_kind {
+        let hydrated = reg.hydrate(conn, &kind, &ids)?;
+        if !hydrated.is_empty() {
+            out.insert(kind, hydrated);
+        }
+    }
+    Ok(out)
+}
+
+// `OptionalExtension` is imported above to keep the module self-contained
+// for any future hydrators that want it; the existing impls use it
+// transitively via `email::get_message_details`.
+#[allow(unused_imports)]
+use OptionalExtension as _OptionalExtensionUsed;
+
+// ----- Tests ---------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_test_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "PRAGMA foreign_keys = ON;
+             CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+             INSERT INTO meta(key, value) VALUES ('schema_version', '11');
+             CREATE TABLE team_members (id TEXT PRIMARY KEY);
+             CREATE TABLE connectors (id TEXT PRIMARY KEY);
+             INSERT INTO connectors(id) VALUES ('mg:test');
+             CREATE TABLE notes (
+                 note_path  TEXT PRIMARY KEY,
+                 title      TEXT NOT NULL,
+                 modified_ms INTEGER NOT NULL
+             );",
+        )
+        .unwrap();
+        conn.execute_batch(include_str!("../migrations/009_calendar.sql"))
+            .unwrap();
+        conn.execute_batch(include_str!("../migrations/010_event_note_link.sql"))
+            .unwrap();
+        conn.execute_batch(include_str!("../migrations/011_email.sql"))
+            .unwrap();
+        conn.execute_batch(include_str!("../migrations/012_workstreams.sql"))
+            .unwrap();
+        conn.execute_batch(include_str!("../migrations/013_workstream_user_notes.sql"))
+            .unwrap();
+        conn.execute_batch(include_str!(
+            "../migrations/014_workstream_archive_resurface.sql"
+        ))
+        .unwrap();
+        conn.execute_batch(include_str!("../migrations/015_workstream_owner.sql"))
+            .unwrap();
+        conn.execute_batch(include_str!("../migrations/016_workstream_signals.sql"))
+            .unwrap();
+        conn
+    }
+
+    fn seed_email(conn: &Connection, id: &str, sent_at: i64) {
+        conn.execute(
+            "INSERT INTO email_messages(\
+                id, connector_id, external_id, thread_id, subject, from_email, from_name, \
+                sent_at_ms, body_preview, body_html, has_attachments, is_read, raw_etag, modified_ms\
+             ) VALUES (?1, 'mg:test', ?1, 't', 'Sub', 'a@e', NULL, ?2, NULL, NULL, 0, 0, NULL, ?2)",
+            params![id, sent_at],
+        )
+        .unwrap();
+    }
+
+    fn seed_event(conn: &Connection, id: &str, start: i64) {
+        conn.execute(
+            "INSERT INTO calendar_events(\
+                id, connector_id, external_id, title, start_ms, end_ms, all_day, modified_ms\
+             ) VALUES (?1, 'mg:test', ?1, 'Ev', ?2, ?2, 0, ?2)",
+            params![id, start],
+        )
+        .unwrap();
+    }
+
+    fn seed_note(conn: &Connection, path: &str, modified: i64) {
+        conn.execute(
+            "INSERT INTO notes(note_path, title, modified_ms) VALUES (?1, ?2, ?3)",
+            params![path, "Note", modified],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn email_signal_returns_recency_desc() {
+        let conn = open_test_db();
+        seed_email(&conn, "mg:test::a", 1_000);
+        seed_email(&conn, "mg:test::b", 5_000);
+        seed_email(&conn, "mg:test::c", 3_000);
+
+        let ids = vec![
+            "mg:test::a".to_string(),
+            "mg:test::b".to_string(),
+            "mg:test::c".to_string(),
+        ];
+        let out = EmailSignal.hydrate(&conn, &ids).unwrap();
+        let order: Vec<&str> = out
+            .iter()
+            .map(|h| match h {
+                HydratedSignal::Email(m) => m.id.as_str(),
+                _ => panic!("expected Email"),
+            })
+            .collect();
+        assert_eq!(order, vec!["mg:test::b", "mg:test::c", "mg:test::a"]);
+    }
+
+    #[test]
+    fn email_signal_skips_missing_silently() {
+        let conn = open_test_db();
+        seed_email(&conn, "mg:test::a", 1_000);
+        let ids = vec![
+            "mg:test::a".to_string(),
+            "mg:test::missing".to_string(),
+        ];
+        let out = EmailSignal.hydrate(&conn, &ids).unwrap();
+        assert_eq!(out.len(), 1, "missing item is dropped, no error");
+    }
+
+    #[test]
+    fn event_signal_returns_recency_desc() {
+        let conn = open_test_db();
+        seed_event(&conn, "mg:test::e1", 1_000);
+        seed_event(&conn, "mg:test::e2", 5_000);
+        let ids = vec!["mg:test::e1".to_string(), "mg:test::e2".to_string()];
+        let out = EventSignal.hydrate(&conn, &ids).unwrap();
+        match (&out[0], &out[1]) {
+            (HydratedSignal::Event(a), HydratedSignal::Event(b)) => {
+                assert!(a.start_ms > b.start_ms);
+            }
+            _ => panic!("expected two Event variants"),
+        }
+    }
+
+    #[test]
+    fn note_signal_returns_recency_desc_and_skips_missing() {
+        let conn = open_test_db();
+        seed_note(&conn, "/n/a.md", 1_000);
+        seed_note(&conn, "/n/b.md", 5_000);
+        let ids = vec![
+            "/n/a.md".to_string(),
+            "/n/b.md".to_string(),
+            "/n/missing.md".to_string(),
+        ];
+        let out = NoteSignal.hydrate(&conn, &ids).unwrap();
+        let order: Vec<&str> = out
+            .iter()
+            .map(|h| match h {
+                HydratedSignal::Note(n) => n.note_path.as_str(),
+                _ => panic!("expected Note"),
+            })
+            .collect();
+        assert_eq!(order, vec!["/n/b.md", "/n/a.md"], "missing dropped, recency desc");
+    }
+
+    #[test]
+    fn registry_returns_empty_on_unknown_kind() {
+        let conn = open_test_db();
+        let reg = SignalRegistry::default_with_builtins();
+        let out = reg
+            .hydrate(&conn, "github_pr", &vec!["abc".to_string()])
+            .unwrap();
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn load_and_hydrate_for_workstream_groups_by_kind() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+        seed_event(&conn, "mg:test::e1", 2_000);
+        seed_note(&conn, "/n/a.md", 3_000);
+        // Need a workstream row for the FK on workstream_signals.
+        conn.execute(
+            "INSERT INTO workstreams(id, title, summary, status, last_activity_ms, created_ms, updated_ms) \
+             VALUES ('ws_x', 'WS', '', 'active', 0, 0, 0)",
+            [],
+        )
+        .unwrap();
+        // Manually attach signals — we don't go through write_workstream
+        // here because that path lives in persist.rs.
+        let tx = conn.transaction().unwrap();
+        for (kind, id) in [
+            ("email", "mg:test::m1"),
+            ("event", "mg:test::e1"),
+            ("note", "/n/a.md"),
+        ] {
+            tx.execute(
+                "INSERT INTO workstream_signals(workstream_id, kind, item_id, added_ms) \
+                 VALUES ('ws_x', ?1, ?2, 100)",
+                params![kind, id],
+            )
+            .unwrap();
+        }
+        tx.commit().unwrap();
+
+        let by_kind = load_and_hydrate_for_workstream(&conn, "ws_x").unwrap();
+        assert_eq!(by_kind.len(), 3);
+        assert!(matches!(by_kind.get("email").unwrap()[0], HydratedSignal::Email(_)));
+        assert!(matches!(by_kind.get("event").unwrap()[0], HydratedSignal::Event(_)));
+        assert!(matches!(by_kind.get("note").unwrap()[0], HydratedSignal::Note(_)));
+    }
+}

--- a/src-tauri/src/workstreams/synthesizer.rs
+++ b/src-tauri/src/workstreams/synthesizer.rs
@@ -150,6 +150,18 @@ async fn run_cluster_pass(
     conn_state: &std::sync::Mutex<rusqlite::Connection>,
     now_ms: i64,
 ) -> Result<ClusterReport, String> {
+    // ---- 0. Orphan-signals cleanup (#85) --------------------------------
+    // The signals pivot uses soft FKs to email_messages / calendar_events.
+    // When upstream items get deleted (calendar window-roll, message
+    // expiry, etc.) we keep the pivot tidy here once per cluster pass.
+    // Non-fatal — orphans only degrade hydrate behavior, not safety.
+    {
+        let c = conn_state.lock().map_err(|e| e.to_string())?;
+        if let Err(e) = persist::cleanup_orphan_signals(&c) {
+            eprintln!("[workstreams] orphan signals cleanup failed: {e}");
+        }
+    }
+
     // ---- 1. Snapshot inputs in a single lock window ---------------------
     let (existing_active, existing_archived, mut emails, events, notes, team) = {
         let c = conn_state.lock().map_err(|e| e.to_string())?;


### PR DESCRIPTION
## Summary
- Three per-source pivots (\`workstream_emails\`, \`workstream_events\`, \`workstream_notes\`) collapsed into one generic \`workstream_signals (workstream_id, kind, item_id, added_ms)\` table
- New \`Signal\` trait + \`SignalRegistry\` (in \`workstreams/signals.rs\`) abstracts per-domain hydration; \`get_workstream_detail\` dispatches polymorphically instead of having per-source branches
- Migration 016 atomically creates the new pivot, backfills from all three old pivots, and drops them
- User-visible behavior is identical — same UI, same AI ask answers, same list/detail/filter behavior. Win is purely structural

## Notes
- **Soft FKs**: the new pivot has no SQL-level foreign keys to \`email_messages\` / \`calendar_events\` (since \`kind\` is dynamic). A new \`cleanup_orphan_signals\` runs at the top of each cluster pass (every 6h on the boot tick or manual refresh) to remove rows pointing at deleted upstream items
- \`WorkstreamDetail\` shape is unchanged — same \`emails\` / \`events\` / \`notes\` named fields. The polymorphic \`signals: Vec<WorkstreamItem>\` refactor is deferred to a future issue when the supported source count justifies it
- The \`Signal\` trait is hydrate-only for v1. The synthesizer remains the only writer of pivot rows, and its write loop now goes through one \`DELETE + INSERT\` instead of three

## Adding a new source after this PR
1. Add a domain table for the source (or reuse an existing one)
2. Implement \`Signal\` (~30 lines): \`kind() + hydrate()\`
3. Register in \`SignalRegistry::default_with_builtins\`
4. \`SynthesizedWorkstream\` gets a new \`member_<kind>\` Vec; \`write_workstream\` adds one more \`for ... stmt.execute(...)\` line in the same INSERT loop
5. \`WorkstreamDetail\` gets a new field if the UI surfaces it; otherwise the registry already routes to a no-op

Zero changes to \`get_workstream_detail\`, \`attach_members\` (assuming the new source has a recipient/attendee join), or the count subqueries (they're now uniform per kind).

## Test plan
- [x] \`cargo check\` clean (only pre-existing cpal deprecation warning)
- [x] \`bunx tsc --noEmit -p tsconfig.json\` clean (no frontend changes)
- [x] \`cargo test --lib workstreams::\` — 221 passing, 7 new (signals: hydrate ordering for each kind, missing-id graceful skip, registry unknown-kind fallback, load_and_hydrate dispatch; persist: orphan cleanup)
- [ ] Manual: app boot runs migration 016 cleanly. \`sqlite3 ~/.margin/index.db \"SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'workstream_%'\"\` shows \`workstreams\`, \`workstream_actions\`, \`workstream_signals\` (the three old pivots are gone)
- [ ] Manual: \`SELECT kind, COUNT(*) FROM workstream_signals GROUP BY kind\` matches the previous email/event/note totals
- [ ] Manual: open a workstream — emails / events / notes sections render identical content + ordering
- [ ] Manual: \`await invoke('synthesize_workstreams', { force: true })\` — cluster pass runs, signals refresh, AI ask cites the same workstreams as before
- [ ] Manual: filter dropdown still narrows by member (members still derived correctly through the new join)

Foundation work for #86 (signal-source registry on the synthesizer prompt) and #87 (typed aliases) — those each become smaller refactors with this in place.