### PR TITLE
External participants on workstreams

### DIFF
--- a/src-tauri/src/ask.rs
+++ b/src-tauri/src/ask.rs
@@ -1192,6 +1192,25 @@ fn format_workstream_detail(
         }
     }
 
+    // External participants (#?) — email addresses on the workstream's
+    // emails / events that don't resolve to a team_member. Lets the
+    // model answer "who else is on Bridge?" without us having to
+    // re-render every email. Cap mirrors the per-workstream cap in
+    // `attach_external_participants`; no truncation suffix because
+    // that cap already bounds the list.
+    if !detail.workstream.external_participants.is_empty() {
+        let externals: Vec<String> = detail
+            .workstream
+            .external_participants
+            .iter()
+            .map(|p| match p.display_name.as_deref().filter(|n| !n.trim().is_empty()) {
+                Some(name) => format!("{name} <{}>", p.email),
+                None => p.email.clone(),
+            })
+            .collect();
+        s.push_str(&format!("External: {}\n", externals.join(", ")));
+    }
+
     // User-authored notes are ground truth (#77). Surface in full near
     // the top so the model reads them before reasoning about the
     // synthesized summary or any inferred state.
@@ -1790,6 +1809,7 @@ mod tests {
             note_count: 0,
             open_action_count: 0,
             link_count: 0,
+            external_participants: Vec::new(),
         }
     }
 
@@ -1882,6 +1902,7 @@ mod tests {
                 note_count: 1,
                 open_action_count: 1,
                 link_count: 0,
+                external_participants: Vec::new(),
             },
             emails: vec![
                 make_email("m1", "Re: invoice", 1000),
@@ -1937,7 +1958,8 @@ mod tests {
                 event_count: 0,
                 note_count: 0,
                 open_action_count: 0,
-            link_count: 0,
+                link_count: 0,
+                external_participants: Vec::new(),
             },
             emails,
             events: vec![],
@@ -1994,7 +2016,8 @@ mod tests {
                 event_count: 0,
                 note_count: 0,
                 open_action_count: 0,
-            link_count: 0,
+                link_count: 0,
+                external_participants: Vec::new(),
             },
             emails: vec![],
             events: vec![],
@@ -2032,7 +2055,8 @@ mod tests {
                 event_count: 0,
                 note_count: 0,
                 open_action_count: 0,
-            link_count: 0,
+                link_count: 0,
+                external_participants: Vec::new(),
             },
             emails: vec![],
             events: vec![],
@@ -2066,6 +2090,7 @@ mod tests {
                 note_count: 0,
                 open_action_count: 1,
                 link_count: 2,
+                external_participants: Vec::new(),
             },
             emails: vec![],
             events: vec![],
@@ -2131,6 +2156,7 @@ mod tests {
                 note_count: 0,
                 open_action_count: 0,
                 link_count: 0,
+                external_participants: Vec::new(),
             },
             emails: vec![],
             events: vec![],
@@ -2141,5 +2167,49 @@ mod tests {
         let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let out = format_workstream_detail("W5", &detail, &team_map);
         assert!(!out.contains("## Links"));
+    }
+
+    #[test]
+    fn format_workstream_detail_renders_external_line() {
+        let mut workstream = make_ws("ws_e", "Hyundai POC", "", 0);
+        workstream.external_participants = vec![
+            crate::workstreams::ExternalParticipant {
+                email: "alice@example.com".into(),
+                display_name: Some("Alice".into()),
+                count: 3,
+            },
+            crate::workstreams::ExternalParticipant {
+                email: "bob@example.com".into(),
+                display_name: None,
+                count: 1,
+            },
+        ];
+        let detail = WorkstreamDetail {
+            workstream,
+            emails: vec![],
+            events: vec![],
+            notes: vec![],
+            actions: vec![],
+            links: Vec::new(),
+        };
+        let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let out = format_workstream_detail("W6", &detail, &team_map);
+        assert!(out.contains("External: Alice <alice@example.com>, bob@example.com\n"));
+    }
+
+    #[test]
+    fn format_workstream_detail_skips_external_line_when_empty() {
+        let workstream = make_ws("ws_e", "Hyundai POC", "", 0);
+        let detail = WorkstreamDetail {
+            workstream,
+            emails: vec![],
+            events: vec![],
+            notes: vec![],
+            actions: vec![],
+            links: Vec::new(),
+        };
+        let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let out = format_workstream_detail("W7", &detail, &team_map);
+        assert!(!out.contains("External:"));
     }
 }

