### PR TITLE
Hierarchical workstreams (parent → child rollup) (#89)

### DIFF
--- a/src-tauri/src/ask.rs
+++ b/src-tauri/src/ask.rs
@@ -1350,6 +1350,29 @@ fn format_workstream_detail(
         }
     }
 
+    // Children rollup (#89). Title + summary + open-action count per
+    // child, no per-child hydration. Lets the model answer
+    // "how's [Bridge] going?" with a parent-level summary plus
+    // status across each sub-thread without growing the prompt by
+    // a full WorkstreamDetail per child.
+    if !detail.children.is_empty() {
+        s.push_str("\n## Children\n\n");
+        for child in &detail.children {
+            let summary = truncate_chars(child.summary.trim(), 200);
+            let open = child.open_action_count;
+            let action_phrase = if open == 1 {
+                "1 open action".to_string()
+            } else {
+                format!("{open} open actions")
+            };
+            s.push_str(&format!(
+                "- [{id}] {title} — {summary} ({action_phrase})\n",
+                id = child.id,
+                title = child.title.trim(),
+            ));
+        }
+    }
+
     s
 }
 
@@ -1809,6 +1832,7 @@ mod tests {
             note_count: 0,
             open_action_count: 0,
             link_count: 0,
+            parent_workstream_id: None,
             external_participants: Vec::new(),
         }
     }
@@ -1902,6 +1926,7 @@ mod tests {
                 note_count: 1,
                 open_action_count: 1,
                 link_count: 0,
+                parent_workstream_id: None,
                 external_participants: Vec::new(),
             },
             emails: vec![
@@ -1916,6 +1941,7 @@ mod tests {
             }],
             actions: vec![make_action("Reply to invoice", false), make_action("Send quote", true)],
             links: Vec::new(),
+            children: Vec::new(),
         };
         let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let out = format_workstream_detail("W1", &detail, &team_map);
@@ -1959,6 +1985,7 @@ mod tests {
                 note_count: 0,
                 open_action_count: 0,
                 link_count: 0,
+                parent_workstream_id: None,
                 external_participants: Vec::new(),
             },
             emails,
@@ -1966,6 +1993,7 @@ mod tests {
             notes: vec![],
             actions: vec![],
             links: Vec::new(),
+            children: Vec::new(),
         };
         let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let out = format_workstream_detail("W2", &detail, &team_map);
@@ -2017,6 +2045,7 @@ mod tests {
                 note_count: 0,
                 open_action_count: 0,
                 link_count: 0,
+                parent_workstream_id: None,
                 external_participants: Vec::new(),
             },
             emails: vec![],
@@ -2024,6 +2053,7 @@ mod tests {
             notes: vec![],
             actions: vec![],
             links: Vec::new(),
+            children: Vec::new(),
         };
         let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let out = format_workstream_detail("W1", &detail, &team_map);
@@ -2056,6 +2086,7 @@ mod tests {
                 note_count: 0,
                 open_action_count: 0,
                 link_count: 0,
+                parent_workstream_id: None,
                 external_participants: Vec::new(),
             },
             emails: vec![],
@@ -2063,6 +2094,7 @@ mod tests {
             notes: vec![],
             actions: vec![],
             links: Vec::new(),
+            children: Vec::new(),
         };
         let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let out = format_workstream_detail("W3", &detail, &team_map);
@@ -2090,6 +2122,7 @@ mod tests {
                 note_count: 0,
                 open_action_count: 1,
                 link_count: 2,
+                parent_workstream_id: None,
                 external_participants: Vec::new(),
             },
             emails: vec![],
@@ -2116,6 +2149,7 @@ mod tests {
                     created_ms: 0,
                 },
             ],
+            children: Vec::new(),
         };
         let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let out = format_workstream_detail("W4", &detail, &team_map);
@@ -2156,6 +2190,7 @@ mod tests {
                 note_count: 0,
                 open_action_count: 0,
                 link_count: 0,
+                parent_workstream_id: None,
                 external_participants: Vec::new(),
             },
             emails: vec![],
@@ -2163,6 +2198,7 @@ mod tests {
             notes: vec![],
             actions: vec![],
             links: Vec::new(),
+            children: Vec::new(),
         };
         let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let out = format_workstream_detail("W5", &detail, &team_map);
@@ -2191,6 +2227,7 @@ mod tests {
             notes: vec![],
             actions: vec![],
             links: Vec::new(),
+            children: Vec::new(),
         };
         let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let out = format_workstream_detail("W6", &detail, &team_map);
@@ -2207,9 +2244,94 @@ mod tests {
             notes: vec![],
             actions: vec![],
             links: Vec::new(),
+            children: Vec::new(),
         };
         let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let out = format_workstream_detail("W7", &detail, &team_map);
         assert!(!out.contains("External:"));
+    }
+
+    fn make_child(id: &str, title: &str, summary: &str, open: u32) -> Workstream {
+        let mut w = make_ws(id, title, summary, 0);
+        w.open_action_count = open;
+        w
+    }
+
+    #[test]
+    fn format_workstream_detail_emits_children_section_after_notes() {
+        let detail = WorkstreamDetail {
+            workstream: Workstream {
+                id: "ws_bridge".into(),
+                title: "ELAN AI Bridge".into(),
+                summary: "Umbrella for Bridge sub-threads.".into(),
+                status: "active".into(),
+                last_activity_ms: 0,
+                created_ms: 0,
+                updated_ms: 0,
+                user_notes: None,
+                archived_at_ms: None,
+                reopened_at_ms: None,
+                owner_member_id: None,
+                members: Vec::new(),
+                email_count: 0,
+                event_count: 0,
+                note_count: 0,
+                open_action_count: 0,
+                link_count: 0,
+                parent_workstream_id: None,
+                external_participants: Vec::new(),
+            },
+            emails: vec![],
+            events: vec![],
+            notes: vec![],
+            actions: vec![],
+            links: Vec::new(),
+            children: vec![
+                make_child("ws_talgo", "Talgo demo", "Vendor evaluation.", 1),
+                make_child("ws_comptia", "CompTIA setup", "Onboarding.", 0),
+            ],
+        };
+        let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let out = format_workstream_detail("W8", &detail, &team_map);
+
+        assert!(out.contains("## Children"));
+        assert!(out.contains("- [ws_talgo] Talgo demo — Vendor evaluation. (1 open action)"));
+        assert!(out.contains("- [ws_comptia] CompTIA setup — Onboarding. (0 open actions)"));
+    }
+
+    #[test]
+    fn format_workstream_detail_skips_children_section_when_empty() {
+        let detail = WorkstreamDetail {
+            workstream: Workstream {
+                id: "ws_leaf".into(),
+                title: "Leaf".into(),
+                summary: "".into(),
+                status: "active".into(),
+                last_activity_ms: 0,
+                created_ms: 0,
+                updated_ms: 0,
+                user_notes: None,
+                archived_at_ms: None,
+                reopened_at_ms: None,
+                owner_member_id: None,
+                members: Vec::new(),
+                email_count: 0,
+                event_count: 0,
+                note_count: 0,
+                open_action_count: 0,
+                link_count: 0,
+                parent_workstream_id: None,
+                external_participants: Vec::new(),
+            },
+            emails: vec![],
+            events: vec![],
+            notes: vec![],
+            actions: vec![],
+            links: Vec::new(),
+            children: Vec::new(),
+        };
+        let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let out = format_workstream_detail("W9", &detail, &team_map);
+        assert!(!out.contains("## Children"));
     }
 }

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -49,7 +49,8 @@ const SCHEMA_V15: &str = include_str!("migrations/015_workstream_owner.sql");
 const SCHEMA_V16: &str = include_str!("migrations/016_workstream_signals.sql");
 const SCHEMA_V17: &str = include_str!("migrations/017_typed_aliases.sql");
 const SCHEMA_V18: &str = include_str!("migrations/018_workstream_links.sql");
-const SCHEMA_VERSION: i64 = 18;
+const SCHEMA_V19: &str = include_str!("migrations/019_workstream_parent.sql");
+const SCHEMA_VERSION: i64 = 19;
 
 /// Open the index DB at `db_path` (creating it if absent) and apply any
 /// pending migrations.
