### PR TITLE
External chip: alias-aware filter + click-to-act modal

### DIFF
--- a/src-tauri/src/workstreams/persist.rs
+++ b/src-tauri/src/workstreams/persist.rs
@@ -486,9 +486,20 @@ fn get_workstream_one(conn: &Connection, id: &str) -> rusqlite::Result<Option<Wo
 
 /// Bulk-derive members for a slice of workstreams (#81). Members are
 /// the team_member ids that resolve from the workstream's email
-/// recipients and event attendees. One UNION query covers all rows in
-/// the slice — far cheaper than per-workstream fetches in the list
-/// view. No-op when the slice is empty.
+/// recipients, email senders, and event attendees. One UNION query
+/// covers all rows in the slice — far cheaper than per-workstream
+/// fetches in the list view. No-op when the slice is empty.
+///
+/// Resolution paths (each becomes a UNION branch):
+///   1. recipient row with `team_member_id` already cached at sync time
+///   2. recipient row with NULL `team_member_id` but matching a
+///      `team_member_aliases` (kind='email') row added later — closes
+///      the "I added my email today, but old recipient rows haven't
+///      been re-synced" gap
+///   3. email sender (`em.from_email`) matched via aliases — senders
+///      were never recorded on `email_recipients`
+///   4. attendee row with `team_member_id` already cached
+///   5. attendee row with NULL `team_member_id` but matching an alias
 fn attach_members(
     conn: &Connection,
     workstreams: &mut [Workstream],
@@ -500,30 +511,56 @@ fn attach_members(
         .take(workstreams.len())
         .collect::<Vec<_>>()
         .join(",");
-    // Two halves UNION'd then DISTINCT'd at the (workstream, member) level.
-    // Each member appears once per workstream regardless of how many
-    // emails / events they're on.
+    // Five UNION branches (see fn doc): cached recipient, alias-matched
+    // recipient, alias-matched sender, cached attendee, alias-matched
+    // attendee. SQL `--` comments are deliberately omitted because the
+    // Rust `\`-line-continuation collapses newlines, leaving the
+    // comment running to the next `\n` we never emit.
     let sql = format!(
         "SELECT DISTINCT workstream_id, member_id FROM ( \
             SELECT ws.workstream_id, er.team_member_id AS member_id \
             FROM workstream_signals ws \
             JOIN email_recipients er ON er.message_id = ws.item_id \
-            WHERE ws.kind = 'email' AND ws.workstream_id IN ({placeholders}) AND er.team_member_id IS NOT NULL \
+            WHERE ws.kind = 'email' AND ws.workstream_id IN ({placeholders}) \
+              AND er.team_member_id IS NOT NULL \
+            UNION \
+            SELECT ws.workstream_id, tma.member_id AS member_id \
+            FROM workstream_signals ws \
+            JOIN email_recipients er ON er.message_id = ws.item_id \
+            JOIN team_member_aliases tma \
+              ON tma.kind = 'email' AND LOWER(tma.value) = LOWER(er.email) \
+            WHERE ws.kind = 'email' AND ws.workstream_id IN ({placeholders}) \
+              AND er.team_member_id IS NULL \
+            UNION \
+            SELECT ws.workstream_id, tma.member_id AS member_id \
+            FROM workstream_signals ws \
+            JOIN email_messages em ON em.id = ws.item_id \
+            JOIN team_member_aliases tma \
+              ON tma.kind = 'email' AND LOWER(tma.value) = LOWER(em.from_email) \
+            WHERE ws.kind = 'email' AND ws.workstream_id IN ({placeholders}) \
             UNION \
             SELECT ws.workstream_id, ca.team_member_id AS member_id \
             FROM workstream_signals ws \
             JOIN calendar_attendees ca ON ca.event_id = ws.item_id \
-            WHERE ws.kind = 'event' AND ws.workstream_id IN ({placeholders}) AND ca.team_member_id IS NOT NULL \
+            WHERE ws.kind = 'event' AND ws.workstream_id IN ({placeholders}) \
+              AND ca.team_member_id IS NOT NULL \
+            UNION \
+            SELECT ws.workstream_id, tma.member_id AS member_id \
+            FROM workstream_signals ws \
+            JOIN calendar_attendees ca ON ca.event_id = ws.item_id \
+            JOIN team_member_aliases tma \
+              ON tma.kind = 'email' AND LOWER(tma.value) = LOWER(ca.email) \
+            WHERE ws.kind = 'event' AND ws.workstream_id IN ({placeholders}) \
+              AND ca.team_member_id IS NULL \
          ) ORDER BY workstream_id"
     );
     let mut stmt = conn.prepare(&sql)?;
-    // The IN list appears twice in the UNION; bind both.
-    let mut params_vec: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(workstreams.len() * 2);
-    for w in workstreams.iter() {
-        params_vec.push(&w.id as &dyn rusqlite::ToSql);
-    }
-    for w in workstreams.iter() {
-        params_vec.push(&w.id as &dyn rusqlite::ToSql);
+    // The IN list appears five times in the UNION; bind each.
+    let mut params_vec: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(workstreams.len() * 5);
+    for _ in 0..5 {
+        for w in workstreams.iter() {
+            params_vec.push(&w.id as &dyn rusqlite::ToSql);
+        }
     }
     let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), |r| {
         Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
@@ -2119,6 +2156,54 @@ mod tests {
             emails,
             vec!["alice@example.com"],
             "team-member senders excluded by NOT EXISTS alias check"
+        );
+    }
+
+    /// Regression: `email_recipients.team_member_id` is set at sync time,
+    /// so when the user adds an email alias AFTER the email was synced,
+    /// old recipient rows still have NULL team_member_id. `attach_members`
+    /// must also resolve via the alias table; otherwise the team_member
+    /// drops out of the workstream's member list (and the user sees no
+    /// chip even though they're aliased).
+    #[test]
+    fn members_resolves_recipients_via_alias_when_team_member_id_is_stale() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+        seed_team_member(&conn, "tm_tj");
+        // Recipient row has NULL team_member_id (sync was before the
+        // user added their alias) but the alias now resolves it.
+        add_recipient(&conn, "mg:test::m1", "tj@example.com", Some("TJ"), None);
+        seed_email_alias(&conn, "tm_tj", "tj@example.com");
+
+        seed_workstream_with_email_signal(&mut conn, "ws_x", "mg:test::m1");
+
+        let listed = list_workstreams_active(&conn).unwrap();
+        let row = listed.iter().find(|w| w.id == "ws_x").unwrap();
+        assert!(
+            row.members.iter().any(|m| m == "tm_tj"),
+            "alias-resolved team member surfaces despite stale team_member_id; got members={:?}",
+            row.members
+        );
+    }
+
+    /// Mirror: senders never had a `team_member_id` column in the first
+    /// place. They should resolve via the alias table.
+    #[test]
+    fn members_resolves_email_senders_via_alias() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+        set_email_sender(&conn, "mg:test::m1", "TJ@Example.com");
+        seed_team_member(&conn, "tm_tj");
+        seed_email_alias(&conn, "tm_tj", "tj@example.com");
+
+        seed_workstream_with_email_signal(&mut conn, "ws_x", "mg:test::m1");
+
+        let listed = list_workstreams_active(&conn).unwrap();
+        let row = listed.iter().find(|w| w.id == "ws_x").unwrap();
+        assert!(
+            row.members.iter().any(|m| m == "tm_tj"),
+            "sender resolved via alias; got members={:?}",
+            row.members
         );
     }
 

