### PR TITLE
Typed team-member aliases (#87)

### DIFF
--- a/src-tauri/src/ask.rs
+++ b/src-tauri/src/ask.rs
@@ -1486,7 +1486,8 @@ fn format_user_message(
             let aliases = if m.aliases.is_empty() {
                 String::new()
             } else {
-                format!(" (aliases: {})", m.aliases.join(", "))
+                let vals: Vec<&str> = m.aliases.iter().map(|a| a.value.as_str()).collect();
+                format!(" (aliases: {})", vals.join(", "))
             };
             let role = if m.role.is_empty() {
                 String::new()

--- a/src-tauri/src/connectors/google.rs
+++ b/src-tauri/src/connectors/google.rs
@@ -356,7 +356,7 @@ fn map_event(
                         .map(|e| e.eq_ignore_ascii_case(&email_lc))
                         .unwrap_or(false),
                     is_organizer: true,
-                    team_member_id: resolver.resolve(&email_lc, org.display_name.as_deref()),
+                    team_member_id: resolver.resolve_attendee(&email_lc, org.display_name.as_deref()),
                 });
             }
         }
@@ -381,7 +381,7 @@ fn map_event(
             response_status: raw_a.response_status,
             is_self,
             is_organizer,
-            team_member_id: resolver.resolve(&email, raw_a.display_name.as_deref()),
+            team_member_id: resolver.resolve_attendee(&email, raw_a.display_name.as_deref()),
         });
     }
 
@@ -671,7 +671,7 @@ fn map_message(
                     continue;
                 }
                 recipients.push(EmailRecipient {
-                    team_member_id: resolver.resolve(&email, name.as_deref()),
+                    team_member_id: resolver.resolve_attendee(&email, name.as_deref()),
                     email,
                     display_name: name,
                     recipient_type: kind.to_string(),
@@ -902,12 +902,18 @@ mod tests {
     use super::*;
     use crate::team::TeamMember;
 
-    fn mk_member(id: &str, name: &str, aliases: &[&str]) -> TeamMember {
+    fn mk_member(id: &str, name: &str, aliases: &[(&str, &str)]) -> TeamMember {
         TeamMember {
             id: id.to_string(),
             display_name: name.to_string(),
             role: String::new(),
-            aliases: aliases.iter().map(|s| s.to_string()).collect(),
+            aliases: aliases
+                .iter()
+                .map(|(k, v)| crate::team::TypedAlias {
+                    kind: (*k).to_string(),
+                    value: (*v).to_string(),
+                })
+                .collect(),
             profile_md_path: String::new(),
             is_self: false,
             created_ms: 0,
@@ -1004,7 +1010,7 @@ mod tests {
             }),
             updated: Some("2026-05-09T12:00:00Z".into()),
         };
-        let members = [mk_member("hk1", "Heike", &["heike@example.com"])];
+        let members = [mk_member("hk1", "Heike", &[("email", "heike@example.com")])];
         let resolver = AttendeeResolver::new(&members);
         let ev = map_event("google:tj@example.com", raw, &resolver, Some("tj@example.com"));
 

--- a/src-tauri/src/connectors/microsoft_graph.rs
+++ b/src-tauri/src/connectors/microsoft_graph.rs
@@ -438,7 +438,7 @@ pub(crate) fn map_event(
                     response_status: Some("organizer".to_string()),
                     is_self: self_email.map(|e| e.eq_ignore_ascii_case(&email_lc)).unwrap_or(false),
                     is_organizer: true,
-                    team_member_id: resolver.resolve(&email_lc, org.name.as_deref()),
+                    team_member_id: resolver.resolve_attendee(&email_lc, org.name.as_deref()),
                 });
             }
         }
@@ -463,7 +463,7 @@ pub(crate) fn map_event(
             response_status: raw_a.status.and_then(|s| s.response),
             is_self: self_email.map(|e| e.eq_ignore_ascii_case(&email)).unwrap_or(false),
             is_organizer: false,
-            team_member_id: resolver.resolve(&email, None),
+            team_member_id: resolver.resolve_attendee(&email, None),
         });
     }
 