--- a/src-tauri/src/workstreams/mod.rs
+++ b/src-tauri/src/workstreams/mod.rs
@@ -74,6 +74,30 @@ pub struct Workstream {
     /// link-icon badge on the list card; the actual links land in
     /// `WorkstreamDetail.links` on detail-view fetch.
     pub link_count: u32,
+    /// Email addresses that participate in the workstream's emails or
+    /// events but don't resolve to any team_member. Sorted by signal
+    /// count desc; deduped case-insensitively. Capped per workstream
+    /// (see `EXTERNAL_PARTICIPANT_CAP` in `persist.rs`). Drives the
+    /// "External" chip strip on the detail view and the "+N external"
+    /// pill on the list card.
+    pub external_participants: Vec<ExternalParticipant>,
+}
+
+/// One email address that participates in a workstream but has no
+/// corresponding `team_member` (no team_member_id on the recipient /
+/// attendee row, and — for senders — no matching `team_member_aliases`
+/// entry of kind 'email'). Surfaces external counterparties on the
+/// workstream detail + list views.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExternalParticipant {
+    /// Lowercased canonical email.
+    pub email: String,
+    /// First non-null display name encountered across the joined rows.
+    /// `None` when only the bare address is known.
+    pub display_name: Option<String>,
+    /// Number of signals (emails + events) that involve this address.
+    /// Used to sort the chip strip — frequent counterparties first.
+    pub count: u32,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/src/workstreams/persist.rs
+++ b/src-tauri/src/workstreams/persist.rs
@@ -9,7 +9,10 @@
 use rusqlite::{params, Connection, OptionalExtension};
 use sha2::{Digest, Sha256};
 
-use super::{NoteRef, WorkstreamDetail, Workstream, WorkstreamAction, WorkstreamLink, WriteCounts};
+use super::{
+    ExternalParticipant, NoteRef, Workstream, WorkstreamAction, WorkstreamDetail, WorkstreamLink,
+    WriteCounts,
+};
 use crate::connectors::calendar;
 use crate::connectors::email;
 
@@ -99,6 +102,7 @@ pub fn list_workstreams_active(conn: &Connection) -> rusqlite::Result<Vec<Workst
             note_count: r.get::<_, i64>(13)? as u32,
             open_action_count: r.get::<_, i64>(14)? as u32,
             link_count: r.get::<_, i64>(15)? as u32,
+            external_participants: Vec::new(),
         })
     })?;
     let mut out = Vec::new();
@@ -106,6 +110,7 @@ pub fn list_workstreams_active(conn: &Connection) -> rusqlite::Result<Vec<Workst
         out.push(row?);
     }
     attach_members(conn, &mut out)?;
+    attach_external_participants(conn, &mut out)?;
     Ok(out)
 }
 
@@ -145,6 +150,7 @@ pub fn list_workstreams_archived(
             note_count: r.get::<_, i64>(13)? as u32,
             open_action_count: r.get::<_, i64>(14)? as u32,
             link_count: r.get::<_, i64>(15)? as u32,
+            external_participants: Vec::new(),
         })
     })?;
     let mut out = Vec::new();
@@ -152,6 +158,7 @@ pub fn list_workstreams_archived(
         out.push(row?);
     }
     attach_members(conn, &mut out)?;
+    attach_external_participants(conn, &mut out)?;
     Ok(out)
 }
 
