### PR TITLE
Linked external URLs on workstreams (#88)

### DIFF
--- a/src-tauri/src/ask.rs
+++ b/src-tauri/src/ask.rs
@@ -1206,6 +1206,26 @@ fn format_workstream_detail(
         s.push('\n');
     }
 
+    // User-curated external links (#88). Markdown link syntax so Claude
+    // can cite them naturally ("the repo for X is at github.com/…").
+    // The optional kind tag is a hint, not a constraint, so it goes in
+    // parens after the link.
+    if !detail.links.is_empty() {
+        s.push_str("\n## Links\n\n");
+        for link in &detail.links {
+            let label = link.label.trim();
+            let url = link.url.trim();
+            match link.kind.as_deref().map(str::trim).filter(|k| !k.is_empty()) {
+                Some(kind) => {
+                    s.push_str(&format!("- [{label}]({url}) ({kind})\n"));
+                }
+                None => {
+                    s.push_str(&format!("- [{label}]({url})\n"));
+                }
+            }
+        }
+    }
+
     // Actions: open first, then recently done.
     if !detail.actions.is_empty() {
         let open: Vec<&crate::workstreams::WorkstreamAction> =
@@ -1769,6 +1789,7 @@ mod tests {
             event_count: 0,
             note_count: 0,
             open_action_count: 0,
+            link_count: 0,
         }
     }
 
@@ -1860,6 +1881,7 @@ mod tests {
                 event_count: 0,
                 note_count: 1,
                 open_action_count: 1,
+                link_count: 0,
             },
             emails: vec![
                 make_email("m1", "Re: invoice", 1000),
@@ -1872,6 +1894,7 @@ mod tests {
                 modified_ms: 800,
             }],
             actions: vec![make_action("Reply to invoice", false), make_action("Send quote", true)],
+            links: Vec::new(),
         };
         let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let out = format_workstream_detail("W1", &detail, &team_map);
@@ -1914,11 +1937,13 @@ mod tests {
                 event_count: 0,
                 note_count: 0,
                 open_action_count: 0,
+            link_count: 0,
             },
             emails,
             events: vec![],
             notes: vec![],
             actions: vec![],
+            links: Vec::new(),
         };
         let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let out = format_workstream_detail("W2", &detail, &team_map);
@@ -1969,11 +1994,13 @@ mod tests {
                 event_count: 0,
                 note_count: 0,
                 open_action_count: 0,
+            link_count: 0,
             },
             emails: vec![],
             events: vec![],
             notes: vec![],
             actions: vec![],
+            links: Vec::new(),
         };
         let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let out = format_workstream_detail("W1", &detail, &team_map);
@@ -2005,14 +2032,114 @@ mod tests {
                 event_count: 0,
                 note_count: 0,
                 open_action_count: 0,
+            link_count: 0,
             },
             emails: vec![],
             events: vec![],
             notes: vec![],
             actions: vec![],
+            links: Vec::new(),
         };
         let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let out = format_workstream_detail("W3", &detail, &team_map);
         assert_eq!(out, "# [W3] Bare\n");