@@ -163,6 +164,10 @@ fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 17 {
         conn.execute_batch(SCHEMA_V18)?;
         version = 18;
+    }
+    if version == 18 {
+        conn.execute_batch(SCHEMA_V19)?;
+        version = 19;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -698,7 +698,8 @@ pub fn run() {
             workstreams::commands::set_workstream_owner,
             workstreams::commands::list_workstream_links,
             workstreams::commands::add_workstream_link,
-            workstreams::commands::remove_workstream_link
+            workstreams::commands::remove_workstream_link,
+            workstreams::commands::set_workstream_parent
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/migrations/019_workstream_parent.sql
+++ b/src-tauri/src/migrations/019_workstream_parent.sql
@@ -1,0 +1,19 @@
+-- Hierarchical workstreams (#89).
+--
+-- A flat 2-level hierarchy: a workstream may have a parent (the umbrella
+-- effort) but parents themselves cannot have parents. The 2-level cap is
+-- enforced in code (see `validate_proposed_parent` in persist.rs); the
+-- schema only carries the FK so referential integrity holds.
+--
+-- ON DELETE SET NULL — deleting a parent leaves its children as
+-- standalone workstreams rather than cascade-deleting them. Matches the
+-- issue's "cascading archive out of scope" stance: each child should be
+-- a separate decision when its umbrella goes away.
+--
+-- The new column is NULL on every existing row, so no backfill needed.
+
+ALTER TABLE workstreams ADD COLUMN parent_workstream_id TEXT
+  REFERENCES workstreams(id) ON DELETE SET NULL;
+CREATE INDEX idx_workstreams_parent ON workstreams(parent_workstream_id);
+
+UPDATE meta SET value = '19' WHERE key = 'schema_version';

--- a/src-tauri/src/workstreams/commands.rs
+++ b/src-tauri/src/workstreams/commands.rs
@@ -104,6 +104,23 @@ pub fn set_workstream_owner(
     persist::set_owner(&c, &id, owner_member_id.as_deref()).map_err(|e| e.to_string())
 }
 
+/// Set or clear a workstream's parent (#89). Pass `null` to make it a
+/// top-level standalone. The 2-level hierarchy is enforced server-side
+/// — invalid edges (self-parent, would-be-grandparent, current
+/// workstream already has children, parent doesn't exist) come back as
+/// a user-facing error string the UI surfaces verbatim.
+#[tauri::command]
+pub fn set_workstream_parent(
+    id: String,
+    parent_id: Option<String>,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<(), String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    persist::set_workstream_parent(&c, &id, parent_id.as_deref())
+        .map_err(|e| e.to_string())?
+        .map_err(|reason| reason)
+}
+
 // ----- User-curated links (#88) ------------------------------------------
 
 #[tauri::command]

--- a/src-tauri/src/workstreams/mod.rs
+++ b/src-tauri/src/workstreams/mod.rs
@@ -60,6 +60,12 @@ pub struct Workstream {
     /// team_member id; `None` when unassigned. Synthesizer never sets
     /// this — same authority pattern as user_notes.
     pub owner_member_id: Option<String>,
+    /// Parent workstream id (#89). `None` for top-level workstreams.
+    /// Hierarchy is flat 2-level; the synthesizer's `write_workstream`
+    /// + the manual `set_workstream_parent` command both validate
+    /// against would-be-grandparent / self-parent / has-children
+    /// before persisting.
+    pub parent_workstream_id: Option<String>,
     /// Derived list of team_member ids involved in the workstream
     /// (#81). Computed on read by joining the workstream's pivot
     /// emails / events against `email_recipients` / `calendar_attendees`
@@ -157,6 +163,11 @@ pub struct WorkstreamDetail {
     pub notes: Vec<NoteRef>,
     pub actions: Vec<WorkstreamAction>,
     pub links: Vec<WorkstreamLink>,
+    /// Direct children when this workstream is a parent (#89). Lean
+    /// `Workstream` shape — counts + members already populated, no
+    /// emails/events/notes/actions hydration. Empty for leaves and
+    /// standalones. Ordered by `last_activity_ms` desc.
+    pub children: Vec<Workstream>,
 }
 
 #[derive(Debug, Clone, Serialize, Default)]

--- a/src-tauri/src/workstreams/persist.rs
+++ b/src-tauri/src/workstreams/persist.rs
@@ -36,6 +36,11 @@ pub struct SynthesizedWorkstream {
     /// runs `resurrect_if_archived`. Other values are ignored — archive
     /// flow is user-driven only.
     pub status: Option<String>,
+    /// Optional parent workstream id from Claude (#89). When set, the
+    /// synthesizer's write path validates against the 2-level cap +
+    /// self-parent / unknown-id rules; invalid values are silently
+    /// dropped to NULL with a log line.
+    pub parent_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -78,7 +83,8 @@ pub fn list_workstreams_active(conn: &Connection) -> rusqlite::Result<Vec<Workst
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'event'), 0) AS evc, \
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'note'), 0) AS nc, \
                 COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0) AS ac, \
-                COALESCE((SELECT COUNT(*) FROM workstream_links WHERE workstream_id = w.id), 0) AS lc \
+                COALESCE((SELECT COUNT(*) FROM workstream_links WHERE workstream_id = w.id), 0) AS lc, \
+                w.parent_workstream_id \
          FROM workstreams w \
          WHERE w.status = 'active' \
          ORDER BY w.last_activity_ms DESC",
@@ -102,6 +108,7 @@ pub fn list_workstreams_active(conn: &Connection) -> rusqlite::Result<Vec<Workst
             note_count: r.get::<_, i64>(13)? as u32,
             open_action_count: r.get::<_, i64>(14)? as u32,
             link_count: r.get::<_, i64>(15)? as u32,
+            parent_workstream_id: r.get(16)?,
             external_participants: Vec::new(),
         })
     })?;
@@ -126,7 +133,8 @@ pub fn list_workstreams_archived(
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'event'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'note'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0), \
-                COALESCE((SELECT COUNT(*) FROM workstream_links WHERE workstream_id = w.id), 0) \
+                COALESCE((SELECT COUNT(*) FROM workstream_links WHERE workstream_id = w.id), 0), \
+                w.parent_workstream_id \
          FROM workstreams w \
          WHERE w.status = 'archived' \
          ORDER BY w.archived_at_ms DESC NULLS LAST",
@@ -150,6 +158,7 @@ pub fn list_workstreams_archived(
             note_count: r.get::<_, i64>(13)? as u32,
             open_action_count: r.get::<_, i64>(14)? as u32,
             link_count: r.get::<_, i64>(15)? as u32,
+            parent_workstream_id: r.get(16)?,
             external_participants: Vec::new(),
         })
     })?;
@@ -179,7 +188,8 @@ pub fn list_workstreams_for_synthesis(
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'event'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'note'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0), \
-                COALESCE((SELECT COUNT(*) FROM workstream_links WHERE workstream_id = w.id), 0) \
+                COALESCE((SELECT COUNT(*) FROM workstream_links WHERE workstream_id = w.id), 0), \
+                w.parent_workstream_id \
          FROM workstreams w \
          WHERE w.status IN ('active', 'archived') \
          ORDER BY \
@@ -208,6 +218,7 @@ pub fn list_workstreams_for_synthesis(
                 note_count: r.get::<_, i64>(13)? as u32,
                 open_action_count: r.get::<_, i64>(14)? as u32,
                 link_count: r.get::<_, i64>(15)? as u32,
+                parent_workstream_id: r.get(16)?,
                 external_participants: Vec::new(),
             },
             is_archived,
@@ -272,6 +283,7 @@ pub fn get_workstream_detail(
 
     let actions = list_actions_for(conn, id)?;
     let links = list_workstream_links(conn, id)?;
+    let children = list_children_of(conn, id)?;
 
     Ok(Some(WorkstreamDetail {
         workstream,
@@ -280,7 +292,60 @@ pub fn get_workstream_detail(
         notes,
         actions,
         links,
+        children,
     }))
+}
+
+/// All direct children of `parent_id`, ordered by recency (#89).
+/// Reuses the same column shape as the list builders so `attach_members`
+/// applies. Empty for leaves and standalones.
+pub fn list_children_of(
+    conn: &Connection,
+    parent_id: &str,
+) -> rusqlite::Result<Vec<Workstream>> {
+    let mut stmt = conn.prepare(
+        "SELECT w.id, w.title, w.summary, w.status, w.last_activity_ms, w.created_ms, w.updated_ms, \
+                w.user_notes, w.archived_at_ms, w.reopened_at_ms, w.owner_member_id, \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'email'), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'event'), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'note'), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0), \
+                COALESCE((SELECT COUNT(*) FROM workstream_links WHERE workstream_id = w.id), 0), \
+                w.parent_workstream_id \
+         FROM workstreams w \
+         WHERE w.parent_workstream_id = ?1 \
+         ORDER BY w.last_activity_ms DESC",
+    )?;
+    let rows = stmt.query_map(params![parent_id], |r| {
+        Ok(Workstream {
+            id: r.get(0)?,
+            title: r.get(1)?,
+            summary: r.get(2)?,
+            status: r.get(3)?,
+            last_activity_ms: r.get(4)?,
+            created_ms: r.get(5)?,
+            updated_ms: r.get(6)?,
+            user_notes: r.get(7)?,
+            archived_at_ms: r.get(8)?,
+            reopened_at_ms: r.get(9)?,
+            owner_member_id: r.get(10)?,
+            members: Vec::new(),
+            email_count: r.get::<_, i64>(11)? as u32,
+            event_count: r.get::<_, i64>(12)? as u32,
+            note_count: r.get::<_, i64>(13)? as u32,
+            open_action_count: r.get::<_, i64>(14)? as u32,
+            link_count: r.get::<_, i64>(15)? as u32,
+            parent_workstream_id: r.get(16)?,
+            external_participants: Vec::new(),
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    attach_members(conn, &mut out)?;
+    attach_external_participants(conn, &mut out)?;
+    Ok(out)
 }
 
 // ----- User-curated links (#88) -------------------------------------------
@@ -381,7 +446,8 @@ fn get_workstream_one(conn: &Connection, id: &str) -> rusqlite::Result<Option<Wo
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'event'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_signals WHERE workstream_id = w.id AND kind = 'note'), 0), \
                 COALESCE((SELECT COUNT(*) FROM workstream_actions WHERE workstream_id = w.id AND done = 0), 0), \
-                COALESCE((SELECT COUNT(*) FROM workstream_links WHERE workstream_id = w.id), 0) \
+                COALESCE((SELECT COUNT(*) FROM workstream_links WHERE workstream_id = w.id), 0), \
+                w.parent_workstream_id \
          FROM workstreams w WHERE w.id = ?1",
     )?;
     let mut ws = stmt
@@ -404,6 +470,7 @@ fn get_workstream_one(conn: &Connection, id: &str) -> rusqlite::Result<Option<Wo
                 note_count: r.get::<_, i64>(13)? as u32,
                 open_action_count: r.get::<_, i64>(14)? as u32,
                 link_count: r.get::<_, i64>(15)? as u32,
+                parent_workstream_id: r.get(16)?,
                 external_participants: Vec::new(),
             })
         })