@@ -201,6 +208,7 @@ pub fn list_workstreams_for_synthesis(
                 note_count: r.get::<_, i64>(13)? as u32,
                 open_action_count: r.get::<_, i64>(14)? as u32,
                 link_count: r.get::<_, i64>(15)? as u32,
+                external_participants: Vec::new(),
             },
             is_archived,
         ))
@@ -209,12 +217,15 @@ pub fn list_workstreams_for_synthesis(
     for row in rows {
         out.push(row?);
     }
-    // Attach members to the workstreams (mutating in place via a
+    // Attach members + external participants (mutating in place via a
     // throwaway view onto just the Workstream side of the tuple).
     let mut just_ws: Vec<Workstream> = out.iter().map(|(w, _)| w.clone()).collect();
     attach_members(conn, &mut just_ws)?;
+    attach_external_participants(conn, &mut just_ws)?;
     for (i, (w, _)) in out.iter_mut().enumerate() {
         w.members = std::mem::take(&mut just_ws[i].members);
+        w.external_participants =
+            std::mem::take(&mut just_ws[i].external_participants);
     }
     Ok(out)
 }
@@ -393,12 +404,14 @@ fn get_workstream_one(conn: &Connection, id: &str) -> rusqlite::Result<Option<Wo
                 note_count: r.get::<_, i64>(13)? as u32,
                 open_action_count: r.get::<_, i64>(14)? as u32,
                 link_count: r.get::<_, i64>(15)? as u32,
+                external_participants: Vec::new(),
             })
         })
         .optional()?;
     if let Some(ref mut w) = ws {
         let mut single = vec![std::mem::take(w)];
         attach_members(conn, &mut single)?;
+        attach_external_participants(conn, &mut single)?;
         *w = single.pop().unwrap();
     }
     Ok(ws)