@@ -651,7 +651,7 @@ pub(crate) fn map_message(
                 continue;
             }
             recipients.push(EmailRecipient {
-                team_member_id: resolver.resolve(&email, addr.name.as_deref()),
+                team_member_id: resolver.resolve_attendee(&email, addr.name.as_deref()),
                 email,
                 display_name: addr.name,
                 recipient_type: kind.to_string(),
@@ -699,52 +699,91 @@ fn percent_encode_path(s: &str) -> String {
 
 // ----- Attendee resolver -------------------------------------------------
 
-/// Resolve an attendee's `email` (and optional display name) to a
-/// `team_member_id`, if Margin knows the person.
-///
-/// Strategy:
-///   1. Email match: lowercased email vs. team_member's display_name
-///      (some teams use email-as-name) AND any of their aliases.
-///   2. Name match: display_name through the existing
-///      `team::OwnerResolver` (handles diacritic-insensitive
-///      first-name matching).
-///
-/// `OwnerResolver` is in #[allow(dead_code)] until owner resolution
-/// expands beyond the action-items pipeline; we hold a reference here.
+/// Resolve a person identifier (email, GitHub login, Slack id, …) to a
+/// `team_member_id`, if Margin knows the person. Each alias kind has
+/// its own lookup map built from the typed `team_member_aliases` rows
+/// (#87). Connectors call the per-kind methods directly; the email +
+/// calendar pipelines use the convenience `resolve_attendee` shim that
+/// preserves the existing email-then-name fallback.
 pub(crate) struct AttendeeResolver<'a> {
+    by_email: HashMap<String, String>,        // email_lc → team_member_id
+    by_github_login: HashMap<String, String>, // login_lc → team_member_id
+    by_slack_id: HashMap<String, String>,     // slack_id → team_member_id (case-preserved)
     by_name: OwnerResolver,
-    by_email: HashMap<String, String>, // email_lc → team_member_id
     _members: &'a [TeamMember],
 }
 
 impl<'a> AttendeeResolver<'a> {
     pub(crate) fn new(members: &'a [TeamMember]) -> Self {
         let mut by_email: HashMap<String, String> = HashMap::new();
+        let mut by_github_login: HashMap<String, String> = HashMap::new();
+        let mut by_slack_id: HashMap<String, String> = HashMap::new();
         for m in members {
             // Some teams put the email itself as display_name; treat
-            // that as an email key too.
+            // that as an email key too — preserves prior behavior.
             if m.display_name.contains('@') {
                 by_email.insert(m.display_name.to_lowercase(), m.id.clone());
             }
             for alias in &m.aliases {
-                if alias.contains('@') {
-                    by_email.insert(alias.to_lowercase(), m.id.clone());
+                match alias.kind.as_str() {
+                    team::kinds::EMAIL => {
+                        by_email.insert(alias.value.to_lowercase(), m.id.clone());
+                    }
+                    team::kinds::GITHUB_LOGIN => {
+                        by_github_login.insert(alias.value.to_lowercase(), m.id.clone());
+                    }
+                    team::kinds::SLACK_ID => {
+                        // Slack ids are case-significant ("U0ABCDE")
+                        // but practically uppercase; index as-is.
+                        by_slack_id.insert(alias.value.clone(), m.id.clone());
+                    }
+                    // `name` aliases live in `OwnerResolver`; other
+                    // unknown kinds are dropped here and re-added when
+                    // a future resolver method is registered.
+                    _ => {}
                 }
             }
         }
         Self {
-            by_name: OwnerResolver::from_members(members),
             by_email,
+            by_github_login,
+            by_slack_id,
+            by_name: OwnerResolver::from_members(members),
             _members: members,
         }
     }
 
-    pub(crate) fn resolve(&self, email_lc: &str, display_name: Option<&str>) -> Option<String> {
-        if let Some(id) = self.by_email.get(email_lc) {
-            return Some(id.clone());
+    pub(crate) fn resolve_by_email(&self, email_lc: &str) -> Option<String> {
+        self.by_email.get(email_lc).cloned()
+    }
+
+    pub(crate) fn resolve_by_name(&self, name: &str) -> Option<String> {
+        self.by_name.resolve(name)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn resolve_by_github_login(&self, login: &str) -> Option<String> {
+        self.by_github_login.get(&login.to_lowercase()).cloned()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn resolve_by_slack_id(&self, slack_id: &str) -> Option<String> {
+        self.by_slack_id.get(slack_id).cloned()
+    }
+
+    /// Combined helper preserving the existing email-then-name dispatch
+    /// used by every email/calendar connector. New connectors that
+    /// don't carry both kinds should call the per-kind methods directly.
+    pub(crate) fn resolve_attendee(
+        &self,
+        email_lc: &str,
+        display_name: Option<&str>,
+    ) -> Option<String> {
+        if let Some(id) = self.resolve_by_email(email_lc) {
+            return Some(id);
         }
         if let Some(name) = display_name {
-            if let Some(id) = self.by_name.resolve(name) {
+            if let Some(id) = self.resolve_by_name(name) {
                 return Some(id);
             }
         }
@@ -793,12 +832,18 @@ use chrono::TimeZone as _;
 mod tests {
     use super::*;
 
-    fn mk_member(id: &str, name: &str, aliases: &[&str]) -> TeamMember {
+    fn mk_member(id: &str, name: &str, aliases: &[(&str, &str)]) -> TeamMember {
         TeamMember {
             id: id.to_string(),
             display_name: name.to_string(),
             role: String::new(),
-            aliases: aliases.iter().map(|s| s.to_string()).collect(),
+            aliases: aliases
+                .iter()
+                .map(|(k, v)| team::TypedAlias {
+                    kind: (*k).to_string(),
+                    value: (*v).to_string(),
+                })
+                .collect(),
             profile_md_path: String::new(),
             is_self: false,
             created_ms: 0,
@@ -850,7 +895,7 @@ mod tests {
             etag: Some("W/\"abc\"".to_string()),
             last_modified: Some("2026-05-09T12:34:56Z".to_string()),
         };
-        let members = [mk_member("hk1", "Heike", &["heike@example.com"])];
+        let members = [mk_member("hk1", "Heike", &[("email", "heike@example.com")])];
         let resolver = AttendeeResolver::new(&members);
         let ev = map_event("microsoft_graph:tj@example.com", raw, &resolver, Some("tj@example.com"));
 
@@ -929,11 +974,11 @@ mod tests {
 
     #[test]
     fn attendee_resolver_email_match() {
-        let members = [mk_member("hk1", "Heike Müller", &["heike@contoso.com"])];
+        let members = [mk_member("hk1", "Heike Müller", &[("email", "heike@contoso.com")])];
         let r = AttendeeResolver::new(&members);
-        assert_eq!(r.resolve("heike@contoso.com", None).as_deref(), Some("hk1"));
+        assert_eq!(r.resolve_attendee("heike@contoso.com", None).as_deref(), Some("hk1"));
         // Case-insensitive
-        assert_eq!(r.resolve("Heike@CONTOSO.com".to_lowercase().as_str(), None).as_deref(), Some("hk1"));
+        assert_eq!(r.resolve_attendee("Heike@CONTOSO.com".to_lowercase().as_str(), None).as_deref(), Some("hk1"));
     }
 
     #[test]
@@ -941,13 +986,47 @@ mod tests {
         let members = [mk_member("hk1", "Heike Müller", &[])];
         let r = AttendeeResolver::new(&members);
         // Email not registered as alias.
-        assert_eq!(r.resolve("unknown@x.com", Some("Heike Müller")).as_deref(), Some("hk1"));
+        assert_eq!(r.resolve_attendee("unknown@x.com", Some("Heike Müller")).as_deref(), Some("hk1"));
     }
 
     #[test]
     fn attendee_resolver_no_match_returns_none() {
         let r = AttendeeResolver::new(&[]);
-        assert!(r.resolve("nobody@nope.com", Some("Nobody")).is_none());
+        assert!(r.resolve_attendee("nobody@nope.com", Some("Nobody")).is_none());
+    }
+
+    #[test]
+    fn attendee_resolver_resolves_by_github_login() {
+        let members = [mk_member(
+            "hk1",
+            "Heike Müller",
+            &[("github_login", "heike-mueller")],
+        )];
+        let r = AttendeeResolver::new(&members);
+        assert_eq!(r.resolve_by_github_login("heike-mueller").as_deref(), Some("hk1"));
+        // Case-insensitive
+        assert_eq!(r.resolve_by_github_login("Heike-Mueller").as_deref(), Some("hk1"));
+        // Email map untouched by a github_login alias.
+        assert!(r.resolve_by_email("heike-mueller").is_none());
+    }
+
+    #[test]
+    fn attendee_resolver_resolves_by_slack_id() {
+        let members = [mk_member("hk1", "Heike Müller", &[("slack_id", "U0ABCDE12")])];
+        let r = AttendeeResolver::new(&members);
+        assert_eq!(r.resolve_by_slack_id("U0ABCDE12").as_deref(), Some("hk1"));
+        // Slack ids are case-significant; lowercase shouldn't match.
+        assert!(r.resolve_by_slack_id("u0abcde12").is_none());
+    }
+
+    #[test]
+    fn attendee_resolver_kinds_are_isolated() {
+        // A `name` alias whose value matches an email local part should
+        // not leak into the email map (#87).
+        let members = [mk_member("hk1", "Heike Müller", &[("name", "heike")])];
+        let r = AttendeeResolver::new(&members);
+        assert!(r.resolve_by_email("heike").is_none(), "no email alias was registered");
+        assert_eq!(r.resolve_by_name("heike").as_deref(), Some("hk1"));
     }
 
     fn mk_recip(email: &str, name: Option<&str>) -> RawRecipientWrapper {
@@ -1059,7 +1138,7 @@ mod tests {
 
     #[test]
     fn map_message_resolves_recipients_via_team() {
-        let members = [mk_member("hk1", "Heike Müller", &["heike@contoso.com"])];
+        let members = [mk_member("hk1", "Heike Müller", &[("email", "heike@contoso.com")])];
         let resolver = AttendeeResolver::new(&members);
         let raw = RawMessage {
             id: "MSG5".into(),

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -47,7 +47,8 @@ const SCHEMA_V13: &str = include_str!("migrations/013_workstream_user_notes.sql"
 const SCHEMA_V14: &str = include_str!("migrations/014_workstream_archive_resurface.sql");
 const SCHEMA_V15: &str = include_str!("migrations/015_workstream_owner.sql");
 const SCHEMA_V16: &str = include_str!("migrations/016_workstream_signals.sql");
-const SCHEMA_VERSION: i64 = 16;
+const SCHEMA_V17: &str = include_str!("migrations/017_typed_aliases.sql");
+const SCHEMA_VERSION: i64 = 17;
 
 /// Open the index DB at `db_path` (creating it if absent) and apply any
 /// pending migrations.
@@ -153,6 +154,10 @@ fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 15 {
         conn.execute_batch(SCHEMA_V16)?;
         version = 16;
+    }
+    if version == 16 {
+        conn.execute_batch(SCHEMA_V17)?;
+        version = 17;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/migrations/017_typed_aliases.sql
+++ b/src-tauri/src/migrations/017_typed_aliases.sql
@@ -1,0 +1,33 @@
+-- Typed team-member aliases (#87).
+--
+-- The flat `team_members.aliases` JSON column conflates emails, names, and
+-- (incoming) GitHub/Slack handles. The resolver assumed every alias was an
+-- email-or-name, so a GitHub username like `heike-mueller` would either
+-- leak into email matching or fail to resolve at all.
+--
+-- This migration introduces a typed pivot keyed by (member_id, kind, value)
+-- and backfills existing rows by sniffing for `@` (email) or falling back
+-- to name. The original JSON column is dropped — single source of truth.
+
+CREATE TABLE team_member_aliases (
+  member_id TEXT NOT NULL REFERENCES team_members(id) ON DELETE CASCADE,
+  kind      TEXT NOT NULL,
+  value     TEXT NOT NULL,
+  PRIMARY KEY (member_id, kind, value)
+);
+CREATE INDEX idx_alias_kind_value ON team_member_aliases(kind, value);
+
+-- Existing aliases live as a JSON array on `team_members.aliases`. Sniff
+-- each entry: anything containing `@` is presumed an email, everything
+-- else is a name. Empty strings are filtered.
+INSERT INTO team_member_aliases(member_id, kind, value)
+SELECT
+  tm.id,
+  CASE WHEN je.value LIKE '%@%' THEN 'email' ELSE 'name' END,
+  je.value
+FROM team_members tm, json_each(tm.aliases) je
+WHERE je.value <> '';
+
+ALTER TABLE team_members DROP COLUMN aliases;
+
+UPDATE meta SET value = '17' WHERE key = 'schema_version';

--- a/src-tauri/src/reconcile.rs
+++ b/src-tauri/src/reconcile.rs
@@ -362,7 +362,7 @@ fn format_attendee_entry(member: &TeamMember, excerpt: &str) -> String {
     let alias_list: Vec<&str> = member
         .aliases
         .iter()
-        .map(|a| a.trim())
+        .map(|a| a.value.trim())
         .filter(|a| !a.is_empty())
         .collect();
     if !alias_list.is_empty() {
@@ -770,12 +770,18 @@ mod tests {
         assert_eq!(got, "first part second part");
     }
 
-    fn member(name: &str, role: &str, aliases: &[&str], is_self: bool) -> TeamMember {
+    fn member(name: &str, role: &str, aliases: &[(&str, &str)], is_self: bool) -> TeamMember {
         TeamMember {
             id: format!("{}-id", name.to_ascii_lowercase()),
             display_name: name.into(),
             role: role.into(),
-            aliases: aliases.iter().map(|s| s.to_string()).collect(),
+            aliases: aliases
+                .iter()
+                .map(|(k, v)| crate::team::TypedAlias {
+                    kind: (*k).to_string(),
+                    value: (*v).to_string(),
+                })
+                .collect(),
             profile_md_path: format!("/tmp/{}.md", name),
             is_self,
             created_ms: 0,
@@ -830,7 +836,7 @@ mod tests {
     fn format_attendees_section_marks_self_and_omits_empty_fields() {
         let entries = vec![
             (
-                member("Tom Ruesch", "CEO", &["TJ", "Tom"], true),
+                member("Tom Ruesch", "CEO", &[("name", "TJ"), ("name", "Tom")], true),
                 "Leads engineering.".to_string(),
             ),
             (member("Sarah Smith", "", &[], false), String::new()),

--- a/src-tauri/src/team.rs
+++ b/src-tauri/src/team.rs
@@ -25,19 +25,29 @@ pub struct TeamMember {
     pub id: String,
     pub display_name: String,
     pub role: String,
-    pub aliases: Vec<String>,
+    pub aliases: Vec<TypedAlias>,
     pub profile_md_path: String,
     pub is_self: bool,
     pub created_ms: i64,
     pub updated_ms: i64,
 }
 
-fn aliases_to_json(v: &[String]) -> String {
-    serde_json::to_string(v).unwrap_or_else(|_| "[]".into())
+/// One typed identity (#87). `kind` is a soft enum; the canonical
+/// values live in [`kinds`]. Adding a new alias kind is a pure-add: a
+/// new constant + a new resolver method, no schema change.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TypedAlias {
+    pub kind: String,
+    pub value: String,
 }
 
-fn aliases_from_json(s: &str) -> Vec<String> {
-    serde_json::from_str(s).unwrap_or_default()
+/// Canonical string values for `TypedAlias.kind`. Soft enum so adding a
+/// new kind doesn't touch the schema or this module's surface.
+pub mod kinds {
+    pub const EMAIL: &str = "email";
+    pub const NAME: &str = "name";
+    pub const GITHUB_LOGIN: &str = "github_login";
+    pub const SLACK_ID: &str = "slack_id";
 }
 
 fn now_ms() -> i64 {
@@ -66,7 +76,6 @@ fn row_to_member(
     id: String,
     display_name: String,
     role: String,
-    aliases_json: String,
     profile_md_path: String,
     is_self: i64,
     created_ms: i64,
@@ -76,7 +85,9 @@ fn row_to_member(
         id,
         display_name,
         role,
-        aliases: aliases_from_json(&aliases_json),
+        // Aliases are joined separately to avoid a JSON column. Callers
+        // populate this Vec via `attach_aliases` after the main query.
+        aliases: Vec::new(),
         profile_md_path,
         is_self: is_self != 0,
         created_ms,
@@ -84,28 +95,73 @@ fn row_to_member(
     }
 }
 
-const SELECT_MEMBER_COLS: &str = "id, display_name, role, aliases, profile_md_path, is_self, \
+const SELECT_MEMBER_COLS: &str = "id, display_name, role, profile_md_path, is_self, \
                                   created_ms, updated_ms";
+
+/// Read all alias rows for the given member ids in a single query, then
+/// attach them to each member. One extra round-trip regardless of input
+/// size — no per-row N+1.
+fn attach_aliases(conn: &Connection, members: &mut [TeamMember]) -> Result<(), String> {
+    if members.is_empty() {
+        return Ok(());
+    }
+    let placeholders = std::iter::repeat("?")
+        .take(members.len())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "SELECT member_id, kind, value FROM team_member_aliases \
+         WHERE member_id IN ({placeholders}) \
+         ORDER BY member_id, kind, value"
+    );
+    let id_refs: Vec<&dyn rusqlite::ToSql> = members
+        .iter()
+        .map(|m| &m.id as &dyn rusqlite::ToSql)
+        .collect();
+    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map(rusqlite::params_from_iter(id_refs), |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?, r.get::<_, String>(2)?))
+        })
+        .map_err(|e| e.to_string())?;
+    let mut by_member: HashMap<String, Vec<TypedAlias>> = HashMap::new();
+    for row in rows {
+        let (member_id, kind, value) = row.map_err(|e| e.to_string())?;
+        by_member
+            .entry(member_id)
+            .or_default()
+            .push(TypedAlias { kind, value });
+    }
+    for m in members.iter_mut() {
+        if let Some(v) = by_member.remove(&m.id) {
+            m.aliases = v;
+        }
+    }
+    Ok(())
+}
 
 fn fetch_one(conn: &Connection, id: &str) -> Result<TeamMember, String> {
     let sql = format!(
         "SELECT {SELECT_MEMBER_COLS} FROM team_members WHERE id = ?1"
     );
-    conn.query_row(&sql, params![id], |r| {
-        Ok(row_to_member(
-            r.get(0)?,
-            r.get(1)?,
-            r.get(2)?,
-            r.get(3)?,
-            r.get(4)?,
-            r.get(5)?,
-            r.get(6)?,
-            r.get(7)?,
-        ))
-    })
-    .optional()
-    .map_err(|e| e.to_string())?
-    .ok_or_else(|| format!("team member not found: {id}"))
+    let member = conn
+        .query_row(&sql, params![id], |r| {
+            Ok(row_to_member(
+                r.get(0)?,
+                r.get(1)?,
+                r.get(2)?,
+                r.get(3)?,
+                r.get(4)?,
+                r.get(5)?,
+                r.get(6)?,
+            ))
+        })
+        .optional()
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("team member not found: {id}"))?;
+    let mut members = vec![member];
+    attach_aliases(conn, &mut members)?;
+    Ok(members.into_iter().next().unwrap())
 }
 
 fn default_self_display_name() -> String {
@@ -143,8 +199,8 @@ pub fn bootstrap_self_if_missing(conn: &mut Connection) -> Result<(), String> {
     write_stub_profile(&profile_md_path, &display_name)?;
     let now = now_ms();
     conn.execute(
-        "INSERT INTO team_members(id, display_name, role, aliases, profile_md_path, is_self, \
-         created_ms, updated_ms) VALUES (?1, ?2, '', '[]', ?3, 1, ?4, ?4)",
+        "INSERT INTO team_members(id, display_name, role, profile_md_path, is_self, \
+         created_ms, updated_ms) VALUES (?1, ?2, '', ?3, 1, ?4, ?4)",
         params![id, display_name, profile_md_path.to_string_lossy().to_string(), now],
     )
     .map_err(|e| e.to_string())?;
@@ -171,7 +227,6 @@ pub(crate) fn list_team_members_raw(conn: &Connection) -> Result<Vec<TeamMember>
                 r.get(4)?,
                 r.get(5)?,
                 r.get(6)?,
-                r.get(7)?,
             ))
         })
         .map_err(|e| e.to_string())?;
@@ -179,6 +234,7 @@ pub(crate) fn list_team_members_raw(conn: &Connection) -> Result<Vec<TeamMember>
     for row in rows {
         out.push(row.map_err(|e| e.to_string())?);
     }
+    attach_aliases(conn, &mut out)?;
     Ok(out)
 }
 
@@ -215,8 +271,14 @@ impl OwnerResolver {
         for m in members {
             let mut keys: Vec<String> = Vec::with_capacity(1 + m.aliases.len());
             keys.push(fold_for_match(&m.display_name));
+            // Only `name`-kind aliases participate in name resolution
+            // (#87). Email / GitHub / Slack handles aren't names, even
+            // when their string shape happens to look like one.
             for a in &m.aliases {
-                let k = fold_for_match(a);
+                if a.kind != kinds::NAME {
+                    continue;
+                }
+                let k = fold_for_match(&a.value);
                 if !k.is_empty() {
                     keys.push(k);
                 }
@@ -259,7 +321,7 @@ pub fn get_team_member(
 pub fn create_team_member(
     display_name: String,
     role: String,
-    aliases: Vec<String>,
+    aliases: Vec<TypedAlias>,
     conn: tauri::State<'_, std::sync::Mutex<rusqlite::Connection>>,
 ) -> Result<TeamMember, String> {
     let trimmed = display_name.trim();
@@ -270,25 +332,54 @@ pub fn create_team_member(
     let profile_md_path = profile_path_for(&id);
     write_stub_profile(&profile_md_path, trimmed)?;
     let now = now_ms();
-    let aliases_json = aliases_to_json(&aliases);
     {
-        let c = conn.lock().map_err(|e| e.to_string())?;
-        c.execute(
-            "INSERT INTO team_members(id, display_name, role, aliases, profile_md_path, \
-             is_self, created_ms, updated_ms) VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6, ?6)",
+        let mut c = conn.lock().map_err(|e| e.to_string())?;
+        let tx = c.transaction().map_err(|e| e.to_string())?;
+        tx.execute(
+            "INSERT INTO team_members(id, display_name, role, profile_md_path, \
+             is_self, created_ms, updated_ms) VALUES (?1, ?2, ?3, ?4, 0, ?5, ?5)",
             params![
                 id,
                 trimmed,
                 role,
-                aliases_json,
                 profile_md_path.to_string_lossy().to_string(),
                 now,
             ],
         )
         .map_err(|e| e.to_string())?;
+        write_aliases(&tx, &id, &aliases).map_err(|e| e.to_string())?;
+        tx.commit().map_err(|e| e.to_string())?;
     }
     let c = conn.lock().map_err(|e| e.to_string())?;
     fetch_one(&c, &id)
+}
+
+/// Replace all alias rows for `member_id` with `aliases`. Caller is
+/// responsible for the transaction. Empty values are filtered; the PK
+/// `(member_id, kind, value)` enforces dedup at the SQL layer so even
+/// a sloppy caller can't double-insert.
+fn write_aliases(
+    tx: &rusqlite::Transaction<'_>,
+    member_id: &str,
+    aliases: &[TypedAlias],
+) -> rusqlite::Result<()> {
+    tx.execute(
+        "DELETE FROM team_member_aliases WHERE member_id = ?1",
+        params![member_id],
+    )?;
+    let mut stmt = tx.prepare(
+        "INSERT OR IGNORE INTO team_member_aliases(member_id, kind, value) \
+         VALUES (?1, ?2, ?3)",
+    )?;
+    for a in aliases {
+        let kind = a.kind.trim();
+        let value = a.value.trim();
+        if kind.is_empty() || value.is_empty() {
+            continue;
+        }
+        stmt.execute(params![member_id, kind, value])?;
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -296,7 +387,7 @@ pub fn update_team_member(
     id: String,
     display_name: Option<String>,
     role: Option<String>,
-    aliases: Option<Vec<String>>,
+    aliases: Option<Vec<TypedAlias>>,
     conn: tauri::State<'_, std::sync::Mutex<rusqlite::Connection>>,
 ) -> Result<TeamMember, String> {
     if display_name.is_none() && role.is_none() && aliases.is_none() {
@@ -305,32 +396,37 @@ pub fn update_team_member(
     }
     let now = now_ms();
     {
-        let c = conn.lock().map_err(|e| e.to_string())?;
+        let mut c = conn.lock().map_err(|e| e.to_string())?;
+        let tx = c.transaction().map_err(|e| e.to_string())?;
         if let Some(name) = display_name.as_deref() {
             let trimmed = name.trim();
             if trimmed.is_empty() {
                 return Err("display_name cannot be empty".to_string());
             }
-            c.execute(
+            tx.execute(
                 "UPDATE team_members SET display_name = ?1, updated_ms = ?2 WHERE id = ?3",
                 params![trimmed, now, id],
             )
             .map_err(|e| e.to_string())?;
         }
         if let Some(role) = role.as_deref() {
-            c.execute(
+            tx.execute(
                 "UPDATE team_members SET role = ?1, updated_ms = ?2 WHERE id = ?3",
                 params![role, now, id],
             )
             .map_err(|e| e.to_string())?;
         }
         if let Some(aliases) = aliases.as_deref() {
-            c.execute(
-                "UPDATE team_members SET aliases = ?1, updated_ms = ?2 WHERE id = ?3",
-                params![aliases_to_json(aliases), now, id],
+            write_aliases(&tx, &id, aliases).map_err(|e| e.to_string())?;
+            // Stamp `updated_ms` so the workstreams list / detail caches
+            // re-render even when only aliases changed.
+            tx.execute(
+                "UPDATE team_members SET updated_ms = ?1 WHERE id = ?2",
+                params![now, id],
             )
             .map_err(|e| e.to_string())?;
         }
+        tx.commit().map_err(|e| e.to_string())?;
     }
     let c = conn.lock().map_err(|e| e.to_string())?;
     fetch_one(&c, &id)
@@ -430,7 +526,6 @@ pub(crate) fn list_meeting_attendees(
                 r.get(4)?,
                 r.get(5)?,
                 r.get(6)?,
-                r.get(7)?,
             ))
         })
         .map_err(|e| e.to_string())?;
@@ -438,6 +533,7 @@ pub(crate) fn list_meeting_attendees(
     for row in rows {
         out.push(row.map_err(|e| e.to_string())?);
     }
+    attach_aliases(conn, &mut out)?;
     Ok(out)
 }
 
@@ -454,34 +550,18 @@ pub fn get_meeting_attendees(
 mod tests {
     use super::*;
 
-    #[test]
-    fn aliases_round_trip_preserves_order() {
-        let v = vec!["TJ".to_string(), "Tom".to_string(), "Tom Ruesch".to_string()];
-        let json = aliases_to_json(&v);
-        let back = aliases_from_json(&json);
-        assert_eq!(back, v);
-    }
-
-    #[test]
-    fn aliases_from_json_empty_or_garbage_returns_empty() {
-        assert!(aliases_from_json("").is_empty());
-        assert!(aliases_from_json("not json").is_empty());
-        assert!(aliases_from_json("{}").is_empty());
-        assert!(aliases_from_json("[]").is_empty());
-    }
-
-    #[test]
-    fn aliases_to_json_empty_is_empty_array() {
-        let v: Vec<String> = Vec::new();
-        assert_eq!(aliases_to_json(&v), "[]");
-    }
-
-    fn make_member(id: &str, name: &str, aliases: &[&str]) -> TeamMember {
+    fn make_member(id: &str, name: &str, aliases: &[(&str, &str)]) -> TeamMember {
         TeamMember {
             id: id.into(),
             display_name: name.into(),
             role: String::new(),
-            aliases: aliases.iter().map(|s| s.to_string()).collect(),
+            aliases: aliases
+                .iter()
+                .map(|(k, v)| TypedAlias {
+                    kind: (*k).to_string(),
+                    value: (*v).to_string(),
+                })
+                .collect(),
             profile_md_path: String::new(),
             is_self: false,
             created_ms: 0,
@@ -499,7 +579,11 @@ mod tests {
 
     #[test]
     fn owner_resolver_matches_display_name_and_aliases() {
-        let members = vec![make_member("tom-id", "Tom Ruesch", &["TJ", "Tom"])];
+        let members = vec![make_member(
+            "tom-id",
+            "Tom Ruesch",
+            &[("name", "TJ"), ("name", "Tom")],
+        )];
         let r = OwnerResolver::from_members(&members);
         assert_eq!(r.resolve("Tom"), Some("tom-id".into()));
         assert_eq!(r.resolve("tom"), Some("tom-id".into()));
@@ -510,8 +594,8 @@ mod tests {
     #[test]
     fn owner_resolver_returns_none_when_ambiguous() {
         let members = vec![
-            make_member("tom-id", "Tom Ruesch", &["TR"]),
-            make_member("tina-id", "Tina Romero", &["TR"]),
+            make_member("tom-id", "Tom Ruesch", &[("name", "TR")]),
+            make_member("tina-id", "Tina Romero", &[("name", "TR")]),
         ];
         let r = OwnerResolver::from_members(&members);
         assert_eq!(r.resolve("TR"), None);
@@ -521,7 +605,7 @@ mod tests {
 
     #[test]
     fn owner_resolver_returns_none_when_unknown() {
-        let members = vec![make_member("tom-id", "Tom Ruesch", &["TJ"])];
+        let members = vec![make_member("tom-id", "Tom Ruesch", &[("name", "TJ")])];
         let r = OwnerResolver::from_members(&members);
         assert_eq!(r.resolve("Sarah"), None);
         assert_eq!(r.resolve(""), None);
@@ -534,5 +618,150 @@ mod tests {
         let r = OwnerResolver::from_members(&members);
         assert_eq!(r.resolve("Jose"), Some("jose-id".into()));
         assert_eq!(r.resolve("JOSÉ"), Some("jose-id".into()));
+    }
+
+    /// Run all migrations 1..=16 against a fresh in-memory DB, stopping
+    /// short of 17 so the test can manually seed pre-#87 data.
+    fn open_db_at_version_16() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        // Apply migrations 1..=16 verbatim. We can't call
+        // `index::apply_migrations` because that would jump to 17. Instead
+        // run each include_str! batch in order.
+        for sql in [
+            include_str!("migrations/001_init.sql"),
+            include_str!("migrations/002_archived.sql"),
+            include_str!("migrations/003_favorite.sql"),
+            include_str!("migrations/004_actions.sql"),
+            include_str!("migrations/005_due_dates.sql"),
+            include_str!("migrations/006_team_members.sql"),
+            include_str!("migrations/007_action_owners.sql"),
+            include_str!("migrations/008_connectors.sql"),
+            include_str!("migrations/009_calendar.sql"),
+            include_str!("migrations/010_event_note_link.sql"),
+            include_str!("migrations/011_email.sql"),
+            include_str!("migrations/012_workstreams.sql"),
+            include_str!("migrations/013_workstream_user_notes.sql"),
+            include_str!("migrations/014_workstream_archive_resurface.sql"),
+            include_str!("migrations/015_workstream_owner.sql"),
+            include_str!("migrations/016_workstream_signals.sql"),
+        ] {
+            conn.execute_batch(sql).unwrap();
+        }
+        conn
+    }
+
+    #[test]
+    fn migration_017_backfills_typed_aliases() {
+        let conn = open_db_at_version_16();
+        // Seed the legacy JSON-aliases shape: one email-shaped, one name.
+        conn.execute(
+            "INSERT INTO team_members(id, display_name, role, aliases, profile_md_path, \
+             is_self, created_ms, updated_ms) \
+             VALUES ('m1', 'Heike Müller', '', \
+                     '[\"heike@example.com\",\"Heike\"]', '', 0, 0, 0)",
+            [],
+        )
+        .unwrap();
+
+        // Apply migration 17.
+        conn.execute_batch(include_str!("migrations/017_typed_aliases.sql"))
+            .unwrap();
+
+        // Pivot rows split by `@` sniff.
+        let rows: Vec<(String, String, String)> = conn
+            .prepare(
+                "SELECT member_id, kind, value FROM team_member_aliases \
+                 WHERE member_id = 'm1' ORDER BY kind, value",
+            )
+            .unwrap()
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(
+            rows,
+            vec![
+                ("m1".into(), "email".into(), "heike@example.com".into()),
+                ("m1".into(), "name".into(), "Heike".into()),
+            ]
+        );
+
+        // The legacy column is gone.
+        let columns: Vec<String> = conn
+            .prepare("PRAGMA table_info(team_members)")
+            .unwrap()
+            .query_map([], |r| r.get::<_, String>(1))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert!(
+            !columns.iter().any(|c| c == "aliases"),
+            "team_members.aliases should be dropped, found columns: {:?}",
+            columns
+        );
+
+        // schema_version stamped.
+        let v: i64 = conn
+            .query_row(
+                "SELECT CAST(value AS INTEGER) FROM meta WHERE key = 'schema_version'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(v, 17);
+    }
+
+    #[test]
+    fn migration_017_filters_empty_aliases() {
+        let conn = open_db_at_version_16();
+        conn.execute(
+            "INSERT INTO team_members(id, display_name, role, aliases, profile_md_path, \
+             is_self, created_ms, updated_ms) \
+             VALUES ('m1', 'Heike', '', '[\"\",\"heike@example.com\",\"\"]', '', 0, 0, 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute_batch(include_str!("migrations/017_typed_aliases.sql"))
+            .unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM team_member_aliases WHERE member_id = 'm1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "empty strings filtered");
+    }
+
+    #[test]
+    fn owner_resolver_ignores_non_name_aliases() {
+        // An email-kind alias's local part used to fold into the
+        // name-match dictionary because all aliases were untyped (#87).
+        // Now name resolution only considers `kind == "name"` aliases —
+        // display_name still always counts.
+        let members = vec![make_member(
+            "heike-id",
+            "Heike Müller",
+            &[
+                ("email", "heike@example.com"),
+                ("github_login", "heike-mueller"),
+            ],
+        )];
+        let r = OwnerResolver::from_members(&members);
+        assert_eq!(
+            r.resolve("Heike Müller"),
+            Some("heike-id".into()),
+            "display_name still resolves"
+        );
+        assert_eq!(
+            r.resolve("heike"),
+            None,
+            "email local part no longer resolves through aliases"
+        );
+        assert_eq!(
+            r.resolve("heike-mueller"),
+            None,
+            "github_login does not resolve as a name"
+        );
     }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -3313,6 +3313,161 @@ input.nh-title {
   color: var(--fg-muted);
 }
 
+/* ----- Identities trigger + modal (#87) ----- */
+
+.team-detail-aliases-trigger {
+  align-self: flex-start;
+  font: inherit;
+  font-size: 12px;
+  color: var(--fg-muted);
+  background: transparent;
+  border: 1px dashed var(--border, rgba(0, 0, 0, 0.15));
+  border-radius: 6px;
+  padding: 4px 10px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.team-detail-aliases-trigger:hover {
+  background: var(--bg-soft, rgba(0, 0, 0, 0.04));
+  color: var(--fg);
+  border-color: var(--border-strong, rgba(0, 0, 0, 0.25));
+}
+
+.identities-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.identities-modal {
+  background: var(--bg, #fff);
+  color: var(--fg);
+  width: min(520px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.identities-modal-header {
+  padding: 16px 20px 8px;
+  border-bottom: 1px solid var(--border, rgba(0, 0, 0, 0.08));
+}
+.identities-modal-header h2 {
+  margin: 0 0 4px;
+  font-size: 15px;
+  font-weight: 600;
+}
+.identities-modal-help {
+  margin: 0;
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+.identities-modal-rows {
+  padding: 12px 20px 4px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.identities-modal-empty {
+  font-size: 12px;
+  color: var(--fg-muted);
+  text-align: center;
+  padding: 16px 0;
+}
+.identities-modal-row {
+  display: grid;
+  grid-template-columns: 130px 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+.identities-modal-kind,
+.identities-modal-value {
+  font: inherit;
+  font-size: 13px;
+  padding: 6px 8px;
+  border: 1px solid var(--border, rgba(0, 0, 0, 0.15));
+  border-radius: 6px;
+  background: var(--bg, #fff);
+  color: var(--fg);
+}
+.identities-modal-value:focus,
+.identities-modal-kind:focus {
+  outline: none;
+  border-color: var(--accent, #4a90e2);
+}
+.identities-modal-remove {
+  background: transparent;
+  border: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+}
+.identities-modal-remove:hover {
+  color: var(--danger, #b00020);
+  background: var(--bg-soft, rgba(0, 0, 0, 0.04));
+}
+.identities-modal-add-row {
+  padding: 4px 20px 12px;
+}
+.identities-modal-add {
+  font: inherit;
+  font-size: 12px;
+  background: transparent;
+  border: 1px dashed var(--border, rgba(0, 0, 0, 0.2));
+  border-radius: 6px;
+  padding: 6px 10px;
+  cursor: pointer;
+  color: var(--fg-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.identities-modal-add:hover {
+  background: var(--bg-soft, rgba(0, 0, 0, 0.04));
+  color: var(--fg);
+}
+.identities-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 20px 16px;
+  border-top: 1px solid var(--border, rgba(0, 0, 0, 0.08));
+}
+.identities-modal-cancel,
+.identities-modal-save {
+  font: inherit;
+  font-size: 13px;
+  padding: 6px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid var(--border, rgba(0, 0, 0, 0.15));
+  background: var(--bg, #fff);
+  color: var(--fg);
+}
+.identities-modal-cancel:hover {
+  background: var(--bg-soft, rgba(0, 0, 0, 0.04));
+}
+.identities-modal-save {
+  background: var(--accent, #4a90e2);
+  border-color: var(--accent, #4a90e2);
+  color: #fff;
+}
+.identities-modal-save:hover {
+  filter: brightness(0.95);
+}
+.identities-modal-save:disabled,
+.identities-modal-cancel:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .team-detail-editor {
   flex: 1;
   min-height: 0;

--- a/src/Team.tsx
+++ b/src/Team.tsx
@@ -6,8 +6,10 @@ import { Editor } from "./Editor";
 import { ActionRow, BUCKET_ORDER } from "./Home";
 import { IconChevLeft, IconPlus, IconTrash } from "./icons";
 import {
+  AliasKind,
   type ActionListItem,
   type TeamMember,
+  type TypedAlias,
   createTeamMember,
   deleteTeamMember,
   listActions,
@@ -399,19 +401,11 @@ function TeamDetail({
     }
   };
 
-  const commitAliases = async (next: string) => {
-    const parsed = next
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
-    if (
-      parsed.length === member.aliases.length &&
-      parsed.every((v, i) => v === member.aliases[i])
-    ) {
-      return;
-    }
+  const [showIdentitiesModal, setShowIdentitiesModal] = useState(false);
+
+  const saveIdentities = async (next: TypedAlias[]) => {
     try {
-      const updated = await updateTeamMember(member.id, { aliases: parsed });
+      const updated = await updateTeamMember(member.id, { aliases: next });
       onUpdated(updated);
     } catch (err) {
       console.error("updateTeamMember (aliases) failed:", err);
@@ -479,14 +473,25 @@ function TeamDetail({
             onCommit={(v) => void commitRole(v)}
             className="team-detail-role"
           />
-          <EditableField
-            value={member.aliases.join(", ")}
-            placeholder="Aliases, comma-separated (e.g. SR, Sara)"
-            onCommit={(v) => void commitAliases(v)}
-            className="team-detail-aliases"
-          />
+          <button
+            type="button"
+            className="team-detail-aliases-trigger"
+            onClick={() => setShowIdentitiesModal(true)}
+          >
+            {identitiesSummary(member.aliases)}
+          </button>
         </div>
       </header>
+      {showIdentitiesModal && (
+        <IdentitiesModal
+          aliases={member.aliases}
+          onClose={() => setShowIdentitiesModal(false)}
+          onSave={async (next) => {
+            await saveIdentities(next);
+            setShowIdentitiesModal(false);
+          }}
+        />
+      )}
       <div className="team-detail-tabs">
         <div className="nh-segmented" role="tablist" aria-label="Section">
           <button
@@ -843,4 +848,189 @@ function TasksTab({
       )}
     </div>
   );
+}
+
+// ---------- Identities modal --------------------------------------------
+
+const ALIAS_KIND_LABELS: Array<{ value: string; label: string }> = [
+  { value: AliasKind.Email, label: "Email" },
+  { value: AliasKind.Name, label: "Name" },
+  { value: AliasKind.GithubLogin, label: "GitHub login" },
+  { value: AliasKind.SlackId, label: "Slack ID" },
+];
+
+function identitiesSummary(aliases: TypedAlias[]): string {
+  if (aliases.length === 0) return "Manage identities…";
+  if (aliases.length === 1) return `1 identity · manage…`;
+  return `${aliases.length} identities · manage…`;
+}
+
+type Draft = { kind: string; value: string };
+
+function IdentitiesModal({
+  aliases,
+  onClose,
+  onSave,
+}: {
+  aliases: TypedAlias[];
+  onClose: () => void;
+  onSave: (next: TypedAlias[]) => Promise<void> | void;
+}) {
+  const [drafts, setDrafts] = useState<Draft[]>(() =>
+    aliases.map((a) => ({ kind: a.kind, value: a.value })),
+  );
+  const [saving, setSaving] = useState(false);
+
+  // Esc closes; backdrop click closes. Save / Add affordances are
+  // explicit buttons inside the modal.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const updateRow = (i: number, patch: Partial<Draft>) => {
+    setDrafts((prev) =>
+      prev.map((d, idx) => (idx === i ? { ...d, ...patch } : d)),
+    );
+  };
+
+  const removeRow = (i: number) => {
+    setDrafts((prev) => prev.filter((_, idx) => idx !== i));
+  };
+
+  const addRow = () => {
+    setDrafts((prev) => [...prev, { kind: AliasKind.Email, value: "" }]);
+  };
+
+  const handleSave = async () => {
+    // Filter empty values, dedupe (kind, value) pairs client-side. The
+    // backend's PRIMARY KEY also enforces this, but trimming here keeps
+    // the optimistic state aligned with what the server will store.
+    const cleaned: TypedAlias[] = [];
+    const seen = new Set<string>();
+    for (const d of drafts) {
+      const kind = d.kind.trim();
+      const value = d.value.trim();
+      if (!kind || !value) continue;
+      const key = `${kind}\x00${value}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      cleaned.push({ kind, value });
+    }
+    setSaving(true);
+    try {
+      await onSave(cleaned);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="identities-modal-backdrop"
+      role="presentation"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="identities-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Manage identities"
+      >
+        <header className="identities-modal-header">
+          <h2>Manage identities</h2>
+          <p className="identities-modal-help">
+            Each identity is tagged with a kind so connectors (email, GitHub,
+            Slack…) can resolve people back to this team member.
+          </p>
+        </header>
+        <div className="identities-modal-rows">
+          {drafts.length === 0 && (
+            <div className="identities-modal-empty">
+              No identities yet — add an email or connector handle below.
+            </div>
+          )}
+          {drafts.map((d, i) => (
+            <div className="identities-modal-row" key={i}>
+              <select
+                className="identities-modal-kind"
+                value={d.kind}
+                onChange={(e) => updateRow(i, { kind: e.target.value })}
+              >
+                {ALIAS_KIND_LABELS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+              <input
+                className="identities-modal-value"
+                type="text"
+                placeholder={placeholderFor(d.kind)}
+                value={d.value}
+                onChange={(e) => updateRow(i, { value: e.target.value })}
+                autoFocus={i === drafts.length - 1 && d.value === ""}
+              />
+              <button
+                type="button"
+                className="identities-modal-remove"
+                onClick={() => removeRow(i)}
+                aria-label="Remove identity"
+              >
+                <IconTrash size={13} sw={1.8} />
+              </button>
+            </div>
+          ))}
+        </div>
+        <div className="identities-modal-add-row">
+          <button
+            type="button"
+            className="identities-modal-add"
+            onClick={addRow}
+          >
+            <IconPlus size={13} sw={1.8} />
+            Add identity
+          </button>
+        </div>
+        <footer className="identities-modal-footer">
+          <button
+            type="button"
+            className="identities-modal-cancel"
+            onClick={onClose}
+            disabled={saving}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="identities-modal-save"
+            onClick={() => void handleSave()}
+            disabled={saving}
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function placeholderFor(kind: string): string {
+  switch (kind) {
+    case AliasKind.Email:
+      return "name@example.com";
+    case AliasKind.Name:
+      return "First Last (or nickname)";
+    case AliasKind.GithubLogin:
+      return "github-handle";
+    case AliasKind.SlackId:
+      return "U0ABCDE12";
+    default:
+      return "value";
+  }
 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -644,11 +644,29 @@ export async function deleteNote(notePath: string): Promise<void> {
 
 // --- Team members --------------------------------------------------------
 
+/**
+ * One typed identity attached to a team_member. `kind` is a soft enum;
+ * canonical values are exported as constants on `AliasKind` below.
+ * Adding a new kind is non-breaking: backend and frontend just need to
+ * agree on the string.
+ */
+export type TypedAlias = {
+  kind: string;
+  value: string;
+};
+
+export const AliasKind = {
+  Email: "email",
+  Name: "name",
+  GithubLogin: "github_login",
+  SlackId: "slack_id",
+} as const;
+
 export type TeamMember = {
   id: string;
   display_name: string;
   role: string;
-  aliases: string[];
+  aliases: TypedAlias[];
   profile_md_path: string;
   is_self: boolean;
   created_ms: number;
@@ -666,14 +684,14 @@ export async function getTeamMember(id: string): Promise<TeamMember> {
 export async function createTeamMember(
   displayName: string,
   role: string,
-  aliases: string[],
+  aliases: TypedAlias[],
 ): Promise<TeamMember> {
   return invoke<TeamMember>("create_team_member", { displayName, role, aliases });
 }
 
 export async function updateTeamMember(
   id: string,
-  fields: { displayName?: string; role?: string; aliases?: string[] },
+  fields: { displayName?: string; role?: string; aliases?: TypedAlias[] },
 ): Promise<TeamMember> {
   return invoke<TeamMember>("update_team_member", { id, ...fields });
 }


### PR DESCRIPTION
## Summary

Replaces `team_members.aliases` (a flat JSON `Vec<String>`) with a typed `team_member_aliases(member_id, kind, value)` pivot table so each alias carries an explicit kind (`email` / `name` / `github_login` / `slack_id` / …). Email connectors resolve identically to today; an upcoming GitHub source can pass a github_login and get the right team_member back without collision.

Closes #87. Pairs with the just-shipped #86 (signal-source registry): together they make adding a non-email signal source a one-file backend change.

### Design choices

- **New table, drop the JSON column.** Single source of truth post-migration. Migration 017 backfills by sniffing `@` (→ `email`) vs everything else (→ `name`).
- **`Vec<TypedAlias>` end-to-end** (Rust struct + serde + TS type) so the UI dropdown ↔ DB pivot stays consistent.
- **Per-kind dispatch on `AttendeeResolver`** with a `resolve_attendee` shim that preserves the existing email-then-name call shape. Connectors only changed at six call sites.
- **String-typed `kind`** (soft enum) — adding a new alias kind requires zero schema work.
- **OwnerResolver filtered to `kind == "name"` aliases.** This is a behavior change worth flagging: a member whose only alias is an email no longer name-matches via the local part of that email. `display_name` continues to resolve, covering the action-owner pipeline.

### UI

A "Manage identities" modal replaces the comma-separated alias text field on the team detail view. Per-row kind dropdown + value input + delete; "Add identity" appends. Esc / backdrop click cancel; Save commits through the existing `update_team_member`.

## Files

| Path | Change |
|------|--------|
| `src-tauri/src/migrations/017_typed_aliases.sql` | NEW — pivot table + backfill + DROP COLUMN |
| `src-tauri/src/index.rs` | Wire SCHEMA_V17 into the migration runner |
| `src-tauri/src/team.rs` | `TypedAlias`, `kinds` mod, rewritten reads/writes via `attach_aliases` + `write_aliases` transaction; `OwnerResolver` filters to `kind=name` |
| `src-tauri/src/connectors/microsoft_graph.rs` | `AttendeeResolver` rebuilt with per-kind maps; new resolver methods; 3 call sites + tests updated |
| `src-tauri/src/connectors/google.rs` | 3 call sites + test helper updated |
| `src-tauri/src/reconcile.rs` | Test helper signature; profile alias rendering walks `.value` |
| `src-tauri/src/ask.rs` | Walk typed alias values in the prompt rendering |
| `src/file.ts` | `TypedAlias` type, `AliasKind` constants, command shapes |
| `src/Team.tsx` | "Manage identities" button + new `IdentitiesModal` component |
| `src/App.css` | Modal + trigger button styles |

## Test plan

- [x] `cargo test --lib` — 231 passed, 0 failed (was 228; +5 new -2 dropped JSON-helper tests)
- [x] `bun run build` — TypeScript + Vite build clean
- [x] **New:** `attendee_resolver_resolves_by_github_login` — `heike-mueller` registered as `("github_login", "heike-mueller")` resolves correctly; case-insensitive; does not leak into the email map.
- [x] **New:** `attendee_resolver_resolves_by_slack_id` — case-significant lookup.
- [x] **New:** `attendee_resolver_kinds_are_isolated` — a `name`-kind alias whose value matches an email local part does not leak into `resolve_by_email`.
- [x] **New:** `owner_resolver_ignores_non_name_aliases` — emails / github_logins do not name-resolve through aliases; `display_name` still does.
- [x] **New:** `migration_017_backfills_typed_aliases` — fresh DB, run migrations 1→16, seed legacy JSON aliases, run 17, assert pivot rows are split by `@` sniff and the `aliases` column is dropped.
- [x] **New:** `migration_017_filters_empty_aliases` — empty strings in the legacy JSON array don't produce empty pivot rows.
- [x] All existing email/calendar connector tests continue to pass with the same fixtures (only the test-helper signature was rewritten; behavior is preserved).
- [ ] Manual: `bun tauri dev`, navigate to a team member, click "Manage identities", add a GitHub login row, save, reload, confirm the alias persists.

## Behavior change to flag

The action-owner / `OwnerResolver` pipeline used to fold every alias (regardless of kind) into the name-match dictionary, which incidentally let a member with `aliases = ["heike@example.com"]` resolve when an action mentioned "heike". After this PR, only `kind == "name"` aliases participate in name resolution. `display_name` is still always folded, so the common case (members with their actual name set as `display_name`) is unaffected. If anyone relied on email-local-part name resolution, they should add an explicit `name`-kind alias.