### PR TITLE
Synthesizer signal-source registry (#86)

### DIFF
--- a/src-tauri/src/workstreams/signals.rs
+++ b/src-tauri/src/workstreams/signals.rs
@@ -1,19 +1,32 @@
-//! Workstream signal hydration layer (#85).
+//! Workstream signal hydration + snapshot layer (#85, #86).
 //!
 //! Workstreams cite items from many domains: emails, calendar events,
 //! notes, and (future) GitHub PRs, Slack threads, Linear issues, etc.
 //! The DB-side pivot is uniform — `workstream_signals(workstream_id,
 //! kind, item_id)` — but each domain has its own rich row type. This
-//! module abstracts the per-domain hydration behind a `Signal` trait
-//! plus a `SignalRegistry` so `get_workstream_detail` can dispatch
-//! polymorphically without growing per-source branches.
+//! module abstracts each domain behind a single `Signal` trait plus a
+//! `SignalRegistry` so the synthesizer's prompt loop and
+//! `get_workstream_detail` both dispatch polymorphically without
+//! growing per-source branches.
 //!
-//! Adding a new source after this module lands is one file: define a
-//! `Signal` impl, register it in `default_with_builtins`, done. No
-//! changes to `persist.rs`, `synthesizer.rs`, or any UI code unless
-//! the new kind also gets its own slot on `WorkstreamDetail` (it
-//! doesn't have to — the registry could feed a generic `signals`
-//! field eventually; we kept named fields for v1 minimal churn).
+//! Each impl owns three things:
+//!   - **Hydration** (#85): `hydrate(conn, item_ids)` turns pivot rows
+//!     into rich domain objects for the detail view + AI ask prompts.
+//!   - **Snapshot** (#86): `snapshot(conn, window, cap)` reads the
+//!     recent items the synthesizer should cluster.
+//!   - **Render** (#86): `format(item)` produces the per-item lines
+//!     for the cluster-pass user message. Multi-line is allowed (email
+//!     emits header + indented body excerpt), so this is not strictly
+//!     "one line".
+//!
+//! Per-source defaults — `default_window()`, `default_cap()`,
+//! `label_prefix()` — live next to each impl so adding a source is a
+//! one-file change with no synthesizer-side surgery.
+//!
+//! Adding a new source: define a `Signal` impl, register it in
+//! `default_with_builtins`, done. No changes to `persist.rs`,
+//! `synthesizer.rs`, or any UI code unless the new kind also gets its
+//! own slot on `WorkstreamDetail`.
 
 use std::collections::HashMap;
 use std::sync::OnceLock;
@@ -23,6 +36,7 @@ use rusqlite::{params, Connection, OptionalExtension};
 use super::NoteRef;
 use crate::connectors::calendar::{self, CalendarEvent};
 use crate::connectors::email::{self, EmailMessage};
+use crate::index;
 
 /// One hydrated item, polymorphic over the registered kinds. The
 /// closed enum is intentional for v1 — every consumer (persist,
@@ -37,8 +51,36 @@ pub enum HydratedSignal {
     Note(NoteRef),
 }
 
-/// Per-domain hydrator. `kind` is the discriminator stored in the
-/// `workstream_signals.kind` column.
+/// One snapshot item from a source. `id` is the canonical id stored in
+/// `workstream_signals.item_id`; `payload` is the rich row used for
+/// rendering. Closed-enum mirrors `HydratedSignal` so consumers can
+/// pattern-match without going through `Any`.
+#[derive(Debug)]
+pub struct SnapshotItem {
+    pub id: String,
+    pub payload: SnapshotPayload,
+}
+
+#[derive(Debug)]
+pub enum SnapshotPayload {
+    Email(EmailMessage),
+    Event(CalendarEvent),
+    Note(NoteRef),
+}
+
+/// Per-source time window for snapshotting. `back_ms` and
+/// `forward_ms` are both non-negative durations; the source applies
+/// `[now - back_ms, now + forward_ms]`. Forward is non-zero for
+/// calendar (upcoming meetings count) and ~1 day for email (covers
+/// clock skew on freshly-sent items); zero for notes.
+#[derive(Debug, Clone, Copy)]
+pub struct SignalWindow {
+    pub back_ms: i64,
+    pub forward_ms: i64,
+}
+
+/// Per-domain hydrator + snapshotter. `kind` is the discriminator
+/// stored in the `workstream_signals.kind` column.
 pub trait Signal: Send + Sync {
     /// The discriminator used in `workstream_signals.kind`. The
     /// registry already keys impls by the same string, so callers
@@ -46,6 +88,47 @@ pub trait Signal: Send + Sync {
     /// in logs and future generic dispatch.
     #[allow(dead_code)]
     fn kind(&self) -> &'static str;
+
+    /// Single-letter prefix for the labels Claude sees in the
+    /// cluster-pass prompt — "M" for email, "E" for events, "N" for
+    /// notes. Each label is `"{prefix}{1-based index}"`. Must be
+    /// unique across registered sources; the registry asserts this.
+    fn label_prefix(&self) -> &'static str;
+
+    /// Markdown header used for this source's section in the cluster
+    /// prompt. Includes the human-readable window so Claude sees the
+    /// time horizon: e.g. "Recent emails (last 14 days)". Does NOT
+    /// include the leading `#` — the synthesizer adds it.
+    fn prompt_section_title(&self) -> &'static str;
+
+    /// Default snapshot window for cluster passes. Lives here (not in
+    /// `synthesizer.rs`) so adding a source is a one-file change.
+    fn default_window(&self) -> SignalWindow;
+
+    /// Default per-source cap on snapshot items. The synthesizer may
+    /// later allocate against a global token budget; for now each
+    /// source returns up to its own cap.
+    fn default_cap(&self) -> usize;
+
+    /// Read recent items from local storage. Implementations return
+    /// recency-desc, already deduplicated. The cap is advisory — the
+    /// caller may pass a smaller value when budget is tight. `now_ms`
+    /// is injected (not read from `SystemTime::now()`) so tests can
+    /// pin the window deterministically.
+    fn snapshot(
+        &self,
+        conn: &Connection,
+        now_ms: i64,
+        window: SignalWindow,
+        cap: usize,
+    ) -> rusqlite::Result<Vec<SnapshotItem>>;
+
+    /// Render one snapshot item for the cluster-pass user message.
+    /// `label` is the Claude-facing identifier (e.g. "M3"). Multi-line
+    /// output is allowed — email emits header + indented body excerpt.
+    /// The trailing newline is the caller's responsibility.
+    fn format(&self, label: &str, item: &SnapshotItem) -> String;
+
     /// Fetch rich rows for the given item ids. Implementations should
     /// return items in recency-desc order (most recent first). Missing
     /// items are dropped silently — the pivot uses soft FKs and an
@@ -57,13 +140,73 @@ pub trait Signal: Send + Sync {
     ) -> rusqlite::Result<Vec<HydratedSignal>>;
 }
 
-// ----- Built-in hydrators -------------------------------------------------
+// ----- Built-in sources ---------------------------------------------------
 
 pub struct EmailSignal;
+
+/// Email: 14d back, +1d forward (covers clock skew on freshly-sent
+/// items), label prefix "M". Cap of 500 mirrors the previous
+/// `list_messages_in_range` limit in `synthesizer.rs`.
+const EMAIL_WINDOW_BACK_MS: i64 = 14 * 24 * 3600 * 1000;
+const EMAIL_WINDOW_FORWARD_MS: i64 = 24 * 3600 * 1000;
+const EMAIL_CAP: usize = 500;
 
 impl Signal for EmailSignal {
     fn kind(&self) -> &'static str {
         "email"
+    }
+    fn label_prefix(&self) -> &'static str {
+        "M"
+    }
+    fn prompt_section_title(&self) -> &'static str {
+        "Recent emails (last 14 days)"
+    }
+    fn default_window(&self) -> SignalWindow {
+        SignalWindow {
+            back_ms: EMAIL_WINDOW_BACK_MS,
+            forward_ms: EMAIL_WINDOW_FORWARD_MS,
+        }
+    }
+    fn default_cap(&self) -> usize {
+        EMAIL_CAP
+    }
+    fn snapshot(
+        &self,
+        conn: &Connection,
+        now_ms: i64,
+        window: SignalWindow,
+        cap: usize,
+    ) -> rusqlite::Result<Vec<SnapshotItem>> {
+        let messages = email::list_messages_in_range(
+            conn,
+            now_ms - window.back_ms,
+            now_ms + window.forward_ms,
+            None,
+            cap,
+        )?;
+        Ok(messages
+            .into_iter()
+            .map(|m| SnapshotItem {
+                id: m.id.clone(),
+                payload: SnapshotPayload::Email(m),
+            })
+            .collect())
+    }
+    fn format(&self, label: &str, item: &SnapshotItem) -> String {
+        let m = match &item.payload {
+            SnapshotPayload::Email(m) => m,
+            _ => return String::new(),
+        };
+        let date = format_iso_date(m.sent_at_ms);
+        let from = format_from(&m.from_email, m.from_name.as_deref());
+        let body = email_body_excerpt(m);
+        // Trailing blank line is intentional — emails are multi-line
+        // and the blank separator keeps headers visually distinct in
+        // the prompt. Events and notes are single-line and don't need it.
+        format!(
+            "[{label}] {date} — From: {from} — Subject: {subject}\n{body}\n\n",
+            subject = m.subject,
+        )
     }
     fn hydrate(
         &self,
@@ -84,9 +227,66 @@ impl Signal for EmailSignal {
 
 pub struct EventSignal;
 
+/// Calendar: ±14d, label prefix "E".
+const EVENT_WINDOW_BACK_MS: i64 = 14 * 24 * 3600 * 1000;
+const EVENT_WINDOW_FORWARD_MS: i64 = 14 * 24 * 3600 * 1000;
+/// list_events_in_range has no LIMIT param; cap is enforced post-fetch.
+const EVENT_CAP: usize = 500;
+
 impl Signal for EventSignal {
     fn kind(&self) -> &'static str {
         "event"
+    }
+    fn label_prefix(&self) -> &'static str {
+        "E"
+    }
+    fn prompt_section_title(&self) -> &'static str {
+        "Recent calendar events (window: -14d .. +14d)"
+    }
+    fn default_window(&self) -> SignalWindow {
+        SignalWindow {
+            back_ms: EVENT_WINDOW_BACK_MS,
+            forward_ms: EVENT_WINDOW_FORWARD_MS,
+        }
+    }
+    fn default_cap(&self) -> usize {
+        EVENT_CAP
+    }
+    fn snapshot(
+        &self,
+        conn: &Connection,
+        now_ms: i64,
+        window: SignalWindow,
+        cap: usize,
+    ) -> rusqlite::Result<Vec<SnapshotItem>> {
+        let mut events =
+            calendar::list_events_in_range(conn, now_ms - window.back_ms, now_ms + window.forward_ms, None)?;
+        events.truncate(cap);
+        Ok(events
+            .into_iter()
+            .map(|e| SnapshotItem {
+                id: e.id.clone(),
+                payload: SnapshotPayload::Event(e),
+            })
+            .collect())
+    }
+    fn format(&self, label: &str, item: &SnapshotItem) -> String {
+        let e = match &item.payload {
+            SnapshotPayload::Event(e) => e,
+            _ => return String::new(),
+        };
+        let when = format_iso_datetime(e.start_ms);
+        let attendees: Vec<&str> =
+            e.attendees.iter().take(8).map(|a| a.email.as_str()).collect();
+        let attendees_str = if attendees.is_empty() {
+            String::new()
+        } else {
+            format!(" — Attendees: {}", attendees.join(", "))
+        };
+        format!(
+            "[{label}] {when} — {title}{attendees_str}\n",
+            title = e.title
+        )
     }
     fn hydrate(
         &self,
@@ -106,9 +306,75 @@ impl Signal for EventSignal {
 
 pub struct NoteSignal;
 
+/// Notes: 30d back, label prefix "N". The directory cap (200) is the
+/// upstream ceiling; window filtering is applied after.
+const NOTE_WINDOW_BACK_MS: i64 = 30 * 24 * 3600 * 1000;
+const NOTE_DIRECTORY_LIMIT: usize = 200;
+const NOTE_CAP: usize = 200;
+
 impl Signal for NoteSignal {
     fn kind(&self) -> &'static str {
         "note"
+    }
+    fn label_prefix(&self) -> &'static str {
+        "N"
+    }
+    fn prompt_section_title(&self) -> &'static str {
+        "Recent notes (last 30 days)"
+    }
+    fn default_window(&self) -> SignalWindow {
+        SignalWindow {
+            back_ms: NOTE_WINDOW_BACK_MS,
+            forward_ms: 0,
+        }
+    }
+    fn default_cap(&self) -> usize {
+        NOTE_CAP
+    }
+    fn snapshot(
+        &self,
+        conn: &Connection,
+        now_ms: i64,
+        window: SignalWindow,
+        cap: usize,
+    ) -> rusqlite::Result<Vec<SnapshotItem>> {
+        let cutoff = now_ms - window.back_ms;
+        let directory = index::list_directory(conn, NOTE_DIRECTORY_LIMIT)?;
+        let mut items: Vec<SnapshotItem> = directory
+            .into_iter()
+            .filter(|d| d.modified_ms >= cutoff)
+            .take(cap)
+            .map(|d| SnapshotItem {
+                id: d.note_path.clone(),
+                payload: SnapshotPayload::Note(NoteRef {
+                    note_path: d.note_path,
+                    title: d.title,
+                    modified_ms: d.modified_ms,
+                }),
+            })
+            .collect();
+        // `index::list_directory` already returns recency-desc; the
+        // sort here just locks the contract in case that ever shifts.
+        items.sort_by(|a, b| {
+            let am = match &a.payload {
+                SnapshotPayload::Note(n) => n.modified_ms,
+                _ => 0,
+            };
+            let bm = match &b.payload {
+                SnapshotPayload::Note(n) => n.modified_ms,
+                _ => 0,
+            };
+            bm.cmp(&am)
+        });
+        Ok(items)
+    }
+    fn format(&self, label: &str, item: &SnapshotItem) -> String {
+        let n = match &item.payload {
+            SnapshotPayload::Note(n) => n,
+            _ => return String::new(),
+        };
+        let date = format_iso_date(n.modified_ms);
+        format!("[{label}] {date} — {title}\n", title = n.title)
     }
     /// Notes are looked up by `note_path` (the soft-FK item_id). Bulk
     /// SELECT keeps it to one query regardless of the input size.