+    }
+
+    #[test]
+    fn format_workstream_detail_renders_links_between_user_notes_and_actions() {
+        let detail = WorkstreamDetail {
+            workstream: Workstream {
+                id: "ws_links".into(),
+                title: "Hyundai POC".into(),
+                summary: "".into(),
+                status: "active".into(),
+                last_activity_ms: 0,
+                created_ms: 0,
+                updated_ms: 0,
+                user_notes: Some("Stay aligned with finance.".into()),
+                archived_at_ms: None,
+                reopened_at_ms: None,
+                owner_member_id: None,
+                members: Vec::new(),
+                email_count: 0,
+                event_count: 0,
+                note_count: 0,
+                open_action_count: 1,
+                link_count: 2,
+            },
+            emails: vec![],
+            events: vec![],
+            notes: vec![],
+            actions: vec![make_action("Reply to invoice", false)],
+            links: vec![
+                crate::workstreams::WorkstreamLink {
+                    id: "wsl_1".into(),
+                    workstream_id: "ws_links".into(),
+                    label: "Repo".into(),
+                    url: "https://github.com/x/y".into(),
+                    kind: Some("github".into()),
+                    position: 0,
+                    created_ms: 0,
+                },
+                crate::workstreams::WorkstreamLink {
+                    id: "wsl_2".into(),
+                    workstream_id: "ws_links".into(),
+                    label: "Design doc".into(),
+                    url: "https://www.notion.so/d".into(),
+                    kind: None,
+                    position: 1,
+                    created_ms: 0,
+                },
+            ],
+        };
+        let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let out = format_workstream_detail("W4", &detail, &team_map);
+
+        assert!(out.contains("## Links"));
+        assert!(out.contains("- [Repo](https://github.com/x/y) (github)"));
+        assert!(
+            out.contains("- [Design doc](https://www.notion.so/d)\n"),
+            "no kind suffix when kind is None"
+        );
+
+        // Section ordering: User notes → Links → Actions.
+        let notes_idx = out.find("User notes (ground truth)").expect("user notes");
+        let links_idx = out.find("## Links").expect("links section");
+        let actions_idx = out.find("Actions (").expect("actions");
+        assert!(notes_idx < links_idx);
+        assert!(links_idx < actions_idx);
+    }
+
+    #[test]
+    fn format_workstream_detail_skips_links_section_when_empty() {
+        let detail = WorkstreamDetail {
+            workstream: Workstream {
+                id: "ws_no_links".into(),
+                title: "Empty".into(),
+                summary: "".into(),
+                status: "active".into(),
+                last_activity_ms: 0,
+                created_ms: 0,
+                updated_ms: 0,
+                user_notes: None,
+                archived_at_ms: None,
+                reopened_at_ms: None,
+                owner_member_id: None,
+                members: Vec::new(),
+                email_count: 0,
+                event_count: 0,
+                note_count: 0,
+                open_action_count: 0,
+                link_count: 0,
+            },
+            emails: vec![],
+            events: vec![],
+            notes: vec![],
+            actions: vec![],
+            links: Vec::new(),
+        };
+        let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let out = format_workstream_detail("W5", &detail, &team_map);
+        assert!(!out.contains("## Links"));
     }
 }

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -48,7 +48,8 @@ const SCHEMA_V14: &str = include_str!("migrations/014_workstream_archive_resurfa
 const SCHEMA_V15: &str = include_str!("migrations/015_workstream_owner.sql");
 const SCHEMA_V16: &str = include_str!("migrations/016_workstream_signals.sql");
 const SCHEMA_V17: &str = include_str!("migrations/017_typed_aliases.sql");
-const SCHEMA_VERSION: i64 = 17;
+const SCHEMA_V18: &str = include_str!("migrations/018_workstream_links.sql");
+const SCHEMA_VERSION: i64 = 18;
 
 /// Open the index DB at `db_path` (creating it if absent) and apply any
 /// pending migrations.
@@ -158,6 +159,10 @@ fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 16 {
         conn.execute_batch(SCHEMA_V17)?;
         version = 17;
+    }
+    if version == 17 {
+        conn.execute_batch(SCHEMA_V18)?;
+        version = 18;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -695,7 +695,10 @@ pub fn run() {
             workstreams::commands::set_workstream_user_notes,
             workstreams::commands::list_archived_workstreams,
             workstreams::commands::mark_workstream_seen,
-            workstreams::commands::set_workstream_owner
+            workstreams::commands::set_workstream_owner,
+            workstreams::commands::list_workstream_links,
+            workstreams::commands::add_workstream_link,
+            workstreams::commands::remove_workstream_link
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/migrations/018_workstream_links.sql
+++ b/src-tauri/src/migrations/018_workstream_links.sql
@@ -1,0 +1,27 @@
+-- User-curated external URLs on workstreams (#88).
+--
+-- Workstreams synthesize from emails / meetings / notes, but the user
+-- often wants to attach the actual external artifact: the GitHub repo,
+-- the Linear project, the Notion design doc. These are user-only — the
+-- synthesizer never touches this table. The detail view renders them
+-- as clickable chips (opened via tauri-plugin-opener) and read_workstream
+-- folds them into the AI ask context.
+--
+-- `position` is reserved for a future drag-handle reorder UI; v1 keeps
+-- insertion order via (position, created_ms). `kind` is a soft enum
+-- ("github" | "linear" | "notion" | "figma" | "other" | NULL) — adding
+-- a new kind is non-breaking, just a new icon mapping client-side.
+
+CREATE TABLE workstream_links (
+  id            TEXT PRIMARY KEY,
+  workstream_id TEXT NOT NULL REFERENCES workstreams(id) ON DELETE CASCADE,
+  label         TEXT NOT NULL,
+  url           TEXT NOT NULL,
+  kind          TEXT,
+  position      INTEGER NOT NULL DEFAULT 0,
+  created_ms    INTEGER NOT NULL
+);
+CREATE INDEX idx_workstream_links_ws
+  ON workstream_links(workstream_id, position, created_ms);
+
+UPDATE meta SET value = '18' WHERE key = 'schema_version';

--- a/src-tauri/src/workstreams/commands.rs
+++ b/src-tauri/src/workstreams/commands.rs
@@ -5,7 +5,7 @@ use std::sync::Mutex;
 use rusqlite::Connection;
 use tauri::AppHandle;
 
-use super::{persist, synthesizer, ClusterReport, Workstream, WorkstreamDetail};
+use super::{persist, synthesizer, ClusterReport, Workstream, WorkstreamDetail, WorkstreamLink};
 
 #[tauri::command]
 pub async fn synthesize_workstreams(
@@ -102,4 +102,40 @@ pub fn set_workstream_owner(
 ) -> Result<(), String> {
     let c = conn.lock().map_err(|e| e.to_string())?;
     persist::set_owner(&c, &id, owner_member_id.as_deref()).map_err(|e| e.to_string())
+}
+
+// ----- User-curated links (#88) ------------------------------------------
+
+#[tauri::command]
+pub fn list_workstream_links(
+    workstream_id: String,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<Vec<WorkstreamLink>, String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    persist::list_workstream_links(&c, &workstream_id).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn add_workstream_link(
+    workstream_id: String,
+    label: String,
+    url: String,
+    kind: Option<String>,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<WorkstreamLink, String> {
+    let now_ms = chrono::Local::now().timestamp_millis();
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    persist::add_workstream_link(&c, &workstream_id, &label, &url, kind.as_deref(), now_ms)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn remove_workstream_link(
+    link_id: String,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<(), String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    persist::remove_workstream_link(&c, &link_id)
+        .map(|_| ())
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/workstreams/mod.rs
+++ b/src-tauri/src/workstreams/mod.rs
@@ -70,6 +70,10 @@ pub struct Workstream {
     pub event_count: u32,
     pub note_count: u32,
     pub open_action_count: u32,
+    /// Count of user-curated external links (#88). Drives the small
+    /// link-icon badge on the list card; the actual links land in
+    /// `WorkstreamDetail.links` on detail-view fetch.
+    pub link_count: u32,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -92,6 +96,34 @@ pub struct NoteRef {
     pub modified_ms: i64,
 }
 
+/// User-curated external URL on a workstream (#88). Pure user
+/// curation — synthesizer never touches this. Rendered as clickable
+/// chips on the detail view and folded into `read_workstream` for AI
+/// ask context.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkstreamLink {
+    pub id: String,
+    pub workstream_id: String,
+    pub label: String,
+    pub url: String,
+    /// Soft enum — `kinds` module below holds the canonical strings.
+    /// `None` is allowed and renders with a generic link glyph.
+    pub kind: Option<String>,
+    pub position: i64,
+    pub created_ms: i64,
+}
+
+/// Canonical string values for `WorkstreamLink.kind`. Soft enum so
+/// adding a new kind is non-breaking — just extend the icon mapping
+/// client-side.
+pub mod link_kinds {
+    pub const GITHUB: &str = "github";
+    pub const LINEAR: &str = "linear";
+    pub const NOTION: &str = "notion";
+    pub const FIGMA: &str = "figma";
+    pub const OTHER: &str = "other";
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct WorkstreamDetail {
     #[serde(flatten)]
@@ -100,6 +132,7 @@ pub struct WorkstreamDetail {
     pub events: Vec<crate::connectors::calendar::CalendarEvent>,
     pub notes: Vec<NoteRef>,
     pub actions: Vec<WorkstreamAction>,
+    pub links: Vec<WorkstreamLink>,
 }
 
 #[derive(Debug, Clone, Serialize, Default)]

--- a/src-tauri/src/workstreams/persist.rs
+++ b/src-tauri/src/workstreams/persist.rs
@@ -9,7 +9,7 @@
 use rusqlite::{params, Connection, OptionalExtension};
 use sha2::{Digest, Sha256};
 
-use super::{NoteRef, WorkstreamDetail, Workstream, WorkstreamAction, WriteCounts};
+use super::{NoteRef, WorkstreamDetail, Workstream, WorkstreamAction, WorkstreamLink, WriteCounts};
 use crate::connectors::calendar;
 use crate::connectors::email;
 
@@ -74,7 +74,8 @@ pub fn list_workstreams_active(conn: &Connection) -> rusqlite::Result<Vec<Workst
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'email'), 0) AS ec, \
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'event'), 0) AS evc, \
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'note'), 0) AS nc, \
-                COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0) AS ac \
+                COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0) AS ac, \
+                COALESCE((SELECT COUNT(*) FROM workstream_links WHERE workstream_id = w.id), 0) AS lc \
          FROM workstreams w \
          WHERE w.status = 'active' \
          ORDER BY w.last_activity_ms DESC",
@@ -97,6 +98,7 @@ pub fn list_workstreams_active(conn: &Connection) -> rusqlite::Result<Vec<Workst
             event_count: r.get::<_, i64>(12)? as u32,
             note_count: r.get::<_, i64>(13)? as u32,
             open_action_count: r.get::<_, i64>(14)? as u32,
+            link_count: r.get::<_, i64>(15)? as u32,
         })
     })?;
     let mut out = Vec::new();