@@ -457,6 +470,107 @@ fn attach_members(
     for w in workstreams.iter_mut() {
         if let Some(members) = by_id.remove(&w.id) {
             w.members = members;
+        }
+    }
+    Ok(())
+}
+
+/// Cap on per-workstream external participants. Bounds the chip strip
+/// + the AI-ask `External:` line — most workstreams have a handful of
+/// counterparties; long mailing-list threads can produce hundreds, and
+/// we want to surface the top recurring ones, not all of them.
+const EXTERNAL_PARTICIPANT_CAP: usize = 12;
+
+/// Bulk-derive external participants for a slice of workstreams (#?). An
+/// "external participant" is an email address that appears in the
+/// workstream's emails (recipients OR senders) or events (attendees)
+/// but does NOT resolve to a `team_member`. Resolution rules:
+///
+///   * recipient/attendee rows are excluded when `team_member_id IS
+///     NOT NULL` (sync-time resolution already mapped them).
+///   * sender rows on `email_messages.from_email` are excluded when a
+///     `team_member_aliases` row of kind 'email' matches the lowercased
+///     address. (The senders path is the only place we re-check by
+///     alias; the existing `attach_members` does not surface senders
+///     at all today, which is a pre-existing gap not addressed here.)
+///
+/// The result is deduplicated case-insensitively by email; display
+/// name is the first non-null encountered. Per-workstream count =
+/// number of signal rows the email appeared on; ordered count desc,
+/// email asc, capped at `EXTERNAL_PARTICIPANT_CAP`.
+fn attach_external_participants(
+    conn: &Connection,
+    workstreams: &mut [Workstream],
+) -> rusqlite::Result<()> {
+    if workstreams.is_empty() {
+        return Ok(());
+    }
+    let placeholders = std::iter::repeat("?")
+        .take(workstreams.len())
+        .collect::<Vec<_>>()
+        .join(",");
+    // Three halves: recipients (no team_member), senders (no matching
+    // email-kind alias), attendees (no team_member). Each emits one row
+    // per signal occurrence so the outer GROUP BY can count.
+    let sql = format!(
+        "SELECT workstream_id, email_lc, MAX(display_name) AS display_name, COUNT(*) AS cnt FROM ( \
+            SELECT ws.workstream_id, LOWER(er.email) AS email_lc, er.display_name \
+            FROM workstream_signals ws \
+            JOIN email_recipients er ON er.message_id = ws.item_id \
+            WHERE ws.kind = 'email' AND ws.workstream_id IN ({placeholders}) \
+              AND er.team_member_id IS NULL \
+            UNION ALL \
+            SELECT ws.workstream_id, LOWER(em.from_email) AS email_lc, em.from_name AS display_name \
+            FROM workstream_signals ws \
+            JOIN email_messages em ON em.id = ws.item_id \
+            WHERE ws.kind = 'email' AND ws.workstream_id IN ({placeholders}) \
+              AND NOT EXISTS ( \
+                SELECT 1 FROM team_member_aliases tma \
+                WHERE tma.kind = 'email' AND LOWER(tma.value) = LOWER(em.from_email) \
+              ) \
+            UNION ALL \
+            SELECT ws.workstream_id, LOWER(ca.email) AS email_lc, ca.display_name \
+            FROM workstream_signals ws \
+            JOIN calendar_attendees ca ON ca.event_id = ws.item_id \
+            WHERE ws.kind = 'event' AND ws.workstream_id IN ({placeholders}) \
+              AND ca.team_member_id IS NULL \
+         ) \
+         WHERE email_lc IS NOT NULL AND email_lc <> '' \
+         GROUP BY workstream_id, email_lc \
+         ORDER BY workstream_id, cnt DESC, email_lc ASC"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut params_vec: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(workstreams.len() * 3);
+    for _ in 0..3 {
+        for w in workstreams.iter() {
+            params_vec.push(&w.id as &dyn rusqlite::ToSql);
+        }
+    }
+    let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), |r| {
+        Ok((
+            r.get::<_, String>(0)?,        // workstream_id
+            r.get::<_, String>(1)?,        // email_lc
+            r.get::<_, Option<String>>(2)?, // display_name
+            r.get::<_, i64>(3)?,           // count
+        ))
+    })?;
+    let mut by_id: std::collections::HashMap<String, Vec<ExternalParticipant>> =
+        std::collections::HashMap::new();
+    for row in rows {
+        let (ws_id, email, display_name, count) = row?;
+        let bucket = by_id.entry(ws_id).or_default();
+        if bucket.len() >= EXTERNAL_PARTICIPANT_CAP {
+            continue;
+        }
+        bucket.push(ExternalParticipant {
+            email,
+            display_name: display_name.filter(|s| !s.trim().is_empty()),
+            count: count as u32,
+        });
+    }
+    for w in workstreams.iter_mut() {
+        if let Some(externals) = by_id.remove(&w.id) {
+            w.external_participants = externals;
         }
     }
     Ok(())
