### PR TITLE
List-view Add buttons in section headers + identities modal polish

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1531,6 +1531,25 @@ select.settings-input {
 .home-section-action:hover {
   color: var(--accent);
 }
+.home-section-add {
+  background: transparent;
+  border: 1px solid var(--home-line);
+  cursor: pointer;
+  color: var(--fg-muted);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.home-section-add:hover {
+  background: var(--bg-soft, rgba(0, 0, 0, 0.04));
+  color: var(--fg);
+}
 
 /* ----- Upcoming meetings ----- */
 
@@ -3388,13 +3407,29 @@ input.nh-title {
 }
 .identities-modal-kind,
 .identities-modal-value {
+  box-sizing: border-box;
+  height: 30px;
   font: inherit;
   font-size: 13px;
-  padding: 6px 8px;
+  line-height: 1;
+  padding: 0 10px;
   border: 1px solid var(--border, rgba(0, 0, 0, 0.15));
   border-radius: 6px;
   background: var(--bg, #fff);
   color: var(--fg);
+}
+/* macOS renders native selects with a chrome chevron + intrinsic
+   height that doesn't honor `height` exactly. Strip the platform
+   chrome and supply our own chevron so it matches the input pixel-
+   for-pixel. */
+.identities-modal-kind {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 26px;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path d='M3 4.5l3 3 3-3' fill='none' stroke='%23808080' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  background-size: 10px 10px;
 }
 .identities-modal-value:focus,
 .identities-modal-kind:focus {

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1037,12 +1037,13 @@ export function ActionRow({
 
 // ---- Inbox composer -----------------------------------------------------
 
-function InboxComposer({
+function InboxComposerForm({
   onAdd,
+  onClose,
 }: {
   onAdd: (text: string, dueToken: string | null) => Promise<void>;
+  onClose: () => void;
 }) {
-  const [open, setOpen] = useState(false);
   const [text, setText] = useState("");
   const [dateStr, setDateStr] = useState("");
   const [includeTime, setIncludeTime] = useState(false);
@@ -1051,8 +1052,8 @@ function InboxComposer({
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
-    if (open) inputRef.current?.focus();
-  }, [open]);
+    inputRef.current?.focus();
+  }, []);
 
   const reset = () => {
     setText("");
@@ -1078,19 +1079,6 @@ function InboxComposer({
     }
   };
 
-  if (!open) {
-    return (
-      <button
-        type="button"
-        className="inbox-composer-toggle"
-        onClick={() => setOpen(true)}
-      >
-        <IconPlus size={12} sw={1.8} />
-        New todo
-      </button>
-    );
-  }
-
   return (
     <div className="inbox-composer">
       <input
@@ -1105,8 +1093,8 @@ function InboxComposer({
             e.preventDefault();
             void submit();
           } else if (e.key === "Escape") {
-            setOpen(false);
             reset();
+            onClose();
           }
         }}
       />
@@ -1140,8 +1128,8 @@ function InboxComposer({
           type="button"
           className="inbox-composer-cancel"
           onClick={() => {
-            setOpen(false);
             reset();
+            onClose();
           }}
         >
           Cancel
@@ -1174,6 +1162,7 @@ function ActionsFeed({
   members: TeamMember[];
   onReassign: (actionId: string, memberId: string | null) => void;
 }) {
+  const [composerOpen, setComposerOpen] = useState(false);
   // Split dated vs. undated, then bucket the dated half by urgency.
   // Backend already orders dated rows by `due_ms ASC`, so each bucket is
   // chronological without further sorting. Undated rows fall into one
@@ -1197,16 +1186,39 @@ function ActionsFeed({
     return { byBucket: buckets, undated: undatedRows };
   }, [actions]);
 
+  // Header used by both the empty and populated states. Toggle button on
+  // the right collapses out of view when the composer is expanded so the
+  // form below isn't competing with a redundant trigger.
+  const head = (
+    <div className="home-section-head">
+      <div>
+        <div className="home-section-eyebrow">Action items</div>
+        <h2 className="home-section-title">Things to do</h2>
+      </div>
+      {!composerOpen && (
+        <button
+          type="button"
+          className="home-section-add"
+          onClick={() => setComposerOpen(true)}
+        >
+          <IconPlus size={12} sw={1.8} />
+          New todo
+        </button>
+      )}
+    </div>
+  );
+  const composer = composerOpen ? (
+    <InboxComposerForm
+      onAdd={onAddInboxTodo}
+      onClose={() => setComposerOpen(false)}
+    />
+  ) : null;
+
   if (actions.length === 0) {
     return (
       <section className="home-section">
-        <div className="home-section-head">
-          <div>
-            <div className="home-section-eyebrow">Action items</div>
-            <h2 className="home-section-title">Things to do</h2>
-          </div>
-        </div>
-        <InboxComposer onAdd={onAddInboxTodo} />
+        {head}
+        {composer}
         <p className="home-empty">
           No open action items. Add <code>- [ ] task</code> lines to any note,
           trail with <code>@2026-01-15</code> / <code>@tomorrow</code> /{" "}
@@ -1218,14 +1230,9 @@ function ActionsFeed({
 
   return (
     <section className="home-section">
-      <div className="home-section-head">
-        <div>
-          <div className="home-section-eyebrow">Action items</div>
-          <h2 className="home-section-title">Things to do</h2>
-        </div>
-      </div>
+      {head}
 
-      <InboxComposer onAdd={onAddInboxTodo} />
+      {composer}
 
       {BUCKET_ORDER.map(({ key, label }) => {
         const items = byBucket[key];

--- a/src/Team.tsx
+++ b/src/Team.tsx
@@ -135,6 +135,7 @@ function ListPane({
   onSelect: (id: string) => void;
   onCreated: (member: TeamMember) => void;
 }) {
+  const [composerOpen, setComposerOpen] = useState(false);
   return (
     <section className="home-section">
       <div className="home-section-head">
@@ -142,8 +143,26 @@ function ListPane({
           <div className="home-section-eyebrow">Team</div>
           <h2 className="home-section-title">Your team</h2>
         </div>
+        {!composerOpen && (
+          <button
+            type="button"
+            className="home-section-add"
+            onClick={() => setComposerOpen(true)}
+          >
+            <IconPlus size={12} sw={1.8} />
+            Add team member
+          </button>
+        )}
       </div>
-      <TeamComposer onCreated={onCreated} />
+      {composerOpen && (
+        <TeamComposerForm
+          onClose={() => setComposerOpen(false)}
+          onCreated={(m) => {
+            setComposerOpen(false);
+            onCreated(m);
+          }}
+        />
+      )}
       {members.length === 0 ? (
         <p className="home-empty">
           No team members yet — start with someone you work with regularly so
@@ -205,15 +224,20 @@ function Avatar({ member, size }: { member: TeamMember; size: number }) {
   );
 }
 
-function TeamComposer({ onCreated }: { onCreated: (member: TeamMember) => void }) {
-  const [open, setOpen] = useState(false);
+function TeamComposerForm({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void;
+  onCreated: (member: TeamMember) => void;
+}) {
   const [text, setText] = useState("");
   const [busy, setBusy] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
-    if (open) inputRef.current?.focus();
-  }, [open]);
+    inputRef.current?.focus();
+  }, []);
 
   const submit = async () => {
     const trimmed = text.trim();
@@ -222,7 +246,6 @@ function TeamComposer({ onCreated }: { onCreated: (member: TeamMember) => void }
     try {
       const member = await createTeamMember(trimmed, "", []);
       setText("");
-      setOpen(false);
       onCreated(member);
     } catch (err) {
       console.error("createTeamMember failed:", err);
@@ -230,19 +253,6 @@ function TeamComposer({ onCreated }: { onCreated: (member: TeamMember) => void }
       setBusy(false);
     }
   };
-
-  if (!open) {
-    return (
-      <button
-        type="button"
-        className="inbox-composer-toggle"
-        onClick={() => setOpen(true)}
-      >
-        <IconPlus size={12} sw={1.8} />
-        Add team member
-      </button>
-    );
-  }
 
   return (
     <div className="team-composer">
@@ -258,8 +268,8 @@ function TeamComposer({ onCreated }: { onCreated: (member: TeamMember) => void }
             e.preventDefault();
             void submit();
           } else if (e.key === "Escape") {
-            setOpen(false);
             setText("");
+            onClose();
           }
         }}
       />
@@ -268,8 +278,8 @@ function TeamComposer({ onCreated }: { onCreated: (member: TeamMember) => void }
           type="button"
           className="inbox-composer-cancel"
           onClick={() => {
-            setOpen(false);
             setText("");
+            onClose();
           }}
         >
           Cancel


### PR DESCRIPTION
## Summary

Two small UI polish items rolled into one PR:

1. **List-view "Add" buttons aligned to the right of the section header.** "Add team member" (Team list) and "New todo" (Things to do) used to sit on their own row below the section header. They now live in `home-section-head`, right-aligned next to the section title — matching the existing pattern used by "View all" on the Things-to-do teaser. The expanded composer form continues to drop below the divider.

2. **Identities modal: kind `<select>` + value `<input>` were rendering at different heights on macOS** (the platform-native select had its own intrinsic chrome height while the input picked up extra internal padding). Both now use `box-sizing: border-box` with an explicit 30px height, and the select's platform chrome is replaced with a custom SVG chevron so the two elements line up pixel-for-pixel.

### Implementation note

Both `TeamComposer` and `InboxComposer` previously owned their own `open` / collapsed-vs-expanded state. To put the toggle in the header while keeping the form below it, I lifted that state into the section parents (`TeamSection`, `ActionsFeed`) and renamed the form-only halves to `TeamComposerForm` / `InboxComposerForm`. The header renders the toggle when collapsed; the form renders below the head when expanded; both share the same close handler.

## Test plan

- [x] `bun run build` — TS + Vite build clean
- [ ] Manual: in `bun tauri dev`, navigate to the Team list — "+ Add team member" appears in the right of the "TEAM / Your team" header line, click expands a form below the divider, Cancel collapses, Save adds and collapses
- [ ] Manual: navigate to Things to do — "+ New todo" appears in the right of the "ACTION ITEMS / Things to do" header line, same expansion behavior
- [ ] Manual: open Manage identities on a team member — kind dropdown and value input render at the same height with consistent borders/padding