@@ -118,7 +120,8 @@ pub fn list_workstreams_archived(
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'email'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'event'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'note'), 0), \
-                COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0) \
+                COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_links WHERE workstream_id = w.id), 0) \
          FROM workstreams w \
          WHERE w.status = 'archived' \
          ORDER BY w.archived_at_ms DESC NULLS LAST",
@@ -141,6 +144,7 @@ pub fn list_workstreams_archived(
             event_count: r.get::<_, i64>(12)? as u32,
             note_count: r.get::<_, i64>(13)? as u32,
             open_action_count: r.get::<_, i64>(14)? as u32,
+            link_count: r.get::<_, i64>(15)? as u32,
         })
     })?;
     let mut out = Vec::new();
@@ -167,7 +171,8 @@ pub fn list_workstreams_for_synthesis(
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'email'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'event'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'note'), 0), \
-                COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0) \
+                COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_links WHERE workstream_id = w.id), 0) \
          FROM workstreams w \
          WHERE w.status IN ('active', 'archived') \
          ORDER BY \
@@ -195,6 +200,7 @@ pub fn list_workstreams_for_synthesis(
                 event_count: r.get::<_, i64>(12)? as u32,
                 note_count: r.get::<_, i64>(13)? as u32,
                 open_action_count: r.get::<_, i64>(14)? as u32,
+                link_count: r.get::<_, i64>(15)? as u32,
             },
             is_archived,
         ))