@@ -1659,5 +1773,245 @@ mod tests {
         let listed = list_workstreams_active(&conn).unwrap();
         let row = listed.iter().find(|w| w.id == "ws_l").expect("present");
         assert_eq!(row.link_count, 2);
+    }
+
+    // ----- External participants ----------------------------------------
+
+    /// Seed a workstream + an email-kind signal so the per-pivot
+    /// queries have something to join against. Returns the workstream
+    /// id for chaining test asserts.
+    fn seed_workstream_with_email_signal(
+        conn: &mut Connection,
+        ws_id: &str,
+        email_id: &str,
+    ) {
+        conn.execute(
+            "INSERT INTO workstreams(id, title, summary, status, last_activity_ms, created_ms, updated_ms) \
+             VALUES (?1, 'WS', '', 'active', 0, 0, 0)",
+            params![ws_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO workstream_signals(workstream_id, kind, item_id, added_ms) \
+             VALUES (?1, 'email', ?2, 0)",
+            params![ws_id, email_id],
+        )
+        .unwrap();
+    }
+
+    fn add_recipient(
+        conn: &Connection,
+        message_id: &str,
+        email: &str,
+        display_name: Option<&str>,
+        team_member_id: Option<&str>,
+    ) {
+        conn.execute(
+            "INSERT INTO email_recipients(message_id, email, display_name, recipient_type, team_member_id) \
+             VALUES (?1, ?2, ?3, 'to', ?4)",
+            params![message_id, email, display_name, team_member_id],
+        )
+        .unwrap();
+    }
+
+    /// Seed a member into the (test) team_members table so FKs from
+    /// `email_recipients.team_member_id` resolve. Tests can then mark
+    /// recipients as resolved by passing this id.
+    fn seed_team_member(conn: &Connection, id: &str) {
+        conn.execute(
+            "INSERT INTO team_members(id) VALUES (?1)",
+            params![id],
+        )
+        .unwrap();
+    }
+
+    /// Seed an email-kind alias on a team member so the externals
+    /// query's NOT EXISTS check excludes that address from senders.
+    fn seed_email_alias(conn: &Connection, member_id: &str, email: &str) {
+        conn.execute(
+            "INSERT INTO team_member_aliases(member_id, kind, value) \
+             VALUES (?1, 'email', ?2)",
+            params![member_id, email],
+        )
+        .unwrap();
+    }
+
+    /// Replace the auto-seeded sender on a previously-`seed_email`-ed row.
+    /// Lets tests vary `from_email` per case without re-implementing
+    /// the seed helper.
+    fn set_email_sender(conn: &Connection, message_id: &str, from_email: &str) {
+        conn.execute(
+            "UPDATE email_messages SET from_email = ?2 WHERE id = ?1",
+            params![message_id, from_email],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn external_participants_lists_recipients_with_null_team_id() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+        set_email_sender(&conn, "mg:test::m1", "internal-noreply@x.io");
+        // Two external recipients (no team_member_id) and one resolved.
+        seed_team_member(&conn, "tm_tom");
+        add_recipient(&conn, "mg:test::m1", "alice@example.com", Some("Alice"), None);
+        add_recipient(&conn, "mg:test::m1", "bob@example.com", None, None);
+        add_recipient(&conn, "mg:test::m1", "tom@x.io", Some("Tom"), Some("tm_tom"));
+        // Mark the sender as a known team member by alias so it doesn't
+        // pollute the externals.
+        seed_team_member(&conn, "tm_noreply");
+        seed_email_alias(&conn, "tm_noreply", "internal-noreply@x.io");
+
+        seed_workstream_with_email_signal(&mut conn, "ws_x", "mg:test::m1");
+
+        let listed = list_workstreams_active(&conn).unwrap();
+        let row = listed.iter().find(|w| w.id == "ws_x").unwrap();
+        let emails: Vec<&str> = row
+            .external_participants
+            .iter()
+            .map(|p| p.email.as_str())
+            .collect();
+        assert_eq!(
+            emails,
+            vec!["alice@example.com", "bob@example.com"],
+            "only the unresolved recipients surface; team_member rows are filtered"
+        );
+        assert_eq!(
+            row.external_participants[0].display_name.as_deref(),
+            Some("Alice")
+        );
+        assert!(row.external_participants[1].display_name.is_none());
+    }
+
+    #[test]
+    fn external_participants_includes_senders_with_no_team_alias() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+        // Sender has no matching team_member_aliases entry.
+        set_email_sender(&conn, "mg:test::m1", "Outsider@External.com");
+        // Recipients are all team members so they don't dominate the
+        // signal — we want to verify the sender path on its own.
+        seed_team_member(&conn, "tm_tom");
+        add_recipient(&conn, "mg:test::m1", "tom@x.io", Some("Tom"), Some("tm_tom"));
+
+        seed_workstream_with_email_signal(&mut conn, "ws_x", "mg:test::m1");
+
+        let listed = list_workstreams_active(&conn).unwrap();
+        let row = listed.iter().find(|w| w.id == "ws_x").unwrap();
+        let emails: Vec<&str> = row
+            .external_participants
+            .iter()
+            .map(|p| p.email.as_str())
+            .collect();
+        assert_eq!(
+            emails,
+            vec!["outsider@external.com"],
+            "sender lowercased + included when no email-alias matches"
+        );
+    }
+
+    #[test]
+    fn external_participants_excludes_team_member_senders() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+        set_email_sender(&conn, "mg:test::m1", "Tom@X.io");
+        seed_team_member(&conn, "tm_tom");
+        seed_email_alias(&conn, "tm_tom", "tom@x.io");
+        // Add an external recipient so the helper has SOMETHING to
+        // surface — keeps the assertion clear.
+        add_recipient(&conn, "mg:test::m1", "alice@example.com", None, None);
+
+        seed_workstream_with_email_signal(&mut conn, "ws_x", "mg:test::m1");
+
+        let listed = list_workstreams_active(&conn).unwrap();
+        let row = listed.iter().find(|w| w.id == "ws_x").unwrap();
+        let emails: Vec<&str> = row
+            .external_participants
+            .iter()
+            .map(|p| p.email.as_str())
+            .collect();
+        assert_eq!(
+            emails,
+            vec!["alice@example.com"],
+            "team-member senders excluded by NOT EXISTS alias check"
+        );
+    }
+
+    #[test]
+    fn external_participants_dedupes_case_insensitively_and_picks_a_display_name() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+        seed_email(&conn, "mg:test::m2", 2_000);
+        set_email_sender(&conn, "mg:test::m1", "system@noreply.io");
+        set_email_sender(&conn, "mg:test::m2", "system@noreply.io");
+        seed_team_member(&conn, "tm_noreply");
+        seed_email_alias(&conn, "tm_noreply", "system@noreply.io");
+        // Same external email across two messages, varying case + null name.
+        add_recipient(&conn, "mg:test::m1", "Alice@Example.com", Some("Alice"), None);
+        add_recipient(&conn, "mg:test::m2", "alice@example.com", None, None);
+
+        conn.execute(
+            "INSERT INTO workstreams(id, title, summary, status, last_activity_ms, created_ms, updated_ms) \
+             VALUES ('ws_x', 'WS', '', 'active', 0, 0, 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO workstream_signals(workstream_id, kind, item_id, added_ms) \
+             VALUES ('ws_x', 'email', 'mg:test::m1', 0), \
+                    ('ws_x', 'email', 'mg:test::m2', 0)",
+            [],
+        )
+        .unwrap();
+
+        let listed = list_workstreams_active(&conn).unwrap();
+        let row = listed.iter().find(|w| w.id == "ws_x").unwrap();
+        assert_eq!(row.external_participants.len(), 1, "deduped case-insensitively");
+        let p = &row.external_participants[0];
+        assert_eq!(p.email, "alice@example.com");
+        assert_eq!(p.display_name.as_deref(), Some("Alice"));
+        assert_eq!(p.count, 2);
+    }
+
+    #[test]
+    fn external_participants_orders_by_count_desc() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+        seed_email(&conn, "mg:test::m2", 2_000);
+        seed_email(&conn, "mg:test::m3", 3_000);
+        for id in ["mg:test::m1", "mg:test::m2", "mg:test::m3"] {
+            set_email_sender(&conn, id, "noreply@x.io");
+        }
+        seed_team_member(&conn, "tm_noreply");
+        seed_email_alias(&conn, "tm_noreply", "noreply@x.io");
+        // bob shows up on 1 message, alice on 3.
+        add_recipient(&conn, "mg:test::m1", "alice@x.io", None, None);
+        add_recipient(&conn, "mg:test::m2", "alice@x.io", None, None);
+        add_recipient(&conn, "mg:test::m3", "alice@x.io", None, None);
+        add_recipient(&conn, "mg:test::m1", "bob@x.io", None, None);
+
+        conn.execute(
+            "INSERT INTO workstreams(id, title, summary, status, last_activity_ms, created_ms, updated_ms) \
+             VALUES ('ws_x', 'WS', '', 'active', 0, 0, 0)",
+            [],
+        )
+        .unwrap();
+        for id in ["mg:test::m1", "mg:test::m2", "mg:test::m3"] {
+            conn.execute(
+                "INSERT INTO workstream_signals(workstream_id, kind, item_id, added_ms) \
+                 VALUES ('ws_x', 'email', ?1, 0)",
+                params![id],
+            )
+            .unwrap();
+        }
+
+        let listed = list_workstreams_active(&conn).unwrap();
+        let row = listed.iter().find(|w| w.id == "ws_x").unwrap();
+        let pairs: Vec<(&str, u32)> = row
+            .external_participants
+            .iter()
+            .map(|p| (p.email.as_str(), p.count))
+            .collect();
+        assert_eq!(pairs, vec![("alice@x.io", 3), ("bob@x.io", 1)]);
     }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -5110,6 +5110,64 @@ input.nh-title {
 .workstream-member-name {
   padding-right: 2px;
 }
+
+/* External participants strip — sits below members on the detail
+   view. Visually muted (transparent background, dashed border) so it
+   reads as "people we don't know about" without competing with the
+   solid member chips. */
+.workstream-externals-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 4px 0;
+}
+.workstream-externals-label {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  margin-right: 2px;
+}
+.workstream-external-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 9px;
+  border-radius: 12px;
+  background: transparent;
+  border: 0.5px dashed var(--home-line);
+  font-size: 11.5px;
+  color: var(--fg-muted);
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.workstream-externals-overflow {
+  font-size: 11.5px;
+  color: var(--fg-muted);
+  padding: 2px 4px;
+}
+
+/* List-card "+N external" pill (#?). Sits next to the link/reopened
+   badges in the card header. Muted treatment matching the externals
+   chip so the eye groups them together. */
+.workstream-card-externals-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 8px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: transparent;
+  border: 0.5px dashed var(--home-line);
+  color: var(--fg-muted);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  vertical-align: middle;
+}
+
 .workstream-card-counts {
   font-size: 12px;
   color: var(--fg-muted);

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -12,6 +12,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 
 import {
   type EmailMessage,
+  type ExternalParticipant,
   LinkKind,
   type TeamMember,
   type Workstream,
@@ -302,6 +303,23 @@ function WorkstreamCard({
             >
               <IconLink size={11} sw={1.8} />
               {w.link_count}
+            </span>
+          ) : null}
+          {w.external_participants.length > 0 ? (
+            <span
+              className="workstream-card-externals-badge"
+              aria-label={`${w.external_participants.length} external participant${w.external_participants.length === 1 ? "" : "s"}`}
+              title={
+                w.external_participants
+                  .slice(0, 5)
+                  .map((p) => p.display_name?.trim() || p.email)
+                  .join(", ") +
+                (w.external_participants.length > 5
+                  ? `, +${w.external_participants.length - 5} more`
+                  : "")
+              }
+            >
+              +{w.external_participants.length} external
             </span>
           ) : null}
         </span>
@@ -632,6 +650,10 @@ function WorkstreamDetailView({
         />
       ) : null}
 
+      {detail.external_participants.length > 0 ? (
+        <ExternalsStrip externals={detail.external_participants} />
+      ) : null}
+
       <WorkstreamUserNotes
         workstreamId={detail.id}
         initialNotes={detail.user_notes}
@@ -923,6 +945,35 @@ function MembersStrip({
           </span>
         );
       })}