@@ -640,6 +707,32 @@ pub fn write_workstream(
             params![id, record.title, record.summary, last_activity, now_ms],
         )?;
         counts.workstream_added = true;
+
+        // Synthesizer-proposed parent (#89) only applies on insert. For
+        // updates we preserve user-set parent — same authority pattern
+        // as `owner_member_id` and `user_notes`. Validation drops bad
+        // values (would-be-grandparent, self-parent, unknown id) with a
+        // log line; the new row stays standalone in those cases.
+        if let Some(parent_id) = record
+            .parent_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty() && *s != "null")
+        {
+            match validate_proposed_parent(tx, &id, parent_id)? {
+                Ok(()) => {
+                    tx.execute(
+                        "UPDATE workstreams SET parent_workstream_id = ?2 WHERE id = ?1",
+                        params![id, parent_id],
+                    )?;
+                }
+                Err(reason) => {
+                    eprintln!(
+                        "[workstreams] dropping parent_id {parent_id} for new workstream {id}: {reason}"
+                    );
+                }
+            }
+        }
     } else {
         tx.execute(
             "UPDATE workstreams SET title = ?2, summary = ?3, last_activity_ms = ?4, updated_ms = ?5 \
@@ -860,6 +953,79 @@ pub fn set_owner(
     Ok(())
 }
 
+/// Validate a proposed `(child, parent)` edge for #89's flat 2-level
+/// hierarchy. Returns `Ok(())` when the edge is allowed, `Err(reason)`
+/// otherwise. Cheap — at most three single-row lookups.
+///
+/// Rules:
+///   1. `parent_id == child_id` is forbidden (self-parent).
+///   2. `parent_id` must resolve to an existing workstream.
+///   3. The resolved parent must itself have `parent_workstream_id IS NULL`
+///      (otherwise the chain is 3 levels).
+///   4. `child_id` must not already have children (would push them to a
+///      grandchild slot).
+pub fn validate_proposed_parent(
+    conn: &Connection,
+    child_id: &str,
+    parent_id: &str,
+) -> rusqlite::Result<Result<(), String>> {
+    if parent_id == child_id {
+        return Ok(Err("a workstream can't be its own parent".to_string()));
+    }
+    let parent_grandparent: Option<Option<String>> = conn
+        .query_row(
+            "SELECT parent_workstream_id FROM workstreams WHERE id = ?1",
+            params![parent_id],
+            |r| r.get::<_, Option<String>>(0),
+        )
+        .optional()?;
+    let Some(parent_grandparent) = parent_grandparent else {
+        return Ok(Err(format!("parent {parent_id} not found")));
+    };
+    if parent_grandparent.is_some() {
+        return Ok(Err(
+            "the proposed parent is itself a child — hierarchy is capped at 2 levels".to_string(),
+        ));
+    }
+    let child_has_children: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM workstreams WHERE parent_workstream_id = ?1",
+        params![child_id],
+        |r| r.get(0),
+    )?;
+    if child_has_children > 0 {
+        return Ok(Err(
+            "this workstream already has children — unparent them before assigning a parent here"
+                .to_string(),
+        ));
+    }
+    Ok(Ok(()))
+}
+
+/// Set or clear a workstream's parent (#89). Pass `None` to make it a
+/// top-level standalone. Validates via `validate_proposed_parent` when
+/// `parent_id` is `Some`; rejects with a user-facing error string the
+/// UI surfaces directly.
+pub fn set_workstream_parent(
+    conn: &Connection,
+    child_id: &str,
+    parent_id: Option<&str>,
+) -> rusqlite::Result<Result<(), String>> {
+    if let Some(p) = parent_id {
+        match validate_proposed_parent(conn, child_id, p)? {
+            Ok(()) => {}
+            Err(e) => return Ok(Err(e)),
+        }
+    }
+    let n = conn.execute(
+        "UPDATE workstreams SET parent_workstream_id = ?2, updated_ms = ?3 WHERE id = ?1",
+        params![child_id, parent_id, now_ms()],
+    )?;
+    if n == 0 {
+        return Ok(Err(format!("workstream {child_id} not found")));
+    }
+    Ok(Ok(()))
+}
+
 /// Drop signal pivot rows that point at items no longer present in
 /// their domain table (#85). Soft FKs mean the cascade-on-delete the
 /// old per-source pivots had via `ON DELETE CASCADE` is gone — this
@@ -1003,6 +1169,8 @@ mod tests {
             .unwrap();
         conn.execute_batch(include_str!("../migrations/018_workstream_links.sql"))
             .unwrap();
+        conn.execute_batch(include_str!("../migrations/019_workstream_parent.sql"))
+            .unwrap();
         conn
     }
 
@@ -1045,6 +1213,7 @@ mod tests {
             member_notes: notes.iter().map(|s| s.to_string()).collect(),
             actions,
             status: None,
+            parent_id: None,
         }
     }
 
@@ -2013,5 +2182,194 @@ mod tests {
             .map(|p| (p.email.as_str(), p.count))
             .collect();
         assert_eq!(pairs, vec![("alice@x.io", 3), ("bob@x.io", 1)]);
+    }
+
+    // ----- Hierarchy (#89) -------------------------------------------------
+
+    #[test]
+    fn set_workstream_parent_happy_path_then_clear() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_parent");
+        seed_workstream(&mut conn, "ws_child");
+
+        let r = set_workstream_parent(&conn, "ws_child", Some("ws_parent")).unwrap();
+        assert!(r.is_ok(), "happy path: {:?}", r);
+
+        let detail = get_workstream_detail(&conn, "ws_child").unwrap().unwrap();
+        assert_eq!(detail.workstream.parent_workstream_id.as_deref(), Some("ws_parent"));
+        let parent = get_workstream_detail(&conn, "ws_parent").unwrap().unwrap();
+        assert_eq!(parent.children.len(), 1);
+        assert_eq!(parent.children[0].id, "ws_child");
+
+        // Clear → standalone again.
+        let r = set_workstream_parent(&conn, "ws_child", None).unwrap();
+        assert!(r.is_ok());
+        let detail = get_workstream_detail(&conn, "ws_child").unwrap().unwrap();
+        assert!(detail.workstream.parent_workstream_id.is_none());
+    }
+
+    #[test]
+    fn set_workstream_parent_rejects_self_parent() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_self");
+        let r = set_workstream_parent(&conn, "ws_self", Some("ws_self")).unwrap();
+        assert!(r.is_err());
+        assert!(r.unwrap_err().contains("its own parent"));
+    }
+
+    #[test]
+    fn set_workstream_parent_rejects_grandparent_chain() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_a");
+        seed_workstream(&mut conn, "ws_b");
+        seed_workstream(&mut conn, "ws_c");
+        // A has parent B (so A is mid-level). Now trying to point C
+        // at A would make a 3-level chain.
+        set_workstream_parent(&conn, "ws_a", Some("ws_b"))
+            .unwrap()
+            .unwrap();
+        let r = set_workstream_parent(&conn, "ws_c", Some("ws_a")).unwrap();
+        assert!(r.is_err());
+        assert!(r.unwrap_err().contains("2 levels"));
+    }
+
+    #[test]
+    fn set_workstream_parent_rejects_when_self_has_children() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_p");
+        seed_workstream(&mut conn, "ws_c");
+        seed_workstream(&mut conn, "ws_x");
+        // ws_p already has a child (ws_c). Trying to set ws_p's parent
+        // would push ws_c to a third level.
+        set_workstream_parent(&conn, "ws_c", Some("ws_p"))
+            .unwrap()
+            .unwrap();
+        let r = set_workstream_parent(&conn, "ws_p", Some("ws_x")).unwrap();
+        assert!(r.is_err());
+        assert!(r.unwrap_err().contains("already has children"));
+    }
+
+    #[test]
+    fn set_workstream_parent_rejects_unknown_parent_id() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_a");
+        let r = set_workstream_parent(&conn, "ws_a", Some("ws_missing")).unwrap();
+        assert!(r.is_err());
+        assert!(r.unwrap_err().contains("not found"));
+    }
+
+    #[test]
+    fn get_workstream_detail_returns_empty_children_for_leaves_and_standalones() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_solo");
+        let d = get_workstream_detail(&conn, "ws_solo").unwrap().unwrap();
+        assert!(d.children.is_empty());
+    }
+
+    #[test]
+    fn get_workstream_detail_orders_children_by_recency() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_p");
+        seed_workstream(&mut conn, "ws_old");
+        seed_workstream(&mut conn, "ws_new");
+        // Stamp last_activity directly so the ordering is deterministic.
+        conn.execute(
+            "UPDATE workstreams SET last_activity_ms = 1000 WHERE id = 'ws_old'",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE workstreams SET last_activity_ms = 2000 WHERE id = 'ws_new'",
+            [],
+        )
+        .unwrap();
+        set_workstream_parent(&conn, "ws_old", Some("ws_p"))
+            .unwrap()
+            .unwrap();
+        set_workstream_parent(&conn, "ws_new", Some("ws_p"))
+            .unwrap()
+            .unwrap();
+        let d = get_workstream_detail(&conn, "ws_p").unwrap().unwrap();
+        let ids: Vec<&str> = d.children.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(ids, vec!["ws_new", "ws_old"]);
+    }
+
+    #[test]
+    fn delete_workstream_sets_children_parent_to_null() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_p");
+        seed_workstream(&mut conn, "ws_c");
+        set_workstream_parent(&conn, "ws_c", Some("ws_p"))
+            .unwrap()
+            .unwrap();
+
+        conn.execute("DELETE FROM workstreams WHERE id = 'ws_p'", [])
+            .unwrap();
+
+        let d = get_workstream_detail(&conn, "ws_c").unwrap().unwrap();
+        assert!(
+            d.workstream.parent_workstream_id.is_none(),
+            "FK ON DELETE SET NULL keeps the child but clears its parent"
+        );
+    }
+
+    #[test]
+    fn write_workstream_drops_invalid_parent_id_for_new_workstream() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_a");
+        seed_workstream(&mut conn, "ws_b");
+        // Make ws_a a child first; using it as a parent on a new write
+        // should be rejected (would-be-grandparent).
+        set_workstream_parent(&conn, "ws_a", Some("ws_b"))
+            .unwrap()
+            .unwrap();
+
+        let tx = conn.transaction().unwrap();
+        let mut record = make_ws(Some("ws_new"), "Spawn", &[], &[], &[], vec![]);
+        record.parent_id = Some("ws_a".to_string());
+        write_workstream(&tx, &record, 9_000).unwrap();
+        tx.commit().unwrap();
+
+        let d = get_workstream_detail(&conn, "ws_new").unwrap().unwrap();
+        assert!(
+            d.workstream.parent_workstream_id.is_none(),
+            "invalid parent_id (would-be-grandparent) silently dropped"
+        );
+    }
+
+    #[test]
+    fn write_workstream_does_not_clobber_user_set_parent_on_resync() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_p");
+        seed_workstream(&mut conn, "ws_c");
+        set_workstream_parent(&conn, "ws_c", Some("ws_p"))
+            .unwrap()
+            .unwrap();
+
+        // Resync the existing workstream; even with no parent_id in the
+        // record, the user's parent assignment must survive.
+        let tx = conn.transaction().unwrap();
+        let record = make_ws(Some("ws_c"), "Renamed child", &[], &[], &[], vec![]);
+        write_workstream(&tx, &record, 9_000).unwrap();
+        tx.commit().unwrap();
+
+        let d = get_workstream_detail(&conn, "ws_c").unwrap().unwrap();
+        assert_eq!(d.workstream.parent_workstream_id.as_deref(), Some("ws_p"));
+    }
+
+    #[test]
+    fn list_workstreams_active_populates_parent_workstream_id() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_p");
+        seed_workstream(&mut conn, "ws_c");
+        set_workstream_parent(&conn, "ws_c", Some("ws_p"))
+            .unwrap()
+            .unwrap();
+
+        let listed = list_workstreams_active(&conn).unwrap();
+        let parent = listed.iter().find(|w| w.id == "ws_p").unwrap();
+        let child = listed.iter().find(|w| w.id == "ws_c").unwrap();
+        assert!(parent.parent_workstream_id.is_none());
+        assert_eq!(child.parent_workstream_id.as_deref(), Some("ws_p"));
     }
 }