--- a/src-tauri/src/workstreams/persist.rs
+++ b/src-tauri/src/workstreams/persist.rs
@@ -579,6 +579,14 @@ fn attach_external_participants(
     // Three halves: recipients (no team_member), senders (no matching
     // email-kind alias), attendees (no team_member). Each emits one row
     // per signal occurrence so the outer GROUP BY can count.
+    // For all three sources: a row is "external" only if the email
+    // doesn't match a team_member by alias. The sync-time
+    // `team_member_id` column on recipients/attendees is treated as a
+    // fast-path hint, but typed aliases added AFTER sync (#87) are not
+    // backfilled into those rows — so the alias NOT EXISTS check is
+    // the source of truth. Keep the `team_member_id IS NULL` filter
+    // too: it short-circuits before the correlated subquery for the
+    // common case.
     let sql = format!(
         "SELECT workstream_id, email_lc, MAX(display_name) AS display_name, COUNT(*) AS cnt FROM ( \
             SELECT ws.workstream_id, LOWER(er.email) AS email_lc, er.display_name \
@@ -586,6 +594,10 @@ fn attach_external_participants(
             JOIN email_recipients er ON er.message_id = ws.item_id \
             WHERE ws.kind = 'email' AND ws.workstream_id IN ({placeholders}) \
               AND er.team_member_id IS NULL \
+              AND NOT EXISTS ( \
+                SELECT 1 FROM team_member_aliases tma \
+                WHERE tma.kind = 'email' AND LOWER(tma.value) = LOWER(er.email) \
+              ) \
             UNION ALL \
             SELECT ws.workstream_id, LOWER(em.from_email) AS email_lc, em.from_name AS display_name \
             FROM workstream_signals ws \
@@ -601,6 +613,10 @@ fn attach_external_participants(
             JOIN calendar_attendees ca ON ca.event_id = ws.item_id \
             WHERE ws.kind = 'event' AND ws.workstream_id IN ({placeholders}) \
               AND ca.team_member_id IS NULL \
+              AND NOT EXISTS ( \
+                SELECT 1 FROM team_member_aliases tma \
+                WHERE tma.kind = 'email' AND LOWER(tma.value) = LOWER(ca.email) \
+              ) \
          ) \
          WHERE email_lc IS NOT NULL AND email_lc <> '' \
          GROUP BY workstream_id, email_lc \
@@ -2103,6 +2119,49 @@ mod tests {
             emails,
             vec!["alice@example.com"],
             "team-member senders excluded by NOT EXISTS alias check"
+        );
+    }
+
+    /// Regression: `email_recipients.team_member_id` is set at sync time,
+    /// so when the user adds a typed-alias email to a team member AFTER
+    /// the email was synced, old recipient rows still have NULL
+    /// team_member_id. The externals query must check the aliases too,
+    /// not just the cached column.
+    #[test]
+    fn external_participants_excludes_recipients_resolved_by_alias_after_sync() {
+        let mut conn = open_test_db();
+        seed_email(&conn, "mg:test::m1", 1_000);
+        set_email_sender(&conn, "mg:test::m1", "tom@x.io");
+        seed_team_member(&conn, "tm_tom");
+        seed_email_alias(&conn, "tm_tom", "tom@x.io");
+        // Heike was on the recipient list when the email was synced,
+        // but her team_member_id wasn't set on the recipient row.
+        // Later the user added her email as an alias on tm_heike.
+        seed_team_member(&conn, "tm_heike");
+        add_recipient(
+            &conn,
+            "mg:test::m1",
+            "heike@example.com",
+            Some("Heike"),
+            None, // team_member_id NULL — sync-time mapping missed her
+        );
+        seed_email_alias(&conn, "tm_heike", "heike@example.com");
+        // And one genuinely external recipient as a control.
+        add_recipient(&conn, "mg:test::m1", "alice@example.com", None, None);
+
+        seed_workstream_with_email_signal(&mut conn, "ws_x", "mg:test::m1");
+
+        let listed = list_workstreams_active(&conn).unwrap();
+        let row = listed.iter().find(|w| w.id == "ws_x").unwrap();
+        let emails: Vec<&str> = row
+            .external_participants
+            .iter()
+            .map(|p| p.email.as_str())
+            .collect();
+        assert_eq!(
+            emails,
+            vec!["alice@example.com"],
+            "Heike is now a team member by alias even though the recipient row's team_member_id is stale"
         );
     }
 

--- a/src/App.css
+++ b/src/App.css
@@ -5077,32 +5077,78 @@ input.nh-title {
 }
 
 /* External-chip detail modal — opens when the user clicks an
-   external participant. Shows the address, signal count, and two
-   short actions (copy email / add to team). Reuses the
-   .settings-modal* layout for visual consistency with the workstream
-   settings modal. */
+   external participant. Standalone layout (does not reuse
+   .settings-modal*); compact dialog with a top-right ×, identity
+   header, and a single action row. */
+.external-chip-modal {
+  position: relative;
+  background: var(--bg, #fff);
+  color: var(--fg);
+  width: min(420px, calc(100vw - 32px));
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 18px 20px 16px;
+}
+.external-chip-modal-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--fg-muted);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+.external-chip-modal-close:hover {
+  background: var(--bg-soft, rgba(0, 0, 0, 0.04));
+  color: var(--fg);
+}
+.external-chip-modal-header {
+  padding-right: 24px;
+}
+.external-chip-modal-name {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
 .external-chip-modal-email {
-  margin: 4px 0 0;
+  margin-top: 4px;
   font-size: 12.5px;
   color: var(--fg-muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   word-break: break-all;
+  /* Suppress macOS WebView's auto-detect highlight on email-shaped
+     text. The dialog already exposes the address explicitly; we
+     don't want a second underlay competing with our styling. */
+  -webkit-user-modify: read-only;
+  -webkit-user-select: text;
 }
 .external-chip-modal-count {
-  margin: 4px 0 0;
+  margin-top: 6px;
   font-size: 11.5px;
   color: var(--fg-muted);
 }
 .external-chip-modal-actions {
   display: flex;
   gap: 8px;
-  padding: 16px 20px 0;
+  margin-top: 16px;
 }
 .external-chip-modal-action {
   flex: 1;
   font: inherit;
   font-size: 13px;
-  padding: 8px 14px;
+  padding: 7px 14px;
   border-radius: 6px;
   border: 1px solid var(--home-line);
   background: var(--bg, #fff);
@@ -5126,7 +5172,7 @@ input.nh-title {
   cursor: not-allowed;
 }
 .external-chip-modal-error {
-  margin: 8px 20px 0;
+  margin: 10px 0 0;
   font-size: 12px;
   color: var(--danger, #b00020);
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1356,6 +1356,47 @@ select.settings-input {
   margin-top: auto;
   padding-top: 8px;
   border-top: 0.5px solid var(--home-line);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* New-note / New-meeting CTAs surfaced in the sidebar footer when not
+   on Home. Sized down from the Greeting variant so they fit the
+   narrow sidebar column. */
+.home-side-cta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 10px;
+}
+.home-side-cta-secondary,
+.home-side-cta-primary {
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px solid var(--home-line);
+  background: transparent;
+  color: var(--fg);
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.home-side-cta-secondary:hover {
+  background: var(--bg-soft, rgba(0, 0, 0, 0.04));
+}
+.home-side-cta-primary {
+  background: var(--accent, #4a90e2);
+  border-color: var(--accent, #4a90e2);
+  color: #fff;
+}
+.home-side-cta-primary:hover {
+  filter: brightness(0.95);
 }
 
 /* ----- Main column ----- */
@@ -1495,6 +1536,15 @@ select.settings-input {
   justify-content: space-between;
   border-bottom: 0.5px solid var(--home-line);
   padding-bottom: 10px;
+}
+/* Toolbar variant: section heads on sub-pages where the page title
+   already lives in `PageHeader`. No left-side eyebrow + h2 anymore;
+   the affordance (Refresh, Add team member, New todo) right-aligns. */
+.home-section-head-toolbar {
+  justify-content: flex-end;
+  border-bottom: none;
+  padding-bottom: 0;
+  min-height: 32px;
 }
 .home-section-eyebrow {
   font-size: 10.5px;
@@ -4732,6 +4782,15 @@ input.nh-title {
   flex-direction: column;
   gap: 18px;
 }
+/* List-view toolbar variant of `.workstream-header`. The page title
+   moved into `PageHeader` upstream, so the inner header is just a
+   right-aligned action bar (Refresh button) with no bottom border. */
+.workstream-toolbar {
+  border-bottom: none !important;
+  padding-bottom: 0 !important;
+  justify-content: flex-end;
+  min-height: 32px;
+}
 .workstream-header {
   display: flex;
   align-items: center;
@@ -4946,6 +5005,31 @@ input.nh-title {
 .workstream-detail-breadcrumb-self {
   color: var(--fg);
   font-weight: 500;
+}
+
+/* Back-to-list eyebrow — matches `.home-section-eyebrow` so the
+   detail-view title reads as the section title with a clickable
+   "WORKSTREAMS" eyebrow above it (rather than an inline `< Back`
+   button that pushed the title off-flush). */
+.workstream-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  padding: 0;
+  margin-bottom: 4px;
+  align-self: flex-start;
+}
+.workstream-back-link:hover {
+  color: var(--accent, #4a90e2);
 }
 
 /* Detail-header kebab button (#89). Replaces the three inline native

--- a/src/App.css
+++ b/src/App.css
@@ -5071,6 +5071,78 @@ input.nh-title {
 .settings-modal-done:hover {
   filter: brightness(0.95);
 }
+.settings-modal-done:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* External-chip detail modal — opens when the user clicks an
+   external participant. Shows the address, signal count, and two
+   short actions (copy email / add to team). Reuses the
+   .settings-modal* layout for visual consistency with the workstream
+   settings modal. */
+.external-chip-modal-email {
+  margin: 4px 0 0;
+  font-size: 12.5px;
+  color: var(--fg-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  word-break: break-all;
+}
+.external-chip-modal-count {
+  margin: 4px 0 0;
+  font-size: 11.5px;
+  color: var(--fg-muted);
+}
+.external-chip-modal-actions {
+  display: flex;
+  gap: 8px;
+  padding: 16px 20px 0;
+}
+.external-chip-modal-action {
+  flex: 1;
+  font: inherit;
+  font-size: 13px;
+  padding: 8px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--home-line);
+  background: var(--bg, #fff);
+  color: var(--fg);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.external-chip-modal-action:hover:not(:disabled) {
+  background: var(--bg-soft, rgba(0, 0, 0, 0.04));
+}
+.external-chip-modal-action.primary {
+  background: var(--accent, #4a90e2);
+  border-color: var(--accent, #4a90e2);
+  color: #fff;
+}
+.external-chip-modal-action.primary:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+.external-chip-modal-action:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.external-chip-modal-error {
+  margin: 8px 20px 0;
+  font-size: 12px;
+  color: var(--danger, #b00020);
+}
+
+/* The chip is now a button — strip native styling so it visually
+   matches the previous static span treatment but is keyboard /
+   click accessible. */
+button.workstream-external-chip {
+  cursor: pointer;
+  font: inherit;
+}
+button.workstream-external-chip:hover {
+  border-style: solid;
+  border-color: var(--accent, #4a90e2);
+  color: var(--fg);
+}
 
 /* Children section on a parent's detail view (#89). Same layout
    as the list view's grid; the section title sits above the cards. */

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -502,6 +502,8 @@ export function Home({
           onTagSelect={(t) => setTagFilter(t === tagFilter ? null : t)}
           onOpenSettings={onOpenSettings}
           onOpenPalette={() => setPaletteOpen(true)}
+          onNewNote={onNewNote}
+          onNewMeeting={onNewMeeting}
         />
       )}
       <div className="home-main">
@@ -543,12 +545,22 @@ export function Home({
           </div>
         </div>
 
-        <Greeting
-          upcomingCount={todayCount}
-          nextEvent={nextEvent}
-          onNewNote={onNewNote}
-          onNewMeeting={onNewMeeting}
-        />
+        {nav === "home" ? (
+          <Greeting
+            upcomingCount={todayCount}
+            nextEvent={nextEvent}
+            onNewNote={onNewNote}
+            onNewMeeting={onNewMeeting}
+          />
+        ) : (
+          <PageHeader
+            title={pageHeaderTitle(nav)}
+            actions={renderScopedActions(nav, {
+              onRefreshWorkstreams,
+              synthInFlight,
+            })}
+          />
+        )}
 
         {nav === "home" && upcoming.length > 0 && (
           <UpcomingStrip events={upcoming} onOpen={openEventNote} />
@@ -567,7 +579,6 @@ export function Home({
             loading={workstreamsLoading}
             synthInFlight={synthInFlight}
             synthMessage={synthMessage}
-            onRefresh={onRefreshWorkstreams}
             onOpenNote={onOpen}
           />
         ) : nav === "actions" ? (
@@ -627,6 +638,8 @@ function Sidebar({
   onTagSelect,
   onOpenSettings,
   onOpenPalette,
+  onNewNote,
+  onNewMeeting,
 }: {
   active: NavId;
   onSelect: (id: NavId) => void;
@@ -637,6 +650,12 @@ function Sidebar({
   onTagSelect: (tag: string) => void;
   onOpenSettings: () => void;
   onOpenPalette: () => void;
+  /** Global compose CTAs. The Greeting on Home renders these inline;
+   *  on every other nav we surface them from the sidebar footer
+   *  instead so they stay reachable without crowding the page header
+   *  (where scoped page actions live). */
+  onNewNote: () => void;
+  onNewMeeting: () => void;
 }) {
   return (
     <aside className="home-sidebar">
@@ -724,6 +743,26 @@ function Sidebar({
       </div>
 
       <div className="home-side-foot">
+        {active !== "home" ? (
+          <div className="home-side-cta">
+            <button
+              type="button"
+              className="home-side-cta-secondary"
+              onClick={onNewNote}
+            >
+              <IconPlus size={12} sw={1.8} />
+              New note
+            </button>
+            <button
+              type="button"
+              className="home-side-cta-primary"
+              onClick={onNewMeeting}
+            >
+              <span className="home-cta-dot" />
+              New meeting
+            </button>
+          </div>
+        ) : null}
         <NavItem
           icon={<IconSettings size={14} sw={1.7} />}
           label="Settings"
@@ -818,6 +857,100 @@ function Greeting({
           New meeting
         </button>
       </div>
+    </header>
+  );
+}
+
+/** Page-scoped actions for the right side of `PageHeader`. Composer
+ *  toggles dispatch CustomEvents because the composer state lives
+ *  inside the sub-page component (TeamSection / ActionsFeed); the
+ *  page header just fires the open trigger. Refresh on Workstreams
+ *  has its handler already at Home.tsx scope so it's a direct call. */
+function renderScopedActions(
+  nav: NavId,
+  ctx: { onRefreshWorkstreams: () => void; synthInFlight: boolean },
+): React.ReactNode {
+  switch (nav) {
+    case "team":
+      return (
+        <button
+          type="button"
+          className="home-section-add"
+          onClick={() =>
+            window.dispatchEvent(new CustomEvent("margin:open-team-composer"))
+          }
+        >
+          <IconPlus size={13} sw={1.8} />
+          Add team member
+        </button>
+      );
+    case "actions":
+      return (
+        <button
+          type="button"
+          className="home-section-add"
+          onClick={() =>
+            window.dispatchEvent(new CustomEvent("margin:open-actions-composer"))
+          }
+        >
+          <IconPlus size={13} sw={1.8} />
+          New todo
+        </button>
+      );
+    case "workstreams":
+      return (
+        <button
+          type="button"
+          className="home-section-add"
+          onClick={ctx.onRefreshWorkstreams}
+          disabled={ctx.synthInFlight}
+        >
+          {ctx.synthInFlight ? "Synthesizing…" : "Refresh"}
+        </button>
+      );
+    case "favorites":
+    case "archive":
+    case "home":
+      return null;
+  }
+}
+
+function pageHeaderTitle(nav: NavId): string {
+  switch (nav) {
+    case "actions":
+      return "Action items";
+    case "workstreams":
+      return "Workstreams";
+    case "team":
+      return "Team";
+    case "favorites":
+      return "Favorites";
+    case "archive":
+      return "Archive";
+    case "home":
+      // Home renders the Greeting variant; this branch is unreachable
+      // from the call site but kept exhaustive for the compiler.
+      return "Margin";
+  }
+}
+
+function PageHeader({
+  title,
+  actions,
+}: {
+  title: string;
+  /** Page-scoped actions rendered on the right of the header. e.g.
+   *  "Add team member" on Team, "New todo" on Actions, "Refresh" on
+   *  Workstreams. The global New-note / New-meeting CTAs live in the
+   *  sidebar footer for non-home pages instead of competing here. */
+  actions?: React.ReactNode;
+}) {
+  return (
+    <header className="home-greeting page-header">
+      <div className="home-greeting-text">
+        <h1 className="home-greeting-title">{title}</h1>
+      </div>
+      {actions ? <div className="home-greeting-cta">{actions}</div> : null}
     </header>
   );
 }
@@ -1150,6 +1283,14 @@ function ActionsFeed({
   onReassign: (actionId: string, memberId: string | null) => void;
 }) {
   const [composerOpen, setComposerOpen] = useState(false);
+  // The "New todo" trigger lives in PageHeader (when nav === "actions");
+  // we listen for its dispatched event and open the inline composer.
+  useEffect(() => {
+    const onOpen = () => setComposerOpen(true);
+    window.addEventListener("margin:open-actions-composer", onOpen);
+    return () =>
+      window.removeEventListener("margin:open-actions-composer", onOpen);
+  }, []);
   // Split dated vs. undated, then bucket the dated half by urgency.
   // Backend already orders dated rows by `due_ms ASC`, so each bucket is
   // chronological without further sorting. Undated rows fall into one
@@ -1173,27 +1314,8 @@ function ActionsFeed({
     return { byBucket: buckets, undated: undatedRows };
   }, [actions]);
 
-  // Header used by both the empty and populated states. Toggle button on
-  // the right collapses out of view when the composer is expanded so the
-  // form below isn't competing with a redundant trigger.
-  const head = (
-    <div className="home-section-head">
-      <div>
-        <div className="home-section-eyebrow">Action items</div>
-        <h2 className="home-section-title">Things to do</h2>
-      </div>
-      {!composerOpen && (
-        <button
-          type="button"
-          className="home-section-add"
-          onClick={() => setComposerOpen(true)}
-        >
-          <IconPlus size={12} sw={1.8} />
-          New todo
-        </button>
-      )}
-    </div>
-  );
+  // Page-level "New todo" trigger lives in PageHeader (Home.tsx);
+  // ActionsFeed renders only the composer form when open.
   const composer = composerOpen ? (
     <InboxComposerForm
       onAdd={onAddInboxTodo}
@@ -1204,7 +1326,6 @@ function ActionsFeed({
   if (actions.length === 0) {
     return (
       <section className="home-section">
-        {head}
         {composer}
         <p className="home-empty">
           No open action items. Add <code>- [ ] task</code> lines to any note,
@@ -1217,8 +1338,6 @@ function ActionsFeed({
 
   return (
     <section className="home-section">
-      {head}
-
       {composer}
 
       {BUCKET_ORDER.map(({ key, label }) => {

--- a/src/Team.tsx
+++ b/src/Team.tsx
@@ -136,24 +136,17 @@ function ListPane({
   onCreated: (member: TeamMember) => void;
 }) {
   const [composerOpen, setComposerOpen] = useState(false);
+  // The "Add team member" trigger lives in PageHeader (Home.tsx) when
+  // nav === "team"; we listen for its dispatched event and open the
+  // inline composer below.
+  useEffect(() => {
+    const onOpen = () => setComposerOpen(true);
+    window.addEventListener("margin:open-team-composer", onOpen);
+    return () =>
+      window.removeEventListener("margin:open-team-composer", onOpen);
+  }, []);
   return (
     <section className="home-section">
-      <div className="home-section-head">
-        <div>
-          <div className="home-section-eyebrow">Team</div>
-          <h2 className="home-section-title">Your team</h2>
-        </div>
-        {!composerOpen && (
-          <button
-            type="button"
-            className="home-section-add"
-            onClick={() => setComposerOpen(true)}
-          >
-            <IconPlus size={12} sw={1.8} />
-            Add team member
-          </button>
-        )}
-      </div>
       {composerOpen && (
         <TeamComposerForm
           onClose={() => setComposerOpen(false)}

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
 import {
+  AliasKind,
   type EmailMessage,
   type ExternalParticipant,
   LinkKind,
@@ -22,6 +23,7 @@ import {
   type WorkstreamLink,
   type WorkstreamStatus,
   addWorkstreamLink,
+  createTeamMember,
   getEmailBody,
   getWorkstreamDetails,
   listArchivedWorkstreams,
@@ -558,6 +560,7 @@ function WorkstreamDetailView({
   const [loading, setLoading] = useState(true);
   const [missing, setMissing] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [externalDialog, setExternalDialog] = useState<ExternalParticipant | null>(null);
 
   const reload = useCallback(async () => {
     setLoading(true);
@@ -786,7 +789,21 @@ function WorkstreamDetailView({
       ) : null}
 
       {detail.external_participants.length > 0 ? (
-        <ExternalsStrip externals={detail.external_participants} />
+        <ExternalsStrip
+          externals={detail.external_participants}
+          onChipClick={(p) => setExternalDialog(p)}
+        />
+      ) : null}
+      {externalDialog ? (
+        <ExternalChipModal
+          participant={externalDialog}
+          onClose={() => setExternalDialog(null)}
+          onAddedToTeam={() => {
+            // Refetch detail so the chip moves into MembersStrip on
+            // the next render.
+            void reload();
+          }}
+        />
       ) : null}
 
       <WorkstreamUserNotes
@@ -1232,7 +1249,13 @@ function MembersStrip({
 
 const EXTERNAL_VISIBLE_CAP = 8;
 
-function ExternalsStrip({ externals }: { externals: ExternalParticipant[] }) {
+function ExternalsStrip({
+  externals,
+  onChipClick,
+}: {
+  externals: ExternalParticipant[];
+  onChipClick: (p: ExternalParticipant) => void;
+}) {
   const visible = externals.slice(0, EXTERNAL_VISIBLE_CAP);
   const overflow = externals.length - visible.length;
   return (
@@ -1241,19 +1264,142 @@ function ExternalsStrip({ externals }: { externals: ExternalParticipant[] }) {
       {visible.map((p) => {
         const display = p.display_name?.trim() || p.email;
         return (
-          <span
+          <button
             key={p.email}
+            type="button"
             className="workstream-external-chip"
             title={p.display_name ? `${p.display_name} <${p.email}>` : p.email}
+            onClick={() => onChipClick(p)}
           >
             {display}
-          </span>
+          </button>
         );
       })}
       {overflow > 0 ? (
         <span className="workstream-externals-overflow">+{overflow}</span>
       ) : null}
     </section>
+  );
+}
+
+function ExternalChipModal({
+  participant,
+  onClose,
+  onAddedToTeam,
+}: {
+  participant: ExternalParticipant;
+  onClose: () => void;
+  /** Fired after the participant becomes a team member, so the parent
+   *  detail view can refetch — the chip will move from the External
+   *  strip into the Members strip on the next render. */
+  onAddedToTeam: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  // Esc closes; backdrop click closes.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const displayName = participant.display_name?.trim() || participant.email;
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(participant.email);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch (err) {
+      console.error("[workstreams] copy email failed", err);
+    }
+  };
+
+  const onAdd = async () => {
+    setBusy(true);
+    setAddError(null);
+    try {
+      // Create the team member with the email as a typed alias so the
+      // resolver picks them up on the next refresh. display_name is
+      // the address itself when no display name was on the source row;
+      // the user can rename them later from the team detail view.
+      await createTeamMember(displayName, "", [
+        { kind: AliasKind.Email, value: participant.email },
+      ]);
+      window.dispatchEvent(new CustomEvent("margin:team-changed"));
+      onAddedToTeam();
+      onClose();
+    } catch (err) {
+      console.error("[workstreams] createTeamMember failed", err);
+      setAddError(
+        typeof err === "string"
+          ? err
+          : err instanceof Error
+            ? err.message
+            : "Could not add to team",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      className="settings-modal-backdrop"
+      role="presentation"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="settings-modal external-chip-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Identity: ${displayName}`}
+      >
+        <header className="settings-modal-header">
+          <h2>{displayName}</h2>
+          <p className="external-chip-modal-email">{participant.email}</p>
+          <p className="external-chip-modal-count">
+            Seen on {participant.count} signal{participant.count === 1 ? "" : "s"} in this workstream
+          </p>
+        </header>
+        <div className="external-chip-modal-actions">
+          <button
+            type="button"
+            className="external-chip-modal-action"
+            onClick={() => void onCopy()}
+          >
+            {copied ? "Copied!" : "Copy email"}
+          </button>
+          <button
+            type="button"
+            className="external-chip-modal-action primary"
+            onClick={() => void onAdd()}
+            disabled={busy}
+          >
+            {busy ? "Adding…" : "Add to team"}
+          </button>
+        </div>
+        {addError ? (
+          <p className="external-chip-modal-error">{addError}</p>
+        ) : null}
+        <footer className="settings-modal-footer">
+          <button
+            type="button"
+            className="settings-modal-done"
+            onClick={onClose}
+            disabled={busy}
+          >
+            Close
+          </button>
+        </footer>
+      </div>
+    </div>
   );
 }
 

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -1356,17 +1356,27 @@ function ExternalChipModal({
       }}
     >
       <div
-        className="settings-modal external-chip-modal"
+        className="external-chip-modal"
         role="dialog"
         aria-modal="true"
         aria-label={`Identity: ${displayName}`}
       >
-        <header className="settings-modal-header">
-          <h2>{displayName}</h2>
-          <p className="external-chip-modal-email">{participant.email}</p>
-          <p className="external-chip-modal-count">
+        <button
+          type="button"
+          className="external-chip-modal-close"
+          onClick={onClose}
+          disabled={busy}
+          aria-label="Close"
+          title="Close"
+        >
+          ×
+        </button>
+        <header className="external-chip-modal-header">
+          <h2 className="external-chip-modal-name">{displayName}</h2>
+          <div className="external-chip-modal-email">{participant.email}</div>
+          <div className="external-chip-modal-count">
             Seen on {participant.count} signal{participant.count === 1 ? "" : "s"} in this workstream
-          </p>
+          </div>
         </header>
         <div className="external-chip-modal-actions">
           <button
@@ -1388,16 +1398,6 @@ function ExternalChipModal({
         {addError ? (
           <p className="external-chip-modal-error">{addError}</p>
         ) : null}
-        <footer className="settings-modal-footer">
-          <button
-            type="button"
-            className="settings-modal-done"
-            onClick={onClose}
-            disabled={busy}
-          >
-            Close
-          </button>
-        </footer>
       </div>
     </div>
   );

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -48,14 +48,12 @@ export function WorkstreamsView({
   loading,
   synthInFlight,
   synthMessage,
-  onRefresh,
   onOpenNote,
 }: {
   workstreams: Workstream[];
   loading: boolean;
   synthInFlight: boolean;
   synthMessage: string | null;
-  onRefresh: () => void;
   onOpenNote: (path: string) => void;
 }) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -132,30 +130,6 @@ export function WorkstreamsView({
 
   return (
     <div className="workstream-view">
-      <header className="workstream-header">
-        <div>
-          <h1 className="workstream-title">Workstreams</h1>
-          <p className="workstream-subtitle">
-            Ongoing efforts synthesized from emails, meetings, and notes.
-          </p>
-        </div>
-        <button
-          type="button"
-          className="workstream-refresh"
-          onClick={onRefresh}
-          disabled={synthInFlight}
-        >
-          {synthInFlight ? (
-            <>
-              <span className="workstream-spinner" aria-hidden />
-              Synthesizing…
-            </>
-          ) : (
-            "Refresh"
-          )}
-        </button>
-      </header>
-
       {synthMessage ? (
         <div className="workstream-toast" role="status">
           {synthMessage}
@@ -1153,29 +1127,31 @@ function DetailHeader({
   onOpenSettings?: () => void;
 }) {
   return (
-    <header className="workstream-header workstream-detail-header">
+    <>
       <button
         type="button"
-        className="workstream-back"
+        className="workstream-back-link"
         onClick={onBack}
         aria-label="Back to workstreams"
       >
-        <IconChevLeft size={20} />
-        Back
+        <IconChevLeft size={13} sw={1.8} />
+        Workstreams
       </button>
-      <h1 className="workstream-title">{title}</h1>
-      {onOpenSettings ? (
-        <button
-          type="button"
-          className="workstream-detail-settings-button"
-          onClick={onOpenSettings}
-          aria-label="Workstream settings"
-          title="Settings"
-        >
-          <IconMore size={18} sw={1.8} />
-        </button>
-      ) : null}
-    </header>
+      <header className="workstream-header workstream-detail-header">
+        <h1 className="workstream-title">{title}</h1>
+        {onOpenSettings ? (
+          <button
+            type="button"
+            className="workstream-detail-settings-button"
+            onClick={onOpenSettings}
+            aria-label="Workstream settings"
+            title="Settings"
+          >
+            <IconMore size={18} sw={1.8} />
+          </button>
+        ) : null}
+      </header>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary

Two fixes on the External participants strip you saw on the Bridge workstream:

1. **Heike was double-counted** (showing in both the Members chip and as an External chip even after I added her email to her identity). Root cause: `email_recipients.team_member_id` is set at sync time; aliases added afterwards via the typed-identities modal don't backfill old rows. The externals query was trusting the cached column. Fix: the query now also runs a `NOT EXISTS` check against `team_member_aliases` (kind='email') for recipient and attendee rows — same pattern the sender path already used. Aliases are the source of truth; the cached column stays as a fast-path filter.

2. **Click-to-act modal** on each external chip. Shows the participant's name + email + signal count, plus two short actions:
   - **Copy email** (clipboard, with brief "Copied!" feedback)
   - **Add to team** (creates a `team_member` with the email as a typed alias, dispatches `margin:team-changed`, refetches the detail so the chip moves into the Members strip on the next render)

Reuses the existing `.settings-modal` layout for visual consistency.

## Test plan

- [x] `cargo test --lib` — 260 passed (was 259; +1 regression test `external_participants_excludes_recipients_resolved_by_alias_after_sync`).
- [x] `bun run build` — TS + Vite clean.
- [ ] Manual: after a sync where Heike was on a recipient list before her alias existed, add her email via the identities modal → she now shows ONLY in Members, not in External.
- [ ] Manual: click an external chip → modal opens with email + count. Copy email → flash "Copied!". Click Add to team → modal closes, chip disappears from External and reappears in Members on the next list pass.