+    </section>
+  );
+}
+
+// ----- External participants ---------------------------------------------
+
+const EXTERNAL_VISIBLE_CAP = 8;
+
+function ExternalsStrip({ externals }: { externals: ExternalParticipant[] }) {
+  const visible = externals.slice(0, EXTERNAL_VISIBLE_CAP);
+  const overflow = externals.length - visible.length;
+  return (
+    <section className="workstream-externals-strip">
+      <span className="workstream-externals-label">External</span>
+      {visible.map((p) => {
+        const display = p.display_name?.trim() || p.email;
+        return (
+          <span
+            key={p.email}
+            className="workstream-external-chip"
+            title={p.display_name ? `${p.display_name} <${p.email}>` : p.email}
+          >
+            {display}
+          </span>
+        );
+      })}
+      {overflow > 0 ? (
+        <span className="workstream-externals-overflow">+{overflow}</span>
+      ) : null}
     </section>
   );
 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -526,6 +526,21 @@ export type Workstream = {
   /** User-curated external link count (#88). Drives the small link-icon
    *  badge on the list card; the actual links land on WorkstreamDetail. */
   link_count: number;
+  /** Email addresses participating in the workstream's emails / events
+   *  that don't resolve to a team_member. Sorted by signal count desc;
+   *  capped per workstream backend-side. Drives the External chip strip
+   *  on the detail view and the "+N external" pill on the list card. */
+  external_participants: ExternalParticipant[];
+};
+
+export type ExternalParticipant = {
+  /** Lowercased canonical email. */
+  email: string;
+  /** First non-null display name encountered. `null` when only the
+   *  bare address is known. */
+  display_name: string | null;
+  /** Number of signals (emails + events) involving this address. */
+  count: number;
 };
 
 export type WorkstreamAction = {


### PR DESCRIPTION
## Summary

Surfaces email addresses that participate in a workstream's emails or events but don't resolve to any team_member. Renders as a muted "External" chip strip below the team-member strip on the detail view, a "+N external" pill on the list card, and an "External:" line in `read_workstream` output for AI ask.

Branched off main; touches no migration. Independent of #96 (workstream hierarchy) — though both modify the `Workstream` row builder, the conflicts are mechanical (one extra field append) and resolve trivially in either merge order.

## Approach

- **No schema change.** Computed on read from existing rows: `email_recipients`, `email_messages.from_email`, `calendar_attendees`.
- **`ExternalParticipant { email, display_name, count }`** added to the `Workstream` struct. Email is lowercased canonical; display_name is the first non-null encountered; count = number of signal rows the address appears on.
- **`attach_external_participants`** mirrors the shape of the existing `attach_members` but unions over three sources:
  - `email_recipients` joined to the workstream's email-kind signals where `team_member_id IS NULL`
  - `email_messages.from_email` joined to email-kind signals where `NOT EXISTS` against `team_member_aliases` (kind='email'). This closes a pre-existing gap — senders never surface in `attach_members` either; we only include them on the externals path.
  - `calendar_attendees` joined to event-kind signals where `team_member_id IS NULL`.
  Deduped case-insensitively. Capped at 12 per workstream. Ordered `count DESC, email ASC`.
- **Wired into all 4 list builders + `get_workstream_one`**, plus the synthesizer's `list_workstreams_for_synthesis` (with `std::mem::take` symmetry with `attach_members`).
- **`format_workstream_detail`** emits an `External:` line under the existing `Members:` line when non-empty: `External: Alice <alice@example.com>, bob@example.com`.
- **UI**: new `ExternalsStrip` below `MembersStrip` on the detail view (8 chips visible, "+N" overflow), plus a list-card "+N external" pill in the card header. Both visually muted (dashed border, fg-muted color) so they read as "people we don't know yet" without competing with the solid member chips.

## Out of scope

- Filtering noisy automated addresses (`noreply@…`, calendar mailers). Start showing everything; add a denylist later if needed.
- "Promote external to team member" inline action — wire the existing IdentitiesModal as the destination later.
- Fixing the team-member-sender gap in `attach_members` itself (same UNION pattern would need to land there too — separate small follow-up).
- Synthesizer prompt awareness — defer until cluster quality measurably benefits.

## Test plan

- [x] `cargo test --lib` — 246 passed (was 239; +7 new)
- [x] **New persist tests**: lists null-team recipients only; includes senders without a team alias; excludes team-member senders by NOT EXISTS; dedupes case-insensitively and picks first non-null display name; orders by count desc.
- [x] **New ask.rs tests**: `External:` line rendered with `Display <email>` format; skipped when empty.
- [x] `bun run build` — TS + Vite clean.
- [ ] Manual: open a workstream with at least one email from / to an unknown sender → see the External strip + the list-card pill; ask the AI "who else is on X?" and confirm Claude cites the addresses via `read_workstream`.