--- a/src-tauri/src/workstreams/synthesizer.rs
+++ b/src-tauri/src/workstreams/synthesizer.rs
@@ -73,6 +73,14 @@ Summaries: 1-3 sentences. State what's happening and what's next, not what it is
 Action items: extract concrete TODOs the user owes (or owns) per workstream. Each must reference \
 a source by its label. Skip items that are already done.
 
+Hierarchy: the \"Existing workstreams (active)\" section may show parents at the top level with \
+children indented underneath (rendered with a \"↳\" marker). When a NEW workstream cleanly extends \
+an umbrella effort already in the list (e.g. \"ELAN AI Bridge\" with sub-threads like \"Talgo demo\" \
+or \"CompTIA setup\"), set \"parent_id\" to the umbrella's id. Otherwise leave \"parent_id\" null. \
+The hierarchy is flat — max 2 levels — so do NOT set \"parent_id\" to a workstream that's already \
+indented under another. \"parent_id\" only takes effect on newly-spawned workstreams; it is ignored \
+for existing ids (the user owns parent assignment for established workstreams).
+
 Output: a strict JSON array. No prose. No markdown fences. No keys other than the schema below.
 
 Schema:
@@ -80,6 +88,7 @@ Schema:
   {
     \"id\": \"<existing workstream id or null>\",
     \"status\": \"active\" | null,
+    \"parent_id\": \"<existing parent workstream id or null>\",
     \"title\": \"...\",
     \"summary\": \"...\",
     \"members\": { \"emails\": [\"M1\", \"M2\"], \"events\": [\"E3\"], \"notes\": [\"N1\"] },
@@ -465,44 +474,26 @@ fn build_user_message(
     if existing_active.is_empty() {
         s.push_str("(none)\n");
     } else {
+        // Render parents and standalones at the top level in the order
+        // the list builder returned (last_activity DESC). Each parent
+        // is followed by its children indented with `↳` so Claude sees
+        // the umbrella structure when proposing parent_id (#89).
+        let mut children_by_parent: std::collections::HashMap<&str, Vec<&Workstream>> =
+            std::collections::HashMap::new();
         for w in existing_active {
-            s.push_str(&format!(
-                "[{}] {} — {} (active)\n",
-                w.id,
-                w.title,
-                summarize_one_line(&w.summary)
-            ));
-            if let Some(owner_id) = w.owner_member_id.as_deref() {
-                if let Some(name) = team_by_id.get(owner_id) {
-                    s.push_str(&format!("   Owner: {name}\n"));
-                }
+            if let Some(p) = w.parent_workstream_id.as_deref() {
+                children_by_parent.entry(p).or_default().push(w);
             }
-            if !w.members.is_empty() {
-                let names: Vec<&str> = w
-                    .members
-                    .iter()
-                    .filter_map(|id| team_by_id.get(id).map(String::as_str))
-                    .take(8)
-                    .collect();
-                if !names.is_empty() {
-                    let suffix = if w.members.len() > names.len() {
-                        format!(" (+{} more)", w.members.len() - names.len())
-                    } else {
-                        String::new()
-                    };
-                    s.push_str(&format!(
-                        "   Members: {names}{suffix}\n",
-                        names = names.join(", "),
-                        suffix = suffix
-                    ));
-                }
+        }
+        for w in existing_active {
+            if w.parent_workstream_id.is_some() {
+                continue;
             }
-            if let Some(notes) = w.user_notes.as_deref().filter(|s| !s.trim().is_empty()) {
-                let collapsed = collapse_ws(notes);
-                let truncated = truncate_chars(&collapsed, USER_NOTES_PROMPT_CAP);
-                s.push_str(&format!(
-                    "   Notes (user-authored, ground truth): {truncated}\n"
-                ));
+            format_existing_workstream_entry(&mut s, w, team_by_id, false);
+            if let Some(children) = children_by_parent.get(w.id.as_str()) {
+                for child in children {
+                    format_existing_workstream_entry(&mut s, child, team_by_id, true);
+                }
             }
         }
     }
@@ -592,6 +583,59 @@ fn collapse_ws(s: &str) -> String {
     out.trim().to_string()
 }
 
+/// Render one existing-workstream entry in the cluster-pass prompt.
+/// Top-level workstreams render flush left; children render indented
+/// with a "↳" marker so Claude sees the parent → child structure (#89).
+/// The same per-row continuation lines (Owner / Members / Notes) are
+/// emitted for both, just under a deeper indent for children.
+fn format_existing_workstream_entry(
+    s: &mut String,
+    w: &Workstream,
+    team_by_id: &std::collections::HashMap<String, String>,
+    is_child: bool,
+) {
+    let head_prefix = if is_child { "   ↳ " } else { "" };
+    let cont_prefix = if is_child { "      " } else { "   " };
+    s.push_str(&format!(
+        "{head_prefix}[{id}] {title} — {summary} (active)\n",
+        id = w.id,
+        title = w.title,
+        summary = summarize_one_line(&w.summary)
+    ));
+    if let Some(owner_id) = w.owner_member_id.as_deref() {
+        if let Some(name) = team_by_id.get(owner_id) {
+            s.push_str(&format!("{cont_prefix}Owner: {name}\n"));
+        }
+    }
+    if !w.members.is_empty() {
+        let names: Vec<&str> = w
+            .members
+            .iter()
+            .filter_map(|id| team_by_id.get(id).map(String::as_str))
+            .take(8)
+            .collect();
+        if !names.is_empty() {
+            let suffix = if w.members.len() > names.len() {
+                format!(" (+{} more)", w.members.len() - names.len())
+            } else {
+                String::new()
+            };
+            s.push_str(&format!(
+                "{cont_prefix}Members: {names}{suffix}\n",
+                names = names.join(", "),
+                suffix = suffix
+            ));
+        }
+    }
+    if let Some(notes) = w.user_notes.as_deref().filter(|s| !s.trim().is_empty()) {
+        let collapsed = collapse_ws(notes);
+        let truncated = truncate_chars(&collapsed, USER_NOTES_PROMPT_CAP);
+        s.push_str(&format!(
+            "{cont_prefix}Notes (user-authored, ground truth): {truncated}\n"
+        ));
+    }
+}
+
 fn summarize_one_line(s: &str) -> String {
     let collapsed = collapse_ws(s);
     if collapsed.chars().count() <= 200 {
@@ -636,6 +680,12 @@ struct RawWorkstream {
     members: Option<RawMembers>,
     #[serde(default)]
     actions: Option<Vec<RawAction>>,
+    /// Optional parent workstream id (#89). Synthesizer's write path
+    /// validates against the 2-level cap before persisting; invalid
+    /// values are dropped to NULL. Only honored on insert — existing
+    /// workstreams' parent is user-only authority.
+    #[serde(default)]
+    parent_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -708,6 +758,13 @@ fn parse_synthesizer_response(
             .filter(|s| !s.is_empty() && *s != "null")
             .map(|s| s.to_string());
 
+        let parent_id = raw
+            .parent_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty() && *s != "null")
+            .map(|s| s.to_string());
+
         let members = raw.members.unwrap_or(RawMembers {
             emails: Vec::new(),
             events: Vec::new(),
@@ -757,6 +814,7 @@ fn parse_synthesizer_response(
             member_notes,
             actions,
             status,
+            parent_id,
         });
     }
     out

--- a/src/App.css
+++ b/src/App.css
@@ -4948,25 +4948,128 @@ input.nh-title {
   font-weight: 500;
 }
 
-/* Parent picker (#89). Same chrome as the existing status pill so
-   the three pickers (status / owner / parent) align in the header. */
-.workstream-parent-select {
-  font: inherit;
-  font-size: 12.5px;
+/* Detail-header kebab button (#89). Replaces the three inline native
+   `<select>` chips with a single icon that opens the settings modal —
+   keeps the title row clean and gives the pickers room to breathe. */
+.workstream-detail-settings-button {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 6px;
+  cursor: pointer;
   color: var(--fg-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: auto;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.workstream-detail-settings-button:hover {
+  background: var(--bg-soft, rgba(0, 0, 0, 0.04));
+  color: var(--fg);
+  border-color: var(--home-line);
+}
+
+/* Settings modal (#89). Reuses the layout idiom from the identities
+   modal — dimmed backdrop, centered dialog, three labeled rows of
+   pickers. Each picker fires immediately; the Done button just
+   dismisses the modal. */
+.settings-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.settings-modal {
   background: var(--bg, #fff);
+  color: var(--fg);
+  width: min(440px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.settings-modal-header {
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid var(--home-line);
+}
+.settings-modal-header h2 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+}
+.settings-modal-rows {
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.settings-modal-row {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 12px;
+  align-items: center;
+}
+.settings-modal-label {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--fg-muted);
+}
+.settings-modal-select {
+  box-sizing: border-box;
+  height: 32px;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+  padding: 0 28px 0 10px;
   border: 1px solid var(--home-line);
   border-radius: 6px;
-  padding: 4px 10px;
-  cursor: pointer;
-}
-.workstream-parent-select:hover:not(:disabled) {
+  background: var(--bg, #fff);
   color: var(--fg);
-  border-color: var(--border-strong, rgba(0, 0, 0, 0.25));
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path d='M3 4.5l3 3 3-3' fill='none' stroke='%23808080' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  background-size: 10px 10px;
 }
-.workstream-parent-select:disabled {
+.settings-modal-select:focus {
+  outline: none;
+  border-color: var(--accent, #4a90e2);
+}
+.settings-modal-select:disabled {
   opacity: 0.55;
   cursor: not-allowed;
+}
+.settings-modal-hint {
+  grid-column: 2 / -1;
+  font-size: 11.5px;
+  color: var(--fg-muted);
+  margin-top: -4px;
+}
+.settings-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 20px 16px;
+  border-top: 1px solid var(--home-line);
+}
+.settings-modal-done {
+  font: inherit;
+  font-size: 13px;
+  padding: 6px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--accent, #4a90e2);
+  background: var(--accent, #4a90e2);
+  color: #fff;
+  cursor: pointer;
+}
+.settings-modal-done:hover {
+  filter: brightness(0.95);
 }
 
 /* Children section on a parent's detail view (#89). Same layout

--- a/src/App.css
+++ b/src/App.css
@@ -4840,6 +4840,7 @@ input.nh-title {
   gap: 10px;
 }
 .workstream-card {
+  position: relative;
   display: block;
   width: 100%;
   text-align: left;
@@ -4900,6 +4901,89 @@ input.nh-title {
   letter-spacing: 0.04em;
   text-transform: uppercase;
   vertical-align: middle;
+}
+
+/* Nested children cards under a parent (#89). Indent + slightly
+   muted background so the hierarchy reads at a glance, without
+   collapsing them behind a click. */
+.workstream-card.nested {
+  margin-left: 28px;
+  background: color-mix(in srgb, var(--bg-soft, rgba(0, 0, 0, 0.03)) 50%, transparent);
+}
+.workstream-card.nested::before {
+  content: "↳";
+  position: absolute;
+  left: -20px;
+  top: 14px;
+  color: var(--fg-muted);
+  font-size: 13px;
+  opacity: 0.7;
+}
+
+/* Detail-view breadcrumb (#89). Only renders when the workstream
+   has a parent. Shows "[Parent] › [This]" — the parent text is the
+   click target. */
+.workstream-detail-breadcrumb {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12.5px;
+  color: var(--fg-muted);
+  padding: 4px 0;
+  margin-bottom: 4px;
+  align-self: flex-start;
+}
+.workstream-detail-breadcrumb:hover {
+  color: var(--accent, #4a90e2);
+}
+.workstream-detail-breadcrumb-sep {
+  opacity: 0.5;
+}
+.workstream-detail-breadcrumb-self {
+  color: var(--fg);
+  font-weight: 500;
+}
+
+/* Parent picker (#89). Same chrome as the existing status pill so
+   the three pickers (status / owner / parent) align in the header. */
+.workstream-parent-select {
+  font: inherit;
+  font-size: 12.5px;
+  color: var(--fg-muted);
+  background: var(--bg, #fff);
+  border: 1px solid var(--home-line);
+  border-radius: 6px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+.workstream-parent-select:hover:not(:disabled) {
+  color: var(--fg);
+  border-color: var(--border-strong, rgba(0, 0, 0, 0.25));
+}
+.workstream-parent-select:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* Children section on a parent's detail view (#89). Same layout
+   as the list view's grid; the section title sits above the cards. */
+.workstream-children-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+.workstream-section-title {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  text-transform: uppercase;
 }
 
 /* Link-count badge on a list card (#88) — small chip next to the

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -23,7 +23,6 @@ import {
   IconArchive,
   IconBell,
   IconBriefcase,
-  IconCalendar,
   IconCheck,
   IconChecklist,
   IconChevRight,
@@ -96,7 +95,6 @@ type Props = {
 type NavId =
   | "home"
   | "actions"
-  | "meetings"
   | "workstreams"
   | "favorites"
   | "archive"
@@ -392,7 +390,6 @@ export function Home({
     const VALID: NavId[] = [
       "home",
       "actions",
-      "meetings",
       "workstreams",
       "favorites",
       "archive",
@@ -499,7 +496,6 @@ export function Home({
           active={nav}
           onSelect={setNav}
           actionCount={openActionCount}
-          meetingCount={upcoming.length}
           workstreamCount={workstreams.filter((w) => w.open_action_count > 0).length}
           tags={allTags}
           activeTag={tagFilter}
@@ -554,7 +550,7 @@ export function Home({
           onNewMeeting={onNewMeeting}
         />
 
-        {(nav === "home" || nav === "meetings") && upcoming.length > 0 && (
+        {nav === "home" && upcoming.length > 0 && (
           <UpcomingStrip events={upcoming} onOpen={openEventNote} />
         )}
 
@@ -585,7 +581,7 @@ export function Home({
           />
         ) : (
           <>
-            {openActionCount > 0 && (
+            {nav !== "favorites" && openActionCount > 0 && (
               <ActionItemsTeaser
                 items={actions}
                 onToggle={onToggleAction}
@@ -625,7 +621,6 @@ function Sidebar({
   active,
   onSelect,
   actionCount,
-  meetingCount,
   workstreamCount,
   tags,
   activeTag,
@@ -636,7 +631,6 @@ function Sidebar({
   active: NavId;
   onSelect: (id: NavId) => void;
   actionCount: number;
-  meetingCount: number;
   workstreamCount: number;
   tags: string[];
   activeTag: string | null;
@@ -675,13 +669,6 @@ function Sidebar({
           badge={actionCount > 0 ? String(actionCount) : null}
           active={active === "actions"}
           onClick={() => onSelect("actions")}
-        />
-        <NavItem
-          icon={<IconCalendar size={14} sw={1.7} />}
-          label="Meetings"
-          badge={meetingCount > 0 ? String(meetingCount) : null}
-          active={active === "meetings"}
-          onClick={() => onSelect("meetings")}
         />
         <NavItem
           icon={<IconBriefcase size={14} sw={1.7} />}

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -36,7 +36,7 @@ import {
   setWorkstreamUserNotes,
 } from "./file";
 import { DueChip } from "./Home";
-import { IconCheck, IconChevLeft, IconLink, IconPlus, IconTrash } from "./icons";
+import { IconCheck, IconChevLeft, IconLink, IconMore, IconPlus, IconTrash } from "./icons";
 import { avatarColor, initialsFromName } from "./initials";
 
 // ----- List view -----------------------------------------------------------
@@ -557,6 +557,7 @@ function WorkstreamDetailView({
   const [detail, setDetail] = useState<WorkstreamDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [missing, setMissing] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const reload = useCallback(async () => {
     setLoading(true);
@@ -667,7 +668,7 @@ function WorkstreamDetailView({
   if (loading && !detail) {
     return (
       <div className="workstream-view">
-        <DetailHeader title="" onBack={onBack} status={null} onChangeStatus={() => {}} />
+        <DetailHeader title="" onBack={onBack} />
         <p className="home-empty">Loading…</p>
       </div>
     );
@@ -675,7 +676,7 @@ function WorkstreamDetailView({
   if (missing || !detail) {
     return (
       <div className="workstream-view">
-        <DetailHeader title="Workstream" onBack={onBack} status={null} onChangeStatus={() => {}} />
+        <DetailHeader title="Workstream" onBack={onBack} />
         <p className="home-empty">Workstream not found.</p>
       </div>
     );
@@ -703,6 +704,17 @@ function WorkstreamDetailView({
   const isParentItself = allWorkstreams.some(
     (w) => w.parent_workstream_id === detail.id,
   );
+
+  const onChangeOwner = async (ownerId: string | null) => {
+    const prev = detail.owner_member_id;
+    setDetail((d) => (d ? { ...d, owner_member_id: ownerId } : d));
+    try {
+      await setWorkstreamOwner(detail.id, ownerId);
+    } catch (e) {
+      console.error("[workstreams] setWorkstreamOwner failed", e);
+      setDetail((d) => (d ? { ...d, owner_member_id: prev } : d));
+    }
+  };
 
   const onChangeParent = async (parentId: string | null) => {
     const prev = detail.parent_workstream_id;
@@ -747,26 +759,22 @@ function WorkstreamDetailView({
       <DetailHeader
         title={detail.title}
         onBack={onBack}
-        status={detail.status}
-        onChangeStatus={onChangeStatus}
-        ownerId={detail.owner_member_id}
-        teamMembers={teamMembers}
-        onChangeOwner={async (ownerId) => {
-          // Optimistic local update; revert on error.
-          const prev = detail.owner_member_id;
-          setDetail((d) => (d ? { ...d, owner_member_id: ownerId } : d));
-          try {
-            await setWorkstreamOwner(detail.id, ownerId);
-          } catch (e) {
-            console.error("[workstreams] setWorkstreamOwner failed", e);
-            setDetail((d) => (d ? { ...d, owner_member_id: prev } : d));
-          }
-        }}
-        parentId={detail.parent_workstream_id}
-        parentCandidates={parentCandidates}
-        onChangeParent={onChangeParent}
-        parentDisabled={isParentItself}
+        onOpenSettings={() => setSettingsOpen(true)}
       />
+      {settingsOpen ? (
+        <WorkstreamSettingsModal
+          status={detail.status}
+          onChangeStatus={onChangeStatus}
+          ownerId={detail.owner_member_id}
+          teamMembers={teamMembers}
+          onChangeOwner={onChangeOwner}
+          parentId={detail.parent_workstream_id}
+          parentCandidates={parentCandidates}
+          onChangeParent={onChangeParent}
+          parentDisabled={isParentItself}
+          onClose={() => setSettingsOpen(false)}
+        />
+      ) : null}
       <p className="workstream-detail-summary">{detail.summary}</p>
 
       {detail.members.length > 0 || detail.owner_member_id ? (
@@ -827,6 +835,134 @@ function WorkstreamDetailView({
           onSelect={onNavigateTo}
         />
       ) : null}
+    </div>
+  );
+}
+
+/**
+ * Settings modal for a workstream's owner / parent / status (#89).
+ * Replaces the three inline `<select>` chips that used to crowd the
+ * detail header. Each picker fires its handler optimistically — there
+ * is no Save button, the modal is just a less-cluttered home for the
+ * controls. Esc / backdrop click close.
+ */
+function WorkstreamSettingsModal({
+  status,
+  onChangeStatus,
+  ownerId,
+  teamMembers,
+  onChangeOwner,
+  parentId,
+  parentCandidates,
+  onChangeParent,
+  parentDisabled,
+  onClose,
+}: {
+  status: WorkstreamStatus | null;
+  onChangeStatus: (s: WorkstreamStatus) => void | Promise<void>;
+  ownerId: string | null;
+  teamMembers: TeamMember[];
+  onChangeOwner: (ownerId: string | null) => void | Promise<void>;
+  parentId: string | null;
+  parentCandidates: Workstream[];
+  onChangeParent: (parentId: string | null) => void | Promise<void>;
+  parentDisabled: boolean;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="settings-modal-backdrop"
+      role="presentation"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="settings-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Workstream settings"
+      >
+        <header className="settings-modal-header">
+          <h2>Workstream settings</h2>
+        </header>
+        <div className="settings-modal-rows">
+          <label className="settings-modal-row">
+            <span className="settings-modal-label">Owner</span>
+            <select
+              className="settings-modal-select"
+              value={ownerId ?? ""}
+              onChange={(e) => onChangeOwner(e.target.value || null)}
+            >
+              <option value="">Unassigned</option>
+              {teamMembers.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.display_name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="settings-modal-row">
+            <span className="settings-modal-label">Parent</span>
+            <select
+              className="settings-modal-select"
+              value={parentId ?? ""}
+              disabled={parentDisabled}
+              onChange={(e) => onChangeParent(e.target.value || null)}
+              title={
+                parentDisabled
+                  ? "This workstream has children — unparent them before assigning a parent here."
+                  : undefined
+              }
+            >
+              <option value="">No parent</option>
+              {parentCandidates.map((w) => (
+                <option key={w.id} value={w.id}>
+                  {w.title}
+                </option>
+              ))}
+            </select>
+            {parentDisabled ? (
+              <span className="settings-modal-hint">
+                Has children — unparent them first.
+              </span>
+            ) : null}
+          </label>
+          {status ? (
+            <label className="settings-modal-row">
+              <span className="settings-modal-label">Status</span>
+              <select
+                className="settings-modal-select"
+                value={status}
+                onChange={(e) =>
+                  onChangeStatus(e.target.value as WorkstreamStatus)
+                }
+              >
+                <option value="active">Active</option>
+                <option value="snoozed">Snoozed</option>
+                <option value="archived">Archived</option>
+              </select>
+            </label>
+          ) : null}
+        </div>
+        <footer className="settings-modal-footer">
+          <button
+            type="button"
+            className="settings-modal-done"
+            onClick={onClose}
+          >
+            Done
+          </button>
+        </footer>
+      </div>
     </div>
   );
 }
@@ -990,33 +1126,14 @@ function WorkstreamUserNotes({
 function DetailHeader({
   title,
   onBack,
-  status,
-  onChangeStatus,
-  ownerId,
-  teamMembers,
-  onChangeOwner,
-  parentId,
-  parentCandidates,
-  onChangeParent,
-  parentDisabled,
+  onOpenSettings,
 }: {
   title: string;
   onBack: () => void;
-  status: WorkstreamStatus | null;
-  onChangeStatus: (s: WorkstreamStatus) => void | Promise<void>;
-  ownerId?: string | null;
-  teamMembers?: TeamMember[];
-  onChangeOwner?: (ownerId: string | null) => void | Promise<void>;
-  /** Current parent id (#89). `null` = top-level. */
-  parentId?: string | null;
-  /** Workstreams the user is allowed to set as parent. The picker is
-   *  filtered to top-level (NULL-parent), no-children-yet, non-self
-   *  candidates by the caller. */
-  parentCandidates?: Workstream[];
-  onChangeParent?: (parentId: string | null) => void | Promise<void>;
-  /** Disabled when this workstream itself has children — the backend
-   *  rejects the write anyway; this lets the UI explain why. */
-  parentDisabled?: boolean;
+  /** Open the settings modal — owner, parent, status (#89). Omitted on
+   *  the loading / missing-workstream sub-states where there's nothing
+   *  to configure. */
+  onOpenSettings?: () => void;
 }) {
   return (
     <header className="workstream-header workstream-detail-header">
@@ -1030,53 +1147,16 @@ function DetailHeader({
         Back
       </button>
       <h1 className="workstream-title">{title}</h1>
-      {teamMembers && onChangeOwner ? (
-        <select
-          className="workstream-owner-select"
-          value={ownerId ?? ""}
-          onChange={(e) => onChangeOwner(e.target.value || null)}
-          aria-label="Workstream owner"
+      {onOpenSettings ? (
+        <button
+          type="button"
+          className="workstream-detail-settings-button"
+          onClick={onOpenSettings}
+          aria-label="Workstream settings"
+          title="Settings"
         >
-          <option value="">Unassigned</option>
-          {teamMembers.map((m) => (
-            <option key={m.id} value={m.id}>
-              {m.display_name}
-            </option>
-          ))}
-        </select>
-      ) : null}
-      {parentCandidates && onChangeParent ? (
-        <select
-          className="workstream-parent-select"
-          value={parentId ?? ""}
-          disabled={parentDisabled}
-          onChange={(e) => onChangeParent(e.target.value || null)}
-          aria-label="Workstream parent"
-          title={
-            parentDisabled
-              ? "This workstream has children — unparent them before assigning a parent here."
-              : "Set a parent workstream"
-          }
-        >
-          <option value="">No parent</option>
-          {parentCandidates.map((w) => (
-            <option key={w.id} value={w.id}>
-              {w.title}
-            </option>
-          ))}
-        </select>
-      ) : null}
-      {status ? (
-        <select
-          className="workstream-status"
-          value={status}
-          onChange={(e) => onChangeStatus(e.target.value as WorkstreamStatus)}
-          aria-label="Workstream status"
-        >
-          <option value="active">Active</option>
-          <option value="snoozed">Snoozed</option>
-          <option value="archived">Archived</option>
-        </select>
+          <IconMore size={18} sw={1.8} />
+        </button>
       ) : null}
     </header>
   );

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -6,6 +6,7 @@
 //! pipeline added in #70 and listens for `workstream-status` to
 //! refetch.
 
+import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -30,6 +31,7 @@ import {
   removeWorkstreamLink,
   setWorkstreamActionDone,
   setWorkstreamOwner,
+  setWorkstreamParent,
   setWorkstreamStatus,
   setWorkstreamUserNotes,
 } from "./file";
@@ -113,9 +115,11 @@ export function WorkstreamsView({
       <WorkstreamDetailView
         id={selectedId}
         onBack={() => setSelectedId(null)}
+        onNavigateTo={(id) => setSelectedId(id)}
         onOpenNote={onOpenNote}
         teamMembers={teamMembers}
         teamById={teamById}
+        allWorkstreams={workstreams}
       />
     );
   }
@@ -190,13 +194,14 @@ export function WorkstreamsView({
         </p>
       ) : (
         <div className="workstream-list">
-          {filteredActive.map((w) => (
+          {renderHierarchical(filteredActive, (w) => (
             <WorkstreamCard
               key={w.id}
               workstream={w}
               nowMs={nowMs}
               onClick={() => setSelectedId(w.id)}
               teamById={teamById}
+              nested={w.parent_workstream_id != null}
             />
           ))}
         </div>
@@ -245,6 +250,44 @@ function applyMemberFilter<T extends Workstream>(
   );
 }
 
+/**
+ * Render a flat workstreams list with children visually nested under
+ * their parent (#89). Order: top-level workstreams (no parent or whose
+ * parent isn't in the slice) in input order; each parent immediately
+ * followed by its children in input order. Orphan children — whose
+ * parent was filtered out — render at the top level so the filter
+ * still surfaces them.
+ *
+ * The `render` callback is responsible for the `nested` styling on the
+ * card (it inspects `w.parent_workstream_id` itself); this helper just
+ * decides the iteration order.
+ */
+function renderHierarchical(
+  workstreams: Workstream[],
+  render: (w: Workstream) => React.ReactNode,
+): React.ReactNode[] {
+  const ids = new Set(workstreams.map((w) => w.id));
+  const childrenByParent = new Map<string, Workstream[]>();
+  for (const w of workstreams) {
+    if (w.parent_workstream_id && ids.has(w.parent_workstream_id)) {
+      const arr = childrenByParent.get(w.parent_workstream_id) ?? [];
+      arr.push(w);
+      childrenByParent.set(w.parent_workstream_id, arr);
+    }
+  }
+  const out: React.ReactNode[] = [];
+  for (const w of workstreams) {
+    // Skip children that will render under a visible parent.
+    if (w.parent_workstream_id && ids.has(w.parent_workstream_id)) continue;
+    out.push(render(w));
+    const children = childrenByParent.get(w.id);
+    if (children) {
+      for (const child of children) out.push(render(child));
+    }
+  }
+  return out;
+}
+
 /// Max member chips rendered on the card before overflow collapses
 /// into a `+N` pill. Owner always shows when present; the cap covers
 /// owner + non-owner members combined.
@@ -255,11 +298,15 @@ function WorkstreamCard({
   nowMs,
   onClick,
   teamById,
+  nested = false,
 }: {
   workstream: Workstream;
   nowMs: number;
   onClick: () => void;
   teamById: Map<string, TeamMember>;
+  /** When true, renders with a left indent and muted treatment so the
+   *  card visually nests under its parent (#89). */
+  nested?: boolean;
 }) {
   const isReopened = w.reopened_at_ms != null && w.status === "active";
 
@@ -286,7 +333,11 @@ function WorkstreamCard({
   const overflow = ordered.length - visible.length;
 
   return (
-    <button type="button" className="workstream-card" onClick={onClick}>
+    <button
+      type="button"
+      className={"workstream-card" + (nested ? " nested" : "")}
+      onClick={onClick}
+    >
       <div className="workstream-card-head">
         <span className="workstream-card-title">
           {w.title}
@@ -446,13 +497,14 @@ function ArchivedSection({
           <p className="home-empty">No archived workstreams match this filter.</p>
         ) : (
           <div className="workstream-archived-list">
-            {filtered.map((w) => (
+            {renderHierarchical(filtered, (w) => (
               <WorkstreamCard
                 key={w.id}
                 workstream={w}
                 nowMs={nowMs}
                 onClick={() => onSelect(w.id)}
                 teamById={teamById}
+                nested={w.parent_workstream_id != null}
               />
             ))}
           </div>
@@ -482,15 +534,25 @@ function plural(n: number, singular: string, plural_: string): string {
 function WorkstreamDetailView({
   id,
   onBack,
+  onNavigateTo,
   onOpenNote,
   teamMembers,
   teamById,
+  allWorkstreams,
 }: {
   id: string;
   onBack: () => void;
+  /** Switch the selected workstream without leaving the detail view —
+   *  used by the breadcrumb-up-to-parent and the children section's
+   *  card clicks (#89). */
+  onNavigateTo: (id: string) => void;
   onOpenNote: (path: string) => void;
   teamMembers: TeamMember[];
   teamById: Map<string, TeamMember>;
+  /** All active workstreams in the current list — used by the parent
+   *  picker to enumerate legal parent candidates (NULL-parent and
+   *  no children, excluding self). */
+  allWorkstreams: Workstream[];
 }) {
   const [detail, setDetail] = useState<WorkstreamDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -619,8 +681,69 @@ function WorkstreamDetailView({
     );
   }
 
+  // Parent-picker candidate workstreams (#89): NULL-parent, no children
+  // of their own, and not self. We recompute on every render — small
+  // arrays + cheap.
+  const parentCandidates = allWorkstreams.filter(
+    (w) =>
+      w.id !== detail.id &&
+      w.parent_workstream_id == null &&
+      // Exclude workstreams that already have children — they ARE
+      // parents themselves, but allowing them would make them a
+      // grandparent if we added the current workstream under them.
+      // Wait, that's actually allowed (2 levels: A→B is fine). The
+      // backend's rule 3 catches the inverse (you can't move a parent
+      // under another parent). So we don't filter these here.
+      true,
+  );
+
+  // Picker is disabled when this workstream has its own children — to
+  // make it a child would push its children to a third level. The
+  // backend rejects this anyway; this just gives a clearer affordance.
+  const isParentItself = allWorkstreams.some(
+    (w) => w.parent_workstream_id === detail.id,
+  );
+
+  const onChangeParent = async (parentId: string | null) => {
+    const prev = detail.parent_workstream_id;
+    setDetail((d) => (d ? { ...d, parent_workstream_id: parentId } : d));
+    try {
+      await setWorkstreamParent(detail.id, parentId);
+    } catch (e) {
+      console.error("[workstreams] setWorkstreamParent failed", e);
+      // Revert + surface the backend error string to the user.
+      setDetail((d) => (d ? { ...d, parent_workstream_id: prev } : d));
+      // eslint-disable-next-line no-alert
+      alert(
+        typeof e === "string"
+          ? e
+          : e instanceof Error
+            ? e.message
+            : "Could not set parent",
+      );
+    }
+  };
+
+  const parentTitle = detail.parent_workstream_id
+    ? allWorkstreams.find((w) => w.id === detail.parent_workstream_id)?.title
+    : null;
+
   return (
     <div className="workstream-view">
+      {detail.parent_workstream_id && parentTitle ? (
+        <button
+          type="button"
+          className="workstream-detail-breadcrumb"
+          onClick={() => onNavigateTo(detail.parent_workstream_id as string)}
+          title={`Open ${parentTitle}`}
+        >
+          {parentTitle}
+          <span className="workstream-detail-breadcrumb-sep" aria-hidden>
+            ›
+          </span>
+          <span className="workstream-detail-breadcrumb-self">{detail.title}</span>
+        </button>
+      ) : null}
       <DetailHeader
         title={detail.title}
         onBack={onBack}
@@ -639,6 +762,10 @@ function WorkstreamDetailView({
             setDetail((d) => (d ? { ...d, owner_member_id: prev } : d));
           }
         }}
+        parentId={detail.parent_workstream_id}
+        parentCandidates={parentCandidates}
+        onChangeParent={onChangeParent}
+        parentDisabled={isParentItself}
       />
       <p className="workstream-detail-summary">{detail.summary}</p>
 
@@ -692,7 +819,44 @@ function WorkstreamDetailView({
       />
 
       <NotesSection notes={detail.notes} onOpenNote={onOpenNote} />
+
+      {detail.children.length > 0 ? (
+        <ChildrenSection
+          items={detail.children}
+          teamById={teamById}
+          onSelect={onNavigateTo}
+        />
+      ) : null}
     </div>
+  );
+}
+
+function ChildrenSection({
+  items,
+  teamById,
+  onSelect,
+}: {
+  items: Workstream[];
+  teamById: Map<string, TeamMember>;
+  onSelect: (id: string) => void;
+}) {
+  const nowMs = Date.now();
+  return (
+    <section className="workstream-children-section">
+      <h3 className="workstream-section-title">Children ({items.length})</h3>
+      <div className="workstream-list">
+        {items.map((c) => (
+          <WorkstreamCard
+            key={c.id}
+            workstream={c}
+            nowMs={nowMs}
+            onClick={() => onSelect(c.id)}
+            teamById={teamById}
+            nested
+          />
+        ))}
+      </div>
+    </section>
   );
 }
 
@@ -831,6 +995,10 @@ function DetailHeader({
   ownerId,
   teamMembers,
   onChangeOwner,
+  parentId,
+  parentCandidates,
+  onChangeParent,
+  parentDisabled,
 }: {
   title: string;
   onBack: () => void;
@@ -839,6 +1007,16 @@ function DetailHeader({
   ownerId?: string | null;
   teamMembers?: TeamMember[];
   onChangeOwner?: (ownerId: string | null) => void | Promise<void>;
+  /** Current parent id (#89). `null` = top-level. */
+  parentId?: string | null;
+  /** Workstreams the user is allowed to set as parent. The picker is
+   *  filtered to top-level (NULL-parent), no-children-yet, non-self
+   *  candidates by the caller. */
+  parentCandidates?: Workstream[];
+  onChangeParent?: (parentId: string | null) => void | Promise<void>;
+  /** Disabled when this workstream itself has children — the backend
+   *  rejects the write anyway; this lets the UI explain why. */
+  parentDisabled?: boolean;
 }) {
   return (
     <header className="workstream-header workstream-detail-header">
@@ -863,6 +1041,27 @@ function DetailHeader({
           {teamMembers.map((m) => (
             <option key={m.id} value={m.id}>
               {m.display_name}
+            </option>
+          ))}
+        </select>
+      ) : null}
+      {parentCandidates && onChangeParent ? (
+        <select
+          className="workstream-parent-select"
+          value={parentId ?? ""}
+          disabled={parentDisabled}
+          onChange={(e) => onChangeParent(e.target.value || null)}
+          aria-label="Workstream parent"
+          title={
+            parentDisabled
+              ? "This workstream has children — unparent them before assigning a parent here."
+              : "Set a parent workstream"
+          }
+        >
+          <option value="">No parent</option>
+          {parentCandidates.map((w) => (
+            <option key={w.id} value={w.id}>
+              {w.title}
             </option>
           ))}
         </select>

--- a/src/file.ts
+++ b/src/file.ts
@@ -531,6 +531,10 @@ export type Workstream = {
    *  capped per workstream backend-side. Drives the External chip strip
    *  on the detail view and the "+N external" pill on the list card. */
   external_participants: ExternalParticipant[];
+  /** Optional parent workstream id (#89). `null` for top-level workstreams.
+   *  The hierarchy is flat 2-level — backend rejects writes that would
+   *  create a 3-level chain. */
+  parent_workstream_id: string | null;
 };
 
 export type ExternalParticipant = {
@@ -587,6 +591,10 @@ export type WorkstreamDetail = Workstream & {
   notes: WorkstreamNoteRef[];
   actions: WorkstreamAction[];
   links: WorkstreamLink[];
+  /** Direct children when this workstream is a parent (#89). Empty for
+   *  leaves and standalones. Lean `Workstream` shape — counts and
+   *  members already populated. Ordered by last_activity_ms desc. */
+  children: Workstream[];
 };
 
 export type ClusterReport = {
@@ -665,6 +673,18 @@ export async function setWorkstreamOwner(
   ownerMemberId: string | null,
 ): Promise<void> {
   await invoke<void>("set_workstream_owner", { id, ownerMemberId });
+}
+
+/** Set or clear a workstream's parent (#89). Pass `null` to make it a
+ *  top-level standalone. Backend enforces the 2-level cap and surfaces
+ *  validation failures (self-parent, would-be-grandparent, current
+ *  workstream already has children, parent doesn't exist) as a thrown
+ *  Error string the caller should display. */
+export async function setWorkstreamParent(
+  id: string,
+  parentId: string | null,
+): Promise<void> {
+  await invoke<void>("set_workstream_parent", { id, parentId });
 }
 
 // --- Workstream links (#88) ----------------------------------------------


### PR DESCRIPTION
## Summary

Adds a flat 2-level hierarchy on workstreams. Today the synthesizer fans sibling efforts (Bridge / Talgo / CompTIA / Siegfried) that conceptually share an umbrella; this PR lets both the user and Claude assign a parent so the list view nests them, the detail view rolls up children, and AI ask can answer "how's Bridge going?" across the whole umbrella.

Closes #89.

## Approach

- **Schema (`migrations/019`)**: `ALTER TABLE workstreams ADD COLUMN parent_workstream_id` (nullable, FK with `ON DELETE SET NULL`) + index. New column is NULL on every existing row — no backfill.
- **2-level cap in code, not schema** via `validate_proposed_parent`: rejects self-parent, would-be-grandparent (target already has its own parent), "self has children" (would push them to a third level), and unknown parent ids. Same helper used by both the manual UI write (`set_workstream_parent`) and the synthesizer write path (`parent_id` field on `SynthesizedWorkstream`).
- **Reparent-with-children: reject, don't cascade.** UI surfaces "this workstream has children — unparent them first" rather than silently auto-unparenting.
- **Synthesizer ship-now**: existing-workstreams prompt section renders parents with children indented under "↳"; system prompt schema documents `parent_id`; parser captures it. `parent_id` only takes effect on newly-spawned workstreams — user authority preserved on existing rows (same pattern as `user_notes` / `owner_member_id`).
- **Synthesizer ship-later (separate follow-up)**: proactive "encourage Claude to propose new parents" prompt nudge.
- **AI ask integration**: `format_workstream_detail` emits a `## Children` section after `Recent notes` when non-empty. Title + summary + open-action count per child. No per-child hydration. Skipped the optional separate `read_workstream_rollup` tool — inline children get to the rollup answer.
- **Frontend**: backend stays flat; `Workstreams.tsx` groups client-side via `renderHierarchical` (parents/standalones in input order, children inline-indented under each parent). `WorkstreamCard` accepts a `nested` prop for the indent + "↳" marker. Detail header gains a parent picker next to the status pill (disabled with tooltip when the current workstream has children). Breadcrumb `[Parent] › [This]` above the title navigates up. `ChildrenSection` at the end of a parent's detail view lists child cards.

## Files

| Path | Change |
|------|--------|
| `src-tauri/src/migrations/019_workstream_parent.sql` | NEW — ALTER TABLE + index |
| `src-tauri/src/index.rs` | Wire `SCHEMA_V19`; bump `SCHEMA_VERSION` to 19 |
| `src-tauri/src/workstreams/mod.rs` | `Workstream.parent_workstream_id`; `WorkstreamDetail.children` |
| `src-tauri/src/workstreams/persist.rs` | SELECT `parent_workstream_id` in 4 list builders + `get_workstream_one`; `list_children_of`; `validate_proposed_parent` + `set_workstream_parent`; sanitize `parent_id` in `write_workstream`; extend `SynthesizedWorkstream` |
| `src-tauri/src/workstreams/synthesizer.rs` | Hierarchical existing-workstreams section; mention `parent_id` in schema text; parse `parent_id` from `RawWorkstream` |
| `src-tauri/src/workstreams/commands.rs` | `set_workstream_parent` Tauri command |
| `src-tauri/src/lib.rs` | Register the new command |
| `src-tauri/src/ask.rs` | `format_workstream_detail` emits `## Children` after `Recent notes` |
| `src/file.ts` | `Workstream.parent_workstream_id`; `WorkstreamDetail.children`; `setWorkstreamParent` wrapper |
| `src/Workstreams.tsx` | List grouping; nested `WorkstreamCard`; breadcrumb + parent picker + `ChildrenSection` in detail view |
| `src/App.css` | `.workstream-card.nested`, breadcrumb, parent picker, children-section styles |

## Test plan

- [x] `cargo test --lib` — 252 passed (was 239; +13 new)
- [x] **New persist tests**: happy-path set+clear; rejects self-parent, grandparent chain, has-children, unknown parent id; `get_workstream_detail` empty children for leaves and ordered children for parents; FK `SET NULL` cascade on parent delete; `write_workstream` drops invalid `parent_id` and preserves user-set parent on resync; `list_workstreams_active` populates `parent_workstream_id`.
- [x] **New ask.rs tests**: `## Children` section emitted with action-count phrasing; section skipped when children empty.
- [x] `bun run build` — TS + Vite clean.
- [ ] Manual: `bun tauri dev`, two workstreams A and B exist standalone. On B's detail view, set parent = A → list view nests B under A, B's detail shows the `[A] › [B]` breadcrumb, A's detail shows the Children section listing B. Try setting B as A's parent — UI rejects with the "has children" message. Delete A → B becomes standalone (FK SET NULL). Ask the AI palette "how's [A] going?" — answer rolls up B's status.

## Out of scope (per issue)

- 3+ levels of nesting.
- Drag-and-drop reorganization.
- Cascading archive (each child decides its own status).
- Member-filter UI changes (no member-filter exists today).
- Synthesizer prompt enhancement that proactively encourages Claude to propose *new* parent groupings — separate follow-up.
- Optional separate `read_workstream_rollup` tool (inline `## Children` covers the rollup answer).
- Collapse-by-default `▶ N children` toggle (chosen against in plan review; revisit if real parents grow >5 children).