@@ -254,6 +260,7 @@ pub fn get_workstream_detail(
     }
 
     let actions = list_actions_for(conn, id)?;
+    let links = list_workstream_links(conn, id)?;
 
     Ok(Some(WorkstreamDetail {
         workstream,
@@ -261,7 +268,98 @@ pub fn get_workstream_detail(
         events,
         notes,
         actions,
+        links,
     }))
+}
+
+// ----- User-curated links (#88) -------------------------------------------
+
+/// All links for a workstream, ordered by `(position, created_ms)` so
+/// insertion order is preserved when `position` is left at the default.
+pub fn list_workstream_links(
+    conn: &Connection,
+    workstream_id: &str,
+) -> rusqlite::Result<Vec<WorkstreamLink>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, workstream_id, label, url, kind, position, created_ms \
+         FROM workstream_links \
+         WHERE workstream_id = ?1 \
+         ORDER BY position ASC, created_ms ASC",
+    )?;
+    let rows = stmt.query_map(params![workstream_id], |r| {
+        Ok(WorkstreamLink {
+            id: r.get(0)?,
+            workstream_id: r.get(1)?,
+            label: r.get(2)?,
+            url: r.get(3)?,
+            kind: r.get(4)?,
+            position: r.get(5)?,
+            created_ms: r.get(6)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// Insert a new link at the end of the list. `position` is set to
+/// `MAX(position) + 1` for the workstream so insertion order survives
+/// even when the caller skips it. Trims label / url / kind; rejects
+/// empty label or url.
+pub fn add_workstream_link(
+    conn: &Connection,
+    workstream_id: &str,
+    label: &str,
+    url: &str,
+    kind: Option<&str>,
+    now_ms: i64,
+) -> rusqlite::Result<WorkstreamLink> {
+    let label = label.trim();
+    let url = url.trim();
+    if label.is_empty() || url.is_empty() {
+        return Err(rusqlite::Error::InvalidParameterName(
+            "label and url are required".to_string(),
+        ));
+    }
+    let kind_owned = kind
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    let next_position: i64 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(position), -1) + 1 FROM workstream_links \
+             WHERE workstream_id = ?1",
+            params![workstream_id],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    let id = format!("wsl_{}", uuid::Uuid::new_v4());
+    conn.execute(
+        "INSERT INTO workstream_links(id, workstream_id, label, url, kind, position, created_ms) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![id, workstream_id, label, url, kind_owned, next_position, now_ms],
+    )?;
+    Ok(WorkstreamLink {
+        id,
+        workstream_id: workstream_id.to_string(),
+        label: label.to_string(),
+        url: url.to_string(),
+        kind: kind_owned,
+        position: next_position,
+        created_ms: now_ms,
+    })
+}
+
+/// Delete a single link by id. Returns whether a row was actually
+/// removed; callers that pass a stale id can choose how to surface that.
+pub fn remove_workstream_link(conn: &Connection, link_id: &str) -> rusqlite::Result<bool> {
+    let n = conn.execute(
+        "DELETE FROM workstream_links WHERE id = ?1",
+        params![link_id],
+    )?;
+    Ok(n > 0)
 }
 
 fn get_workstream_one(conn: &Connection, id: &str) -> rusqlite::Result<Option<Workstream>> {
@@ -271,7 +369,8 @@ fn get_workstream_one(conn: &Connection, id: &str) -> rusqlite::Result<Option<Wo
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'email'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'event'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'note'), 0), \
-                COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0) \
+                COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_links WHERE workstream_id = w.id), 0) \
          FROM workstreams w WHERE w.id = ?1",
     )?;
     let mut ws = stmt
@@ -293,6 +392,7 @@ fn get_workstream_one(conn: &Connection, id: &str) -> rusqlite::Result<Option<Wo
                 event_count: r.get::<_, i64>(12)? as u32,
                 note_count: r.get::<_, i64>(13)? as u32,
                 open_action_count: r.get::<_, i64>(14)? as u32,
+                link_count: r.get::<_, i64>(15)? as u32,
             })
         })
         .optional()?;