@@ -147,19 +413,141 @@ impl Signal for NoteSignal {
     }
 }
 
+// ----- Render helpers -----------------------------------------------------
+
+fn email_body_excerpt(m: &EmailMessage) -> String {
+    let raw = m
+        .body_html
+        .as_deref()
+        .or(m.body_preview.as_deref())
+        .unwrap_or("");
+    if raw.is_empty() {
+        return String::new();
+    }
+    // Strip HTML tags + collapse whitespace. Keeps the prompt token-
+    // efficient without pulling in a full HTML parser; preview-only
+    // emails skip the strip logic.
+    let stripped = if raw.contains('<') {
+        strip_html(raw)
+    } else {
+        raw.to_string()
+    };
+    let collapsed = collapse_ws(&stripped);
+    let truncated: String = collapsed.chars().take(800).collect();
+    format!("    {}", truncated)
+}
+
+fn strip_html(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_tag = false;
+    for ch in s.chars() {
+        if ch == '<' {
+            in_tag = true;
+            continue;
+        }
+        if ch == '>' {
+            in_tag = false;
+            out.push(' ');
+            continue;
+        }
+        if !in_tag {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn collapse_ws(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut last_space = false;
+    for ch in s.chars() {
+        if ch.is_whitespace() {
+            if !last_space {
+                out.push(' ');
+                last_space = true;
+            }
+        } else {
+            out.push(ch);
+            last_space = false;
+        }
+    }
+    out.trim().to_string()
+}
+
+fn format_from(email: &str, name: Option<&str>) -> String {
+    match name {
+        Some(n) if !n.is_empty() => format!("{n} <{email}>"),
+        _ => email.to_string(),
+    }
+}
+
+fn format_iso_date(ms: i64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms)
+        .map(|dt| dt.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn format_iso_datetime(ms: i64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
 // ----- Registry ------------------------------------------------------------
 
 pub struct SignalRegistry {
-    by_kind: HashMap<&'static str, Box<dyn Signal>>,
+    /// Sources in the order they appear in the cluster-pass prompt.
+    /// Stable order is part of the contract: re-ordering would change
+    /// the labels Claude returns and (more importantly) churn the
+    /// prompt Anthropic sees on every cluster pass.
+    sources: Vec<Box<dyn Signal>>,
+    /// Index into `sources` keyed by `kind()`.
+    by_kind: HashMap<&'static str, usize>,
 }
 
 impl SignalRegistry {
     pub fn default_with_builtins() -> Self {
-        let mut by_kind: HashMap<&'static str, Box<dyn Signal>> = HashMap::new();
-        by_kind.insert("email", Box::new(EmailSignal));
-        by_kind.insert("event", Box::new(EventSignal));
-        by_kind.insert("note", Box::new(NoteSignal));
-        Self { by_kind }
+        let sources: Vec<Box<dyn Signal>> = vec![
+            Box::new(EmailSignal),
+            Box::new(EventSignal),
+            Box::new(NoteSignal),
+        ];
+        Self::from_sources(sources)
+    }
+
+    /// Build a registry from an explicit ordered list. Asserts that
+    /// `kind()` and `label_prefix()` are unique across sources — a
+    /// duplicate would silently shadow a peer in `by_kind` or collide
+    /// in Claude's labels.
+    pub fn from_sources(sources: Vec<Box<dyn Signal>>) -> Self {
+        let mut by_kind: HashMap<&'static str, usize> = HashMap::new();
+        let mut seen_prefixes: HashMap<&'static str, &'static str> = HashMap::new();
+        for (idx, src) in sources.iter().enumerate() {
+            let kind = src.kind();
+            assert!(
+                by_kind.insert(kind, idx).is_none(),
+                "duplicate Signal kind: {kind}"
+            );
+            let prefix = src.label_prefix();
+            if let Some(other) = seen_prefixes.insert(prefix, kind) {
+                panic!("Signal label_prefix {prefix:?} used by both {other:?} and {kind:?}");
+            }
+        }
+        Self { sources, by_kind }
+    }
+
+    /// Iterate sources in stable prompt-section order. Used by the
+    /// synthesizer to drive the `# Recent <kind>` loop.
+    pub fn iter_in_prompt_order(&self) -> impl Iterator<Item = &dyn Signal> {
+        self.sources.iter().map(|b| b.as_ref())
+    }
+
+    /// Look up a source by `kind`. `None` for unknown kinds; the
+    /// synthesizer only needs this for the email-specific lazy-body
+    /// pre-step.
+    #[allow(dead_code)]
+    pub fn get(&self, kind: &str) -> Option<&dyn Signal> {
+        self.by_kind.get(kind).map(|&idx| self.sources[idx].as_ref())
     }
 
     pub fn hydrate(
@@ -169,7 +557,7 @@ impl SignalRegistry {
         item_ids: &[String],
     ) -> rusqlite::Result<Vec<HydratedSignal>> {
         match self.by_kind.get(kind) {
-            Some(sig) => sig.hydrate(conn, item_ids),
+            Some(&idx) => self.sources[idx].hydrate(conn, item_ids),
             None => {
                 eprintln!(
                     "[workstreams] no Signal impl for kind={kind}; {n} ids dropped",
@@ -417,5 +805,127 @@ mod tests {
         assert!(matches!(by_kind.get("email").unwrap()[0], HydratedSignal::Email(_)));
         assert!(matches!(by_kind.get("event").unwrap()[0], HydratedSignal::Event(_)));
         assert!(matches!(by_kind.get("note").unwrap()[0], HydratedSignal::Note(_)));
+    }
+
+    // ----- Snapshot + format (#86) ----------------------------------------
+
+    #[test]
+    fn registry_iter_in_prompt_order_is_stable() {
+        let reg = SignalRegistry::default_with_builtins();
+        let kinds: Vec<&'static str> =
+            reg.iter_in_prompt_order().map(|s| s.kind()).collect();
+        assert_eq!(kinds, vec!["email", "event", "note"]);
+        let prefixes: Vec<&'static str> = reg
+            .iter_in_prompt_order()
+            .map(|s| s.label_prefix())
+            .collect();
+        assert_eq!(prefixes, vec!["M", "E", "N"]);
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate Signal kind")]
+    fn registry_panics_on_duplicate_kind() {
+        // Two EmailSignals share kind "email" — registry must reject.
+        let sources: Vec<Box<dyn Signal>> =
+            vec![Box::new(EmailSignal), Box::new(EmailSignal)];
+        SignalRegistry::from_sources(sources);
+    }
+
+    #[test]
+    fn email_snapshot_returns_window_recency_desc() {
+        let conn = open_test_db();
+        let now = 1_000_000_000;
+        let day = 24 * 3600 * 1000;
+        seed_email(&conn, "mg:test::recent", now - day);
+        seed_email(&conn, "mg:test::older", now - 5 * day);
+        seed_email(&conn, "mg:test::ancient", now - 60 * day); // outside 14d window
+
+        let items = EmailSignal
+            .snapshot(&conn, now, EmailSignal.default_window(), 100)
+            .unwrap();
+        let ids: Vec<&str> = items.iter().map(|i| i.id.as_str()).collect();
+        assert_eq!(ids, vec!["mg:test::recent", "mg:test::older"]);
+    }
+
+    #[test]
+    fn email_format_renders_header_then_indented_body() {
+        let m = EmailMessage {
+            id: "mg:test::m".into(),
+            connector_id: "mg:test".into(),
+            external_id: "m".into(),
+            thread_id: "t".into(),
+            subject: "Renewal".into(),
+            from_email: "alice@x.io".into(),
+            from_name: Some("Alice".into()),
+            sent_at_ms: 1_700_000_000_000,
+            body_preview: Some("Hi, please review.".into()),
+            body_html: None,
+            has_attachments: false,
+            is_read: true,
+            raw_etag: None,
+            modified_ms: 1_700_000_000_000,
+            recipients: Vec::new(),
+        };
+        let item = SnapshotItem {
+            id: m.id.clone(),
+            payload: SnapshotPayload::Email(m),
+        };
+        let out = EmailSignal.format("M3", &item);
+        // 2023-11-14 — From: Alice <alice@x.io> — Subject: Renewal
+        assert!(out.starts_with("[M3] 2023-11-14 — From: Alice <alice@x.io> — Subject: Renewal\n"));
+        assert!(out.contains("    Hi, please review."));
+        assert!(out.ends_with("\n\n"), "trailing blank line for multi-line item");
+    }
+
+    #[test]
+    fn event_format_renders_single_line_with_attendees() {
+        let e = CalendarEvent {
+            id: "mg:test::e".into(),
+            connector_id: "mg:test".into(),
+            external_id: "e".into(),
+            title: "Hyundai sync".into(),
+            start_ms: 1_700_000_000_000,
+            end_ms: 1_700_000_000_000 + 3600_000,
+            all_day: false,
+            location: None,
+            description: None,
+            source_calendar: None,
+            status: None,
+            raw_etag: None,
+            modified_ms: 1_700_000_000_000,
+            linked_note_path: None,
+            attendees: vec![calendar::CalendarAttendee {
+                email: "bob@x.io".into(),
+                display_name: None,
+                response_status: None,
+                is_self: false,
+                is_organizer: false,
+                team_member_id: None,
+            }],
+        };
+        let item = SnapshotItem {
+            id: e.id.clone(),
+            payload: SnapshotPayload::Event(e),
+        };
+        let out = EventSignal.format("E2", &item);
+        assert_eq!(
+            out,
+            "[E2] 2023-11-14 22:13 — Hyundai sync — Attendees: bob@x.io\n"
+        );
+    }
+
+    #[test]
+    fn note_format_renders_single_line() {
+        let n = NoteRef {
+            note_path: "/notes/x.md".into(),
+            title: "Sourcing plan".into(),
+            modified_ms: 1_700_000_000_000,
+        };
+        let item = SnapshotItem {
+            id: n.note_path.clone(),
+            payload: SnapshotPayload::Note(n),
+        };
+        let out = NoteSignal.format("N1", &item);
+        assert_eq!(out, "[N1] 2023-11-14 — Sourcing plan\n");
     }
 }

--- a/src-tauri/src/workstreams/synthesizer.rs
+++ b/src-tauri/src/workstreams/synthesizer.rs
@@ -17,10 +17,10 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager};
 
 use super::persist::{self, SynthesizedAction, SynthesizedWorkstream};
-use super::{ClusterReport, NoteRef, Workstream};
+use super::signals::{self, SignalRegistry, SnapshotItem, SnapshotPayload};
+use super::{ClusterReport, Workstream};
 use crate::anthropic::{ANTHROPIC_VERSION, DEFAULT_MODEL, ENDPOINT};
-use crate::connectors::{calendar, email, microsoft_graph, oauth};
-use crate::index;
+use crate::connectors::{email, microsoft_graph, oauth};
 use crate::keychain;
 use crate::team;
 
@@ -28,13 +28,10 @@ use crate::team;
 /// landed within this window.
 const CLUSTER_TTL_MS: i64 = 6 * 3600 * 1000;
 
-const EMAIL_WINDOW_BACK_MS: i64 = 14 * 24 * 3600 * 1000;
-const EVENT_WINDOW_BACK_MS: i64 = 14 * 24 * 3600 * 1000;
-const EVENT_WINDOW_FORWARD_MS: i64 = 14 * 24 * 3600 * 1000;
-const NOTE_WINDOW_BACK_MS: i64 = 30 * 24 * 3600 * 1000;
-
 /// Cap on lazy body fetches per pass. Each is a Graph round-trip, so
 /// 100 keeps the pre-call work bounded for users with very busy inboxes.
+/// Cross-cutting (not source-owned) — applies to email body backfill
+/// triggered before the snapshot is rendered.
 const MAX_BODY_FETCHES: usize = 100;
 
 const MAX_TOKENS: u32 = 8192;
@@ -163,7 +160,12 @@ async fn run_cluster_pass(
     }
 
     // ---- 1. Snapshot inputs in a single lock window ---------------------
-    let (existing_active, existing_archived, mut emails, events, notes, team) = {
+    // Workstream lists + per-source snapshots come from the same lock
+    // window so the prompt sees a coherent point-in-time view. Each
+    // source declares its own window+cap (see `signals::Signal`); the
+    // synthesizer just iterates the registry.
+    let registry = signals::registry();
+    let (existing_active, existing_archived, mut snapshots, team) = {
         let c = conn_state.lock().map_err(|e| e.to_string())?;
         // Pull both active and archived (snoozed excluded — they're
         // hidden from synthesis) and partition into separate sections
@@ -181,41 +183,27 @@ async fn run_cluster_pass(
             }
         }
         archived.truncate(ARCHIVED_WORKSTREAM_CAP);
-        let emails = email::list_messages_in_range(
-            &c,
-            now_ms - EMAIL_WINDOW_BACK_MS,
-            now_ms + 24 * 3600 * 1000,
-            None,
-            500,
-        )
-        .map_err(|e| e.to_string())?;
-        let events = calendar::list_events_in_range(
-            &c,
-            now_ms - EVENT_WINDOW_BACK_MS,
-            now_ms + EVENT_WINDOW_FORWARD_MS,
-            None,
-        )
-        .map_err(|e| e.to_string())?;
-        let directory = index::list_directory(&c, 200).map_err(|e| e.to_string())?;
-        let notes_cutoff = now_ms - NOTE_WINDOW_BACK_MS;
-        let notes: Vec<NoteRef> = directory
-            .into_iter()
-            .filter(|d| d.modified_ms >= notes_cutoff)
-            .map(|d| NoteRef {
-                note_path: d.note_path,
-                title: d.title,
-                modified_ms: d.modified_ms,
-            })
-            .collect();
+
+        // Per-source snapshots, keyed by kind. Order is the registry's
+        // prompt-section order — the build_user_message loop relies on
+        // it; storing as a Vec preserves that.
+        let mut snapshots: Vec<(&'static str, Vec<SnapshotItem>)> = Vec::new();
+        for src in registry.iter_in_prompt_order() {
+            let items = src
+                .snapshot(&c, now_ms, src.default_window(), src.default_cap())
+                .map_err(|e| format!("{kind} snapshot: {e}", kind = src.kind()))?;
+            snapshots.push((src.kind(), items));
+        }
         let team = team::list_team_members_raw(&c).unwrap_or_default();
-        (active, archived, emails, events, notes, team)
+        (active, archived, snapshots, team)
     };
     let team_by_id: std::collections::HashMap<String, String> = team
         .iter()
         .map(|m| (m.id.clone(), m.display_name.clone()))
         .collect();
 
-    if emails.is_empty() && events.is_empty() && notes.is_empty() {
+    let total_items: usize = snapshots.iter().map(|(_, v)| v.len()).sum();
+    if total_items == 0 {
         eprintln!("[workstreams] no recent items to cluster; skipping");
         return Ok(ClusterReport {
             state: "skipped".into(),
@@ -225,62 +213,21 @@ async fn run_cluster_pass(
     }
 
     // ---- 2. Lazy-fetch missing email bodies -----------------------------
-    // Bound the work to MAX_BODY_FETCHES per pass; older messages stay
-    // preview-only. Errors per message are logged and skipped — a body
-    // fetch failure must not abort the cluster pass.
-    let mut fetched = 0usize;
-    for m in emails.iter_mut() {
-        if fetched >= MAX_BODY_FETCHES {
-            break;
-        }
-        if m.body_html.is_some() {
-            continue;
-        }
-        let kind = m
-            .connector_id
-            .split_once(':')
-            .map(|(k, _)| k.to_string())
-            .unwrap_or_else(|| "microsoft_graph".to_string());
-        let connector_id = m.connector_id.clone();
-        let external_id = m.external_id.clone();
-        let body_result = oauth::with_valid_token(app, &connector_id, &kind, |access| async move {
-            microsoft_graph::fetch_message_body(&access, &external_id).await
-        })
-        .await;
-        match body_result {
-            Ok(Some(body)) => {
-                {
-                    let c = match conn_state.lock() {
-                        Ok(g) => g,
-                        Err(e) => {
-                            eprintln!("[workstreams] conn lock for body persist: {e}");
-                            continue;
-                        }
-                    };
-                    if let Err(e) = email::set_message_body_html(&c, &m.id, &body) {
-                        eprintln!("[workstreams] persist body for {}: {e}", m.id);
-                    }
-                }
-                m.body_html = Some(body);
-                fetched += 1;
-            }
-            Ok(None) => {}
-            Err(e) => {
-                eprintln!("[workstreams] body fetch failed for {}: {e}", m.id);
-            }
-        }
-    }
+    // Email is the only source today that needs a pre-render async
+    // network step. Bound the work to MAX_BODY_FETCHES per pass; older
+    // messages stay preview-only. Errors per message are logged and
+    // skipped — a body fetch failure must not abort the cluster pass.
+    backfill_email_bodies(app, conn_state, &mut snapshots).await;
 
     // ---- 3. Build prompt, label maps ------------------------------------
     let (user_message, label_maps) = build_user_message(
         &existing_active,
         &existing_archived,
-        &emails,
-        &events,
-        &notes,
+        &snapshots,
+        registry,
         &team_by_id,
     );
-    let items_clustered = (emails.len() + events.len() + notes.len()) as u32;
+    let items_clustered = total_items as u32;
 
     // ---- 4. Single-shot Claude call -------------------------------------
     let api_key = keychain::read_anthropic_api_key().map_err(|_| {
@@ -346,6 +293,67 @@ async fn run_cluster_pass(
     }
 
     Ok(report)
+}
+
+/// Pre-render step that mutates the email snapshot in place: lazy-fetch
+/// missing `body_html` for up to `MAX_BODY_FETCHES` messages so the
+/// cluster prompt has rich excerpts. Other sources are left untouched.
+/// Failures are logged and the message is left preview-only — they
+/// must not abort the cluster pass.
+async fn backfill_email_bodies(
+    app: &AppHandle,
+    conn_state: &std::sync::Mutex<rusqlite::Connection>,
+    snapshots: &mut [(&'static str, Vec<SnapshotItem>)],
+) {
+    let Some((_, items)) = snapshots.iter_mut().find(|(k, _)| *k == "email") else {
+        return;
+    };
+    let mut fetched = 0usize;
+    for item in items.iter_mut() {
+        if fetched >= MAX_BODY_FETCHES {
+            break;
+        }
+        let m = match &mut item.payload {
+            SnapshotPayload::Email(m) => m,
+            _ => continue,
+        };
+        if m.body_html.is_some() {
+            continue;
+        }
+        let kind = m
+            .connector_id
+            .split_once(':')
+            .map(|(k, _)| k.to_string())
+            .unwrap_or_else(|| "microsoft_graph".to_string());
+        let connector_id = m.connector_id.clone();
+        let external_id = m.external_id.clone();
+        let body_result = oauth::with_valid_token(app, &connector_id, &kind, |access| async move {
+            microsoft_graph::fetch_message_body(&access, &external_id).await
+        })
+        .await;
+        match body_result {
+            Ok(Some(body)) => {
+                {
+                    let c = match conn_state.lock() {
+                        Ok(g) => g,
+                        Err(e) => {
+                            eprintln!("[workstreams] conn lock for body persist: {e}");
+                            continue;
+                        }
+                    };
+                    if let Err(e) = email::set_message_body_html(&c, &m.id, &body) {
+                        eprintln!("[workstreams] persist body for {}: {e}", m.id);
+                    }
+                }
+                m.body_html = Some(body);
+                fetched += 1;
+            }
+            Ok(None) => {}
+            Err(e) => {
+                eprintln!("[workstreams] body fetch failed for {}: {e}", m.id);
+            }
+        }
+    }
 }
 
 // ----- Anthropic call ------------------------------------------------------
@@ -426,19 +434,30 @@ async fn call_anthropic(api_key: &str, model: &str, user_message: &str) -> Resul
 
 // ----- Prompt building -----------------------------------------------------
 
-/// Maps from Claude-facing labels (M1, E1, N1) back to canonical IDs.
+/// Maps from Claude-facing labels (M1, E1, N1, …) back to canonical
+/// IDs, keyed by source `kind` ("email", "event", "note", …). Built
+/// from the registry so adding a new source extends this map by one
+/// entry without any synthesizer-side surgery.
 struct LabelMaps {
-    emails: HashMap<String, String>,    // "M1" → "<connector>:<external>"
-    events: HashMap<String, String>,    // "E1" → calendar_events.id
-    notes: HashMap<String, String>,     // "N1" → note_path
+    by_kind: HashMap<&'static str, HashMap<String, String>>,
+}
+
+impl LabelMaps {
+    fn empty() -> Self {
+        Self {
+            by_kind: HashMap::new(),
+        }
+    }
+    fn lookup(&self, kind: &str, label: &str) -> Option<&String> {
+        self.by_kind.get(kind).and_then(|m| m.get(label))
+    }
 }
 
 fn build_user_message(
     existing_active: &[Workstream],
     existing_archived: &[Workstream],
-    emails: &[email::EmailMessage],
-    events: &[calendar::CalendarEvent],
-    notes: &[NoteRef],
+    snapshots: &[(&'static str, Vec<SnapshotItem>)],
+    registry: &SignalRegistry,
     team_by_id: &std::collections::HashMap<String, String>,
 ) -> (String, LabelMaps) {
     let mut s = String::new();
@@ -511,120 +530,49 @@ fn build_user_message(
         }
     }
 
-    let mut email_map = HashMap::new();
-    s.push_str("\n# Recent emails (last 14 days)\n\n");
-    if emails.is_empty() {
-        s.push_str("(none)\n");
-    } else {
-        for (i, m) in emails.iter().enumerate() {
-            let label = format!("M{}", i + 1);
-            email_map.insert(label.clone(), m.id.clone());
-            let date = format_iso_date(m.sent_at_ms);
-            let from = format_from(&m.from_email, m.from_name.as_deref());
-            let body = email_body_excerpt(m);
-            s.push_str(&format!(
-                "[{label}] {date} — From: {from} — Subject: {subject}\n{body}\n\n",
-                subject = m.subject,
-            ));
+    let mut maps = LabelMaps::empty();
+    let mut prefixes: Vec<&'static str> = Vec::new();
+    // One section per registered source, in registry order. Adding a
+    // 4th source (e.g. GitHub) is a pure-add — no churn here.
+    for (kind, items) in snapshots {
+        let src = match registry.get(kind) {
+            Some(s) => s,
+            None => {
+                eprintln!("[workstreams] snapshot kind {kind} has no registered Signal");
+                continue;
+            }
+        };
+        prefixes.push(src.label_prefix());
+        s.push_str(&format!("\n# {}\n\n", src.prompt_section_title()));
+        if items.is_empty() {
+            s.push_str("(none)\n");
+            continue;
+        }
+        let kind_map = maps.by_kind.entry(*kind).or_default();
+        for (i, item) in items.iter().enumerate() {
+            let label = format!("{}{}", src.label_prefix(), i + 1);
+            kind_map.insert(label.clone(), item.id.clone());
+            s.push_str(&src.format(&label, item));
         }
     }
 
-    let mut event_map = HashMap::new();
-    s.push_str("\n# Recent calendar events (window: -14d .. +14d)\n\n");
-    if events.is_empty() {
-        s.push_str("(none)\n");
+    let label_glob = if prefixes.is_empty() {
+        String::new()
     } else {
-        for (i, e) in events.iter().enumerate() {
-            let label = format!("E{}", i + 1);
-            event_map.insert(label.clone(), e.id.clone());
-            let when = format_iso_datetime(e.start_ms);
-            let attendees: Vec<&str> =
-                e.attendees.iter().take(8).map(|a| a.email.as_str()).collect();
-            let attendees_str = if attendees.is_empty() {
-                String::new()
-            } else {
-                format!(" — Attendees: {}", attendees.join(", "))
-            };
-            s.push_str(&format!(
-                "[{label}] {when} — {title}{attendees_str}\n",
-                title = e.title
-            ));
-        }
-    }
-
-    let mut note_map = HashMap::new();
-    s.push_str("\n# Recent notes (last 30 days)\n\n");
-    if notes.is_empty() {
-        s.push_str("(none)\n");
-    } else {
-        for (i, n) in notes.iter().enumerate() {
-            let label = format!("N{}", i + 1);
-            note_map.insert(label.clone(), n.note_path.clone());
-            let date = format_iso_date(n.modified_ms);
-            s.push_str(&format!(
-                "[{label}] {date} — {title}\n",
-                title = n.title
-            ));
-        }
-    }
-
-    s.push_str(
+        prefixes
+            .iter()
+            .map(|p| format!("{p}*"))
+            .collect::<Vec<_>>()
+            .join("/")
+    };
+    s.push_str(&format!(
         "\n# Instructions\n\nReturn a JSON array matching the schema in the system prompt. \
          Reuse an existing workstream id when the new items extend it; spawn a new one (id: null) \
          only when no existing fit. Each action's source_label MUST be one of the labels above \
-         (M*/E*/N*). Output JSON only — no prose, no fences.\n",
-    );
+         ({label_glob}). Output JSON only — no prose, no fences.\n"
+    ));
 
-    (
-        s,
-        LabelMaps {
-            emails: email_map,
-            events: event_map,
-            notes: note_map,
-        },
-    )
-}
-
-fn email_body_excerpt(m: &email::EmailMessage) -> String {
-    let raw = m
-        .body_html
-        .as_deref()
-        .or(m.body_preview.as_deref())
-        .unwrap_or("");
-    if raw.is_empty() {
-        return String::new();
-    }
-    // Strip HTML tags + collapse whitespace. Keeps the prompt token-
-    // efficient without pulling in a full HTML parser; preview-only
-    // emails skip the strip logic.
-    let stripped = if raw.contains('<') {
-        strip_html(raw)
-    } else {
-        raw.to_string()
-    };
-    let collapsed = collapse_ws(&stripped);
-    let truncated: String = collapsed.chars().take(800).collect();
-    format!("    {}", truncated)
-}
-
-fn strip_html(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    let mut in_tag = false;
-    for ch in s.chars() {
-        if ch == '<' {
-            in_tag = true;
-            continue;
-        }
-        if ch == '>' {
-            in_tag = false;
-            out.push(' ');
-            continue;
-        }
-        if !in_tag {
-            out.push(ch);
-        }
-    }
-    out
+    (s, maps)
 }
 
 fn collapse_ws(s: &str) -> String {
@@ -664,22 +612,9 @@ fn truncate_chars(s: &str, cap: usize) -> String {
     format!("{truncated}…")
 }
 
-fn format_from(email: &str, name: Option<&str>) -> String {
-    match name {
-        Some(n) if !n.is_empty() => format!("{n} <{email}>"),
-        _ => email.to_string(),
-    }
-}
-
 fn format_iso_date(ms: i64) -> String {
     DateTime::<Utc>::from_timestamp_millis(ms)
         .map(|dt| dt.format("%Y-%m-%d").to_string())
-        .unwrap_or_else(|| "unknown".to_string())
-}
-
-fn format_iso_datetime(ms: i64) -> String {
-    DateTime::<Utc>::from_timestamp_millis(ms)
-        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
         .unwrap_or_else(|| "unknown".to_string())
 }
 
@@ -779,11 +714,9 @@ fn parse_synthesizer_response(
             notes: Vec::new(),
         });
 
-        let member_emails =
-            map_labels(&members.emails, &label_maps.emails, "email");
-        let member_events =
-            map_labels(&members.events, &label_maps.events, "event");
-        let member_notes = map_labels(&members.notes, &label_maps.notes, "note");
+        let member_emails = map_labels(&members.emails, label_maps, "email");
+        let member_events = map_labels(&members.events, label_maps, "event");
+        let member_notes = map_labels(&members.notes, label_maps, "note");
 
         let actions = raw
             .actions
@@ -796,12 +729,7 @@ fn parse_synthesizer_response(
                 };
                 let kind = a.source_kind.unwrap_or_default();
                 let label = a.source_label.unwrap_or_default();
-                let source_id = match kind.as_str() {
-                    "email" => label_maps.emails.get(&label).cloned(),
-                    "event" => label_maps.events.get(&label).cloned(),
-                    "note" => label_maps.notes.get(&label).cloned(),
-                    _ => None,
-                };
+                let source_id = label_maps.lookup(&kind, &label).cloned();
                 let source_id = match source_id {
                     Some(s) => s,
                     None => {
@@ -836,13 +764,13 @@ fn parse_synthesizer_response(
 
 fn map_labels(
     labels: &[String],
-    map: &HashMap<String, String>,
+    maps: &LabelMaps,
     kind: &str,
 ) -> Vec<String> {
     let mut out = Vec::with_capacity(labels.len());
     let mut seen = HashSet::new();
     for label in labels {
-        match map.get(label.trim()) {
+        match maps.lookup(kind, label.trim()) {
             Some(id) => {
                 if seen.insert(id.clone()) {
                     out.push(id.clone());
@@ -906,14 +834,18 @@ mod tests {
     use super::*;
 
     fn label_maps() -> LabelMaps {
+        let mut by_kind: HashMap<&'static str, HashMap<String, String>> = HashMap::new();
         let mut emails = HashMap::new();
-        emails.insert("M1".into(), "mg:test::msg-1".to_string());
-        emails.insert("M2".into(), "mg:test::msg-2".to_string());
+        emails.insert("M1".to_string(), "mg:test::msg-1".to_string());
+        emails.insert("M2".to_string(), "mg:test::msg-2".to_string());
+        by_kind.insert("email", emails);
         let mut events = HashMap::new();
-        events.insert("E1".into(), "mg:test::ev-1".to_string());
+        events.insert("E1".to_string(), "mg:test::ev-1".to_string());
+        by_kind.insert("event", events);
         let mut notes = HashMap::new();
-        notes.insert("N1".into(), "/notes/a.md".to_string());
-        LabelMaps { emails, events, notes }
+        notes.insert("N1".to_string(), "/notes/a.md".to_string());
+        by_kind.insert("note", notes);
+        LabelMaps { by_kind }
     }
 
     #[test]
@@ -997,11 +929,6 @@ mod tests {
     }
 
     #[test]
-    fn strip_html_removes_tags_and_keeps_text() {
-        assert_eq!(strip_html("<p>hello <b>world</b></p>").trim(), "hello  world");
-    }
-
-    #[test]
     fn collapse_ws_squashes_runs() {
         assert_eq!(collapse_ws("  a   b\n\nc  "), "a b c");
     }
@@ -1024,5 +951,136 @@ mod tests {
         let parsed = parse_synthesizer_response(raw, &label_maps());
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].status, None);
+    }
+
+    // ----- Prompt parity (#86) -------------------------------------------
+    //
+    // build_user_message is now driven by the registry. Lock the byte-
+    // exact section structure so a future "add a 4th source" PR doesn't
+    // accidentally reflow the email/event/note rendering. One item per
+    // section keeps the assertion readable; the per-source format()
+    // logic is covered in `signals` tests.
+
+    fn make_email() -> SnapshotItem {
+        let m = email::EmailMessage {
+            id: "mg:test::m1".into(),
+            connector_id: "mg:test".into(),
+            external_id: "m1".into(),
+            thread_id: "t".into(),
+            subject: "Hi".into(),
+            from_email: "alice@x.io".into(),
+            from_name: Some("Alice".into()),
+            sent_at_ms: 1_700_000_000_000,
+            body_preview: Some("Body text".into()),
+            body_html: None,
+            has_attachments: false,
+            is_read: true,
+            raw_etag: None,
+            modified_ms: 1_700_000_000_000,
+            recipients: Vec::new(),
+        };
+        SnapshotItem {
+            id: m.id.clone(),
+            payload: SnapshotPayload::Email(m),
+        }
+    }
+
+    fn make_event() -> SnapshotItem {
+        let e = crate::connectors::calendar::CalendarEvent {
+            id: "mg:test::e1".into(),
+            connector_id: "mg:test".into(),
+            external_id: "e1".into(),
+            title: "Sync".into(),
+            start_ms: 1_700_000_000_000,
+            end_ms: 1_700_000_000_000 + 3600_000,
+            all_day: false,
+            location: None,
+            description: None,
+            source_calendar: None,
+            status: None,
+            raw_etag: None,
+            modified_ms: 1_700_000_000_000,
+            linked_note_path: None,
+            attendees: Vec::new(),
+        };
+        SnapshotItem {
+            id: e.id.clone(),
+            payload: SnapshotPayload::Event(e),
+        }
+    }
+
+    fn make_note() -> SnapshotItem {
+        let n = super::super::NoteRef {
+            note_path: "/notes/a.md".into(),
+            title: "Plan".into(),
+            modified_ms: 1_700_000_000_000,
+        };
+        SnapshotItem {
+            id: n.note_path.clone(),
+            payload: SnapshotPayload::Note(n),
+        }
+    }
+
+    #[test]
+    fn build_user_message_matches_locked_layout() {
+        let registry = signals::registry();
+        let snapshots: Vec<(&'static str, Vec<SnapshotItem>)> = vec![
+            ("email", vec![make_email()]),
+            ("event", vec![make_event()]),
+            ("note", vec![make_note()]),
+        ];
+        let team: HashMap<String, String> = HashMap::new();
+        let (prompt, maps) = build_user_message(&[], &[], &snapshots, registry, &team);
+
+        let expected = concat!(
+            "# Existing workstreams (active)\n\n",
+            "(none)\n",
+            "\n# Recent emails (last 14 days)\n\n",
+            "[M1] 2023-11-14 — From: Alice <alice@x.io> — Subject: Hi\n",
+            "    Body text\n\n",
+            "\n# Recent calendar events (window: -14d .. +14d)\n\n",
+            "[E1] 2023-11-14 22:13 — Sync\n",
+            "\n# Recent notes (last 30 days)\n\n",
+            "[N1] 2023-11-14 — Plan\n",
+            "\n# Instructions\n\n",
+            "Return a JSON array matching the schema in the system prompt. ",
+            "Reuse an existing workstream id when the new items extend it; spawn a new one (id: null) ",
+            "only when no existing fit. Each action's source_label MUST be one of the labels above ",
+            "(M*/E*/N*). Output JSON only — no prose, no fences.\n",
+        );
+
+        assert_eq!(prompt, expected, "prompt layout drifted");
+
+        // Label maps were built keyed by kind.
+        assert_eq!(
+            maps.lookup("email", "M1").map(String::as_str),
+            Some("mg:test::m1")
+        );
+        assert_eq!(
+            maps.lookup("event", "E1").map(String::as_str),
+            Some("mg:test::e1")
+        );
+        assert_eq!(
+            maps.lookup("note", "N1").map(String::as_str),
+            Some("/notes/a.md")
+        );
+        // Cross-kind lookup must miss (event label can't appear under email).
+        assert!(maps.lookup("email", "E1").is_none());
+    }
+
+    #[test]
+    fn build_user_message_renders_none_for_empty_section() {
+        let registry = signals::registry();
+        let snapshots: Vec<(&'static str, Vec<SnapshotItem>)> = vec![
+            ("email", vec![]),
+            ("event", vec![]),
+            ("note", vec![]),
+        ];
+        let team: HashMap<String, String> = HashMap::new();
+        let (prompt, maps) = build_user_message(&[], &[], &snapshots, registry, &team);
+        assert!(prompt.contains("\n# Recent emails (last 14 days)\n\n(none)\n"));
+        assert!(prompt.contains("\n# Recent calendar events (window: -14d .. +14d)\n\n(none)\n"));
+        assert!(prompt.contains("\n# Recent notes (last 30 days)\n\n(none)\n"));
+        assert!(maps.by_kind.is_empty(), "no items, no labels recorded");
     }
 }


### PR DESCRIPTION
## Summary

Extends the existing `Signal` trait in `workstreams/signals.rs` with snapshot + format + window/cap methods so each source owns its contract end-to-end. The synthesizer's cluster pass now drives the prompt loop through `SignalRegistry::iter_in_prompt_order()` instead of hardcoding three sections + the scattered `EMAIL_WINDOW_BACK_MS` / `EVENT_WINDOW_*` / `NOTE_WINDOW_BACK_MS` / `MAX_BODY_FETCHES`-style constants.

Adding a 4th source (e.g. GitHub PRs) becomes a one-file change: implement the trait, register in `default_with_builtins`, done. No synthesizer-prompt-string surgery.

Closes #86.

### Design choices

- **One trait, not two.** Folded the snapshot side into the existing `Signal` trait so each kind lives in a single impl block (hydrate + snapshot + format + windows + caps). Avoids a parallel `SignalSource` trait diverging over time.
- **Closed enum `SnapshotPayload`.** Mirrors the existing `HydratedSignal`. Type-safe pattern matching, no boxed `Any`. New kinds add a variant + an impl.
- **Email body backfill stays in synthesizer.** It's the only async network step today (Graph round-trip + DB persist). Lifting it into the trait would force every `Signal` to be async — not worth it for v1. Extracted into `backfill_email_bodies` so it's no longer inline in `run_cluster_pass`.
- **`now_ms` injected, not read inside snapshots.** Tests pin the window deterministically.
- **Token budget allocator deferred.** Issue calls v1 fixed-priority. Each source returns up to its `default_cap()`.

### Files

- `src-tauri/src/workstreams/signals.rs` — extended trait, added `SnapshotItem` / `SnapshotPayload` / `SignalWindow`, snapshot+format impls per source, registry rebuilt as ordered `Vec<Box<dyn Signal>>` with unique-kind/prefix asserts.
- `src-tauri/src/workstreams/synthesizer.rs` — `run_cluster_pass` and `build_user_message` now iterate the registry; `LabelMaps` rekeyed by source kind; render helpers moved into `signals.rs` next to the impls that use them.

## Test plan

- [x] `cargo test --lib` — 228 passed, 0 failed
- [x] `build_user_message_matches_locked_layout` — byte-exact prompt parity test that locks the cluster-pass layout for unchanged inputs (the issue's "output unchanged for the same inputs" acceptance criterion)
- [x] `build_user_message_renders_none_for_empty_section` — empty-section behavior preserved
- [x] `registry_iter_in_prompt_order_is_stable` — asserts email/event/note ordering + M/E/N prefixes
- [x] `registry_panics_on_duplicate_kind` — `should_panic` smoke test for the registry's invariant
- [x] Per-source snapshot + format tests (email/event/note)
- [x] All existing `parse_synthesizer_response_*` tests pass without modification (label parsing surface is unchanged)
- [ ] Manual: trigger a real cluster pass against a populated DB and diff the prompt against pre-PR output (parity test covers this synthetically; manual verification would close the loop)