@@ -747,7 +847,10 @@ mod tests {
             "PRAGMA foreign_keys = ON;
              CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
              INSERT INTO meta(key, value) VALUES ('schema_version', '11');
-             CREATE TABLE team_members (id TEXT PRIMARY KEY);
+             CREATE TABLE team_members (
+                 id      TEXT PRIMARY KEY,
+                 aliases TEXT NOT NULL DEFAULT '[]'
+             );
              CREATE TABLE connectors (id TEXT PRIMARY KEY);
              INSERT INTO connectors(id) VALUES ('mg:test');
              CREATE TABLE notes (
@@ -777,6 +880,14 @@ mod tests {
         // the migration backfills from the now-deleted pivots so it
         // must run before any test seeds workstreams.
         conn.execute_batch(include_str!("../migrations/016_workstream_signals.sql"))
+            .unwrap();
+        // 017 reshapes team_member_aliases — independent of workstreams
+        // but the persist layer's count subqueries (#88) reference
+        // tables created in 018 below, so we keep the migration order
+        // intact.
+        conn.execute_batch(include_str!("../migrations/017_typed_aliases.sql"))
+            .unwrap();
+        conn.execute_batch(include_str!("../migrations/018_workstream_links.sql"))
             .unwrap();
         conn
     }
@@ -1466,5 +1577,87 @@ mod tests {
         tx.commit().unwrap();
 
         assert!(list_workstreams_active(&conn).unwrap()[0].members.is_empty());
+    }
+
+    // ----- User-curated links (#88) ----------------------------------------
+    //
+    // These tests reuse the `seed_workstream` helper above so the FK on
+    // `workstream_links` resolves through a real `write_workstream` call.
+
+    #[test]
+    fn add_workstream_link_assigns_monotonic_position() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_l");
+
+        let a = add_workstream_link(&conn, "ws_l", "Repo", "https://x/y", Some("github"), 100).unwrap();
+        let b = add_workstream_link(&conn, "ws_l", "Linear", "https://lin/p", Some("linear"), 110).unwrap();
+        let c = add_workstream_link(&conn, "ws_l", "Notes", "https://n/d", None, 120).unwrap();
+        assert_eq!(a.position, 0);
+        assert_eq!(b.position, 1);
+        assert_eq!(c.position, 2);
+        assert_eq!(c.kind, None, "kind=None survives round-trip");
+    }
+
+    #[test]
+    fn list_workstream_links_orders_by_position_then_created_ms() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_l");
+        let _ = add_workstream_link(&conn, "ws_l", "A", "https://a", None, 100).unwrap();
+        let _ = add_workstream_link(&conn, "ws_l", "B", "https://b", None, 110).unwrap();
+        let _ = add_workstream_link(&conn, "ws_l", "C", "https://c", None, 120).unwrap();
+
+        let listed = list_workstream_links(&conn, "ws_l").unwrap();
+        let labels: Vec<&str> = listed.iter().map(|l| l.label.as_str()).collect();
+        assert_eq!(labels, vec!["A", "B", "C"]);
+    }
+
+    #[test]
+    fn add_workstream_link_rejects_empty_label_or_url() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_l");
+        assert!(add_workstream_link(&conn, "ws_l", "  ", "https://x", None, 100).is_err());
+        assert!(add_workstream_link(&conn, "ws_l", "Ok", "  ", None, 100).is_err());
+    }
+
+    #[test]
+    fn remove_workstream_link_targets_only_the_named_id() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_l");
+        let a = add_workstream_link(&conn, "ws_l", "A", "https://a", None, 100).unwrap();
+        let b = add_workstream_link(&conn, "ws_l", "B", "https://b", None, 110).unwrap();
+
+        let removed = remove_workstream_link(&conn, &a.id).unwrap();
+        assert!(removed);
+        let listed = list_workstream_links(&conn, "ws_l").unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, b.id);
+
+        // Re-removing the same id is a no-op (returns false).
+        let removed_again = remove_workstream_link(&conn, &a.id).unwrap();
+        assert!(!removed_again);
+    }
+
+    #[test]
+    fn delete_workstream_cascades_links() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_l");
+        let _ = add_workstream_link(&conn, "ws_l", "A", "https://a", None, 100).unwrap();
+        let _ = add_workstream_link(&conn, "ws_l", "B", "https://b", None, 110).unwrap();
+        assert_eq!(list_workstream_links(&conn, "ws_l").unwrap().len(), 2);
+
+        conn.execute("DELETE FROM workstreams WHERE id = 'ws_l'", []).unwrap();
+        assert!(list_workstream_links(&conn, "ws_l").unwrap().is_empty());
+    }
+
+    #[test]
+    fn workstream_link_count_reflects_pivot_rows() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_l");
+        let _ = add_workstream_link(&conn, "ws_l", "A", "https://a", None, 100).unwrap();
+        let _ = add_workstream_link(&conn, "ws_l", "B", "https://b", None, 110).unwrap();
+
+        let listed = list_workstreams_active(&conn).unwrap();
+        let row = listed.iter().find(|w| w.id == "ws_l").expect("present");
+        assert_eq!(row.link_count, 2);
     }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -4902,6 +4902,23 @@ input.nh-title {
   vertical-align: middle;
 }
 
+/* Link-count badge on a list card (#88) — small chip next to the
+   reopened badge that hints "this workstream has external URLs
+   attached". The full chip set lives on the detail view. */
+.workstream-card-links-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: 8px;
+  padding: 2px 7px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--fg-muted) 12%, transparent);
+  color: var(--fg-muted);
+  font-size: 10.5px;
+  font-weight: 600;
+  vertical-align: middle;
+}
+
 /* Archived workstreams collapsed accordion at the bottom of the list
    view (#78). Default closed; click the toggle to expand. */
 .workstream-archived-section {
@@ -5105,6 +5122,179 @@ input.nh-title {
   line-height: 1.5;
   color: var(--fg);
   margin: 0;
+}
+
+/* ----- User-curated links (#88) ----- */
+.workstream-links {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.workstream-links-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.workstream-links-title {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+}
+.workstream-links-add {
+  background: transparent;
+  border: 1px solid var(--home-line);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.workstream-links-add:hover {
+  background: var(--bg-soft, rgba(0, 0, 0, 0.04));
+  color: var(--fg);
+}
+.workstream-links-empty {
+  margin: 0;
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+.workstream-links-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.workstream-link-chip {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--home-line);
+  border-radius: 999px;
+  background: var(--bg, #fff);
+  overflow: hidden;
+  transition: border-color 0.15s, background 0.15s;
+}
+.workstream-link-chip:hover {
+  border-color: var(--accent, #4a90e2);
+}
+.workstream-link-chip-open {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12.5px;
+  color: var(--fg);
+  max-width: 280px;
+}
+.workstream-link-chip-open:hover {
+  color: var(--accent, #4a90e2);
+}
+.workstream-link-chip-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.workstream-link-chip-kind {
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.workstream-link-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  background: transparent;
+  border: none;
+  border-left: 1px solid var(--home-line);
+  cursor: pointer;
+  color: var(--fg-muted);
+}
+.workstream-link-chip-remove:hover {
+  background: var(--bg-soft, rgba(0, 0, 0, 0.04));
+  color: var(--danger, #b00020);
+}
+.workstream-link-composer {
+  display: grid;
+  grid-template-columns: 1fr 1fr 130px;
+  gap: 8px;
+  align-items: center;
+  padding: 10px;
+  border: 1px solid var(--home-line);
+  border-radius: 8px;
+  background: var(--bg, #fff);
+}
+.workstream-link-composer-input,
+.workstream-link-composer-kind {
+  box-sizing: border-box;
+  height: 30px;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+  padding: 0 10px;
+  border: 1px solid var(--home-line);
+  border-radius: 6px;
+  background: var(--bg, #fff);
+  color: var(--fg);
+}
+.workstream-link-composer-kind {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 26px;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path d='M3 4.5l3 3 3-3' fill='none' stroke='%23808080' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  background-size: 10px 10px;
+}
+.workstream-link-composer-input:focus,
+.workstream-link-composer-kind:focus {
+  outline: none;
+  border-color: var(--accent, #4a90e2);
+}
+.workstream-link-composer-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.workstream-link-composer-cancel,
+.workstream-link-composer-save {
+  font: inherit;
+  font-size: 12.5px;
+  padding: 5px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--home-line);
+  background: var(--bg, #fff);
+  color: var(--fg);
+  cursor: pointer;
+}
+.workstream-link-composer-cancel:hover {
+  background: var(--bg-soft, rgba(0, 0, 0, 0.04));
+}
+.workstream-link-composer-save {
+  background: var(--accent, #4a90e2);
+  border-color: var(--accent, #4a90e2);
+  color: #fff;
+}
+.workstream-link-composer-save:hover {
+  filter: brightness(0.95);
+}
+.workstream-link-composer-save:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 /* ----- User notes (#77) ----- */

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -8,26 +8,32 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { openUrl } from "@tauri-apps/plugin-opener";
+
 import {
   type EmailMessage,
+  LinkKind,
   type TeamMember,
   type Workstream,
   type WorkstreamAction,
   type WorkstreamDetail,
+  type WorkstreamLink,
   type WorkstreamStatus,
+  addWorkstreamLink,
   getEmailBody,
   getWorkstreamDetails,
   listArchivedWorkstreams,
   listTeamMembers,
   markWorkstreamSeen,
   openOrCreateEventNote,
+  removeWorkstreamLink,
   setWorkstreamActionDone,
   setWorkstreamOwner,
   setWorkstreamStatus,
   setWorkstreamUserNotes,
 } from "./file";
 import { DueChip } from "./Home";
-import { IconCheck, IconChevLeft } from "./icons";
+import { IconCheck, IconChevLeft, IconLink, IconPlus, IconTrash } from "./icons";
 import { avatarColor, initialsFromName } from "./initials";
 
 // ----- List view -----------------------------------------------------------
@@ -286,6 +292,16 @@ function WorkstreamCard({
           {isReopened ? (
             <span className="workstream-card-reopened" aria-label="Reopened">
               Reopened
+            </span>
+          ) : null}
+          {w.link_count > 0 ? (
+            <span
+              className="workstream-card-links-badge"
+              aria-label={`${w.link_count} linked URL${w.link_count === 1 ? "" : "s"}`}
+              title={`${w.link_count} linked URL${w.link_count === 1 ? "" : "s"}`}
+            >
+              <IconLink size={11} sw={1.8} />
+              {w.link_count}
             </span>
           ) : null}
         </span>
@@ -624,6 +640,16 @@ function WorkstreamDetailView({
         }
       />
 
+      <LinksSection
+        workstreamId={detail.id}
+        links={detail.links}
+        onLinksChanged={(next) =>
+          setDetail((d) =>
+            d ? { ...d, links: next, link_count: next.length } : d,
+          )
+        }
+      />
+
       <ActionsSection
         actions={detail.actions}
         onToggle={onToggleAction}
@@ -898,6 +924,210 @@ function MembersStrip({
         );
       })}
     </section>
+  );
+}
+
+// ----- User-curated links (#88) -------------------------------------------
+
+const LINK_KIND_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: LinkKind.GitHub, label: "GitHub" },
+  { value: LinkKind.Linear, label: "Linear" },
+  { value: LinkKind.Notion, label: "Notion" },
+  { value: LinkKind.Figma, label: "Figma" },
+  { value: LinkKind.Other, label: "Other" },
+];
+
+function LinksSection({
+  workstreamId,
+  links,
+  onLinksChanged,
+}: {
+  workstreamId: string;
+  links: WorkstreamLink[];
+  onLinksChanged: (next: WorkstreamLink[]) => void;
+}) {
+  const [composerOpen, setComposerOpen] = useState(false);
+
+  const handleOpen = async (url: string) => {
+    try {
+      await openUrl(url);
+    } catch (err) {
+      console.error("[workstreams] openUrl failed", err);
+    }
+  };
+
+  const handleRemove = async (linkId: string) => {
+    // Optimistic remove; revert on error so a transient backend hiccup
+    // doesn't drop the user's curated URL silently.
+    const prev = links;
+    onLinksChanged(links.filter((l) => l.id !== linkId));
+    try {
+      await removeWorkstreamLink(linkId);
+    } catch (err) {
+      console.error("[workstreams] removeWorkstreamLink failed", err);
+      onLinksChanged(prev);
+    }
+  };
+
+  const handleAdd = async (label: string, url: string, kind: string | null) => {
+    try {
+      const created = await addWorkstreamLink(workstreamId, label, url, kind);
+      onLinksChanged([...links, created]);
+      setComposerOpen(false);
+    } catch (err) {
+      console.error("[workstreams] addWorkstreamLink failed", err);
+    }
+  };
+
+  return (
+    <section className="workstream-links">
+      <div className="workstream-links-head">
+        <h3 className="workstream-links-title">Links</h3>
+        {!composerOpen && (
+          <button
+            type="button"
+            className="workstream-links-add"
+            onClick={() => setComposerOpen(true)}
+          >
+            <IconPlus size={12} sw={1.8} />
+            Add link
+          </button>
+        )}
+      </div>
+      {links.length === 0 && !composerOpen ? (
+        <p className="workstream-links-empty">
+          No external links yet — attach the repo, design doc, or tracking
+          ticket so they're one click away.
+        </p>
+      ) : null}
+      {links.length > 0 ? (
+        <div className="workstream-links-chips">
+          {links.map((link) => (
+            <div className="workstream-link-chip" key={link.id}>
+              <button
+                type="button"
+                className="workstream-link-chip-open"
+                onClick={() => void handleOpen(link.url)}
+                title={link.url}
+              >
+                <IconLink size={12} sw={1.8} />
+                <span className="workstream-link-chip-label">
+                  {link.label}
+                </span>
+                {link.kind ? (
+                  <span className="workstream-link-chip-kind">
+                    {link.kind}
+                  </span>
+                ) : null}
+              </button>
+              <button
+                type="button"
+                className="workstream-link-chip-remove"
+                onClick={() => void handleRemove(link.id)}
+                aria-label={`Remove ${link.label}`}
+                title="Remove"
+              >
+                <IconTrash size={11} sw={1.8} />
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {composerOpen ? (
+        <LinkComposer
+          onCancel={() => setComposerOpen(false)}
+          onSubmit={(label, url, kind) => void handleAdd(label, url, kind)}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+function LinkComposer({
+  onCancel,
+  onSubmit,
+}: {
+  onCancel: () => void;
+  onSubmit: (label: string, url: string, kind: string | null) => void;
+}) {
+  const [label, setLabel] = useState("");
+  const [url, setUrl] = useState("");
+  const [kind, setKind] = useState<string>(LinkKind.Other);
+  const labelRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    labelRef.current?.focus();
+  }, []);
+
+  const canSubmit = label.trim() !== "" && url.trim() !== "";
+
+  const submit = () => {
+    if (!canSubmit) return;
+    onSubmit(label.trim(), url.trim(), kind || null);
+  };
+
+  return (
+    <div className="workstream-link-composer">
+      <input
+        ref={labelRef}
+        type="text"
+        className="workstream-link-composer-input"
+        placeholder="Label (e.g. Repo)"
+        value={label}
+        onChange={(e) => setLabel(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            submit();
+          } else if (e.key === "Escape") {
+            onCancel();
+          }
+        }}
+      />
+      <input
+        type="url"
+        className="workstream-link-composer-input"
+        placeholder="https://…"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            submit();
+          } else if (e.key === "Escape") {
+            onCancel();
+          }
+        }}
+      />
+      <select
+        className="workstream-link-composer-kind"
+        value={kind}
+        onChange={(e) => setKind(e.target.value)}
+      >
+        {LINK_KIND_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+      <div className="workstream-link-composer-actions">
+        <button
+          type="button"
+          className="workstream-link-composer-cancel"
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="workstream-link-composer-save"
+          disabled={!canSubmit}
+          onClick={submit}
+        >
+          Add
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -523,6 +523,9 @@ export type Workstream = {
   event_count: number;
   note_count: number;
   open_action_count: number;
+  /** User-curated external link count (#88). Drives the small link-icon
+   *  badge on the list card; the actual links land on WorkstreamDetail. */
+  link_count: number;
 };
 
 export type WorkstreamAction = {
@@ -543,11 +546,32 @@ export type WorkstreamNoteRef = {
   modified_ms: number;
 };
 
+export type WorkstreamLink = {
+  id: string;
+  workstream_id: string;
+  label: string;
+  url: string;
+  /** Soft enum; canonical values exposed via `LinkKind` below. `null`
+   *  renders with a generic link glyph. */
+  kind: string | null;
+  position: number;
+  created_ms: number;
+};
+
+export const LinkKind = {
+  GitHub: "github",
+  Linear: "linear",
+  Notion: "notion",
+  Figma: "figma",
+  Other: "other",
+} as const;
+
 export type WorkstreamDetail = Workstream & {
   emails: EmailMessage[];
   events: CalendarEvent[];
   notes: WorkstreamNoteRef[];
   actions: WorkstreamAction[];
+  links: WorkstreamLink[];
 };
 
 export type ClusterReport = {
@@ -626,6 +650,32 @@ export async function setWorkstreamOwner(
   ownerMemberId: string | null,
 ): Promise<void> {
   await invoke<void>("set_workstream_owner", { id, ownerMemberId });
+}
+
+// --- Workstream links (#88) ----------------------------------------------
+
+export async function listWorkstreamLinks(
+  workstreamId: string,
+): Promise<WorkstreamLink[]> {
+  return invoke<WorkstreamLink[]>("list_workstream_links", { workstreamId });
+}
+
+export async function addWorkstreamLink(
+  workstreamId: string,
+  label: string,
+  url: string,
+  kind?: string | null,
+): Promise<WorkstreamLink> {
+  return invoke<WorkstreamLink>("add_workstream_link", {
+    workstreamId,
+    label,
+    url,
+    kind: kind ?? null,
+  });
+}
+
+export async function removeWorkstreamLink(linkId: string): Promise<void> {
+  await invoke<void>("remove_workstream_link", { linkId });
 }
 
 export type NoteMeta = { modified_ms: number };


### PR DESCRIPTION
## Summary

Adds a small `workstream_links` pivot for user-curated `(label, url, kind)` triples per workstream. Pure user curation — the synthesizer stays untouched. Surfaced as clickable chips on the detail view (opened via `tauri-plugin-opener`), folded into `read_workstream` for AI ask, and hinted on the list card with a small link-icon + count badge.

Closes #88. Mirrors the same lightweight-pivot pattern used by #85 / #86 / #87 — adding a new pivot is one migration + one persist module + one section in the detail view.

## Approach

- **Schema (`migrations/018_workstream_links.sql`)**: `(id, workstream_id, label, url, kind, position, created_ms)` with `ON DELETE CASCADE` to `workstreams`. `kind` is a soft enum (`github` / `linear` / `notion` / `figma` / `other` / NULL). `position` is reserved for a future drag-handle reorder UI; v1 just keeps insertion order.
- **Backend persist**: `list_workstream_links`, `add_workstream_link` (assigns `MAX(position) + 1`), `remove_workstream_link`. `get_workstream_detail` populates `WorkstreamDetail.links`; the four list-builders populate `Workstream.link_count` via a correlated subquery.
- **Tauri commands**: three thin wrappers, registered in `lib.rs`.
- **`read_workstream`**: emits a `## Links` markdown section between User notes and Actions when non-empty. Markdown link syntax + optional `(kind)` suffix, so "what's the repo for X?" gets answered without any tool changes.
- **UI**: `LinksSection` slotted between user notes and actions in the detail view; per-link chip with click → `openUrl` (system browser) and an X-button delete with optimistic-then-revert. Inline composer (label / URL / kind) lifts state up so the composer toggle and the form share the same parent. List-card header gets a small link-icon + count badge when `link_count > 0`.

## Test plan

- [x] `cargo test --lib` — 239 passed, 0 failed (was 231; +8 new)
- [x] **New persist tests**: monotonic `position` on add, ordering on list, empty-input rejection, scoped remove, FK cascade on workstream delete, `link_count` reflection on the list-builder rows.
- [x] **New ask.rs tests**: `## Links` rendered between User notes and Actions; optional `(kind)` suffix omitted when kind is null; whole section skipped when `links` is empty.
- [x] `bun run build` — TS + Vite clean.
- [ ] Manual: `bun tauri dev`, open a workstream, click "+ Add link", enter Label "Repo" + URL `https://github.com/anthropics/claude-code` + kind `github`, save → chip renders. Click chip → opens in system browser. Click trash → removed and persists across reload. List view shows the link badge in the card header. Ask the AI palette "what's the repo for X?" and confirm Claude cites the URL via `read_workstream`. Delete the workstream → links cascade-deleted.

## Out of scope

- Auto-detection of links from email/note bodies (future synthesizer enhancement).
- Link previews / OG-card fetching.
- Drag-and-drop reorder UI; `reorder_workstream_links` Tauri command (no UI consumer in v1).
- Showing links in the cluster-pass prompt's existing-workstreams entry (would add per-pass token cost; defer until evidence shows it helps).
- Per-kind icon glyphs (v1 ships a single generic link icon; per-kind icons are non-breaking to add later).