### PR TITLE
Workstream links: per-kind brand icons + server-side kind validation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "markdown-it-task-lists": "^2.1.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "simple-icons": "^16.19.0",
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
@@ -449,6 +450,8 @@
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "simple-icons": ["simple-icons@16.19.0", "", {}, "sha512-muxcz/FDvWFPrKJdsjaz79qsBjtZeVKUVIFl7wLVOwb+yqAag8FPe8+hFlMVRnmAXYQIm4eUDDm2+dhOj0cFgQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-task-lists": "^2.1.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "simple-icons": "^16.19.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",

--- a/src-tauri/src/anthropic.rs
+++ b/src-tauri/src/anthropic.rs
@@ -8,3 +8,7 @@
 pub const ENDPOINT: &str = "https://api.anthropic.com/v1/messages";
 pub const ANTHROPIC_VERSION: &str = "2023-06-01";
 pub const DEFAULT_MODEL: &str = "claude-sonnet-4-6";
+/// Cheap, fast model for low-stakes single-shot classifiers — e.g. the
+/// link-categorizer prompt that takes a URL and returns `{label, kind}`.
+/// Don't use for anything that needs nuance or long-context reasoning.
+pub const HAIKU_MODEL: &str = "claude-haiku-4-5-20251001";

--- a/src-tauri/src/ask.rs
+++ b/src-tauri/src/ask.rs
@@ -1234,14 +1234,31 @@ fn format_workstream_detail(
         for link in &detail.links {
             let label = link.label.trim();
             let url = link.url.trim();
-            match link.kind.as_deref().map(str::trim).filter(|k| !k.is_empty()) {
-                Some(kind) => {
-                    s.push_str(&format!("- [{label}]({url}) ({kind})\n"));
-                }
-                None => {
-                    s.push_str(&format!("- [{label}]({url})\n"));
-                }
-            }
+            let kind_suffix = match link
+                .kind
+                .as_deref()
+                .map(str::trim)
+                .filter(|k| !k.is_empty())
+            {
+                Some(kind) => format!(" ({kind})"),
+                None => String::new(),
+            };
+            // Append the AI-generated summary (#?) when populated. The
+            // chip view shows the same text inline; including it here
+            // means "what does this link describe?" questions land
+            // without an extra tool call.
+            let summary_suffix = match link
+                .summary
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+            {
+                Some(summary) => format!(" — {summary}"),
+                None => String::new(),
+            };
+            s.push_str(&format!(
+                "- [{label}]({url}){kind_suffix}{summary_suffix}\n"
+            ));
         }
     }
 
@@ -2138,6 +2155,7 @@ mod tests {
                     kind: Some("github".into()),
                     position: 0,
                     created_ms: 0,
+                    summary: None,
                 },
                 crate::workstreams::WorkstreamLink {
                     id: "wsl_2".into(),
@@ -2147,6 +2165,7 @@ mod tests {
                     kind: None,
                     position: 1,
                     created_ms: 0,
+                    summary: None,
                 },
             ],
             children: Vec::new(),
@@ -2203,6 +2222,67 @@ mod tests {
         let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         let out = format_workstream_detail("W5", &detail, &team_map);
         assert!(!out.contains("## Links"));
+    }
+
+    #[test]
+    fn format_workstream_detail_appends_link_summary_when_set() {
+        let detail = WorkstreamDetail {
+            workstream: Workstream {
+                id: "ws_links".into(),
+                title: "Bridge".into(),
+                summary: "".into(),
+                status: "active".into(),
+                last_activity_ms: 0,
+                created_ms: 0,
+                updated_ms: 0,
+                user_notes: None,
+                archived_at_ms: None,
+                reopened_at_ms: None,
+                owner_member_id: None,
+                members: Vec::new(),
+                email_count: 0,
+                event_count: 0,
+                note_count: 0,
+                open_action_count: 0,
+                link_count: 1,
+                parent_workstream_id: None,
+                external_participants: Vec::new(),
+            },
+            emails: vec![],
+            events: vec![],
+            notes: vec![],
+            actions: vec![],
+            links: vec![
+                crate::workstreams::WorkstreamLink {
+                    id: "wsl_1".into(),
+                    workstream_id: "ws_links".into(),
+                    label: "Repo".into(),
+                    url: "https://github.com/x/y".into(),
+                    kind: Some("github".into()),
+                    position: 0,
+                    created_ms: 0,
+                    summary: Some("A small Rust crate for X.".into()),
+                },
+                crate::workstreams::WorkstreamLink {
+                    id: "wsl_2".into(),
+                    workstream_id: "ws_links".into(),
+                    label: "Spec".into(),
+                    url: "https://docs.example.com".into(),
+                    kind: None,
+                    position: 1,
+                    created_ms: 0,
+                    summary: None,
+                },
+            ],
+            children: Vec::new(),
+        };
+        let team_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let out = format_workstream_detail("W6", &detail, &team_map);
+        assert!(out.contains(
+            "- [Repo](https://github.com/x/y) (github) — A small Rust crate for X.\n"
+        ));
+        // No summary suffix on the second link.
+        assert!(out.contains("- [Spec](https://docs.example.com)\n"));
     }
 
     #[test]

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -50,7 +50,8 @@ const SCHEMA_V16: &str = include_str!("migrations/016_workstream_signals.sql");
 const SCHEMA_V17: &str = include_str!("migrations/017_typed_aliases.sql");
 const SCHEMA_V18: &str = include_str!("migrations/018_workstream_links.sql");
 const SCHEMA_V19: &str = include_str!("migrations/019_workstream_parent.sql");
-const SCHEMA_VERSION: i64 = 19;
+const SCHEMA_V20: &str = include_str!("migrations/020_workstream_link_summary.sql");
+const SCHEMA_VERSION: i64 = 20;
 
 /// Open the index DB at `db_path` (creating it if absent) and apply any
 /// pending migrations.
@@ -168,6 +169,10 @@ fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 18 {
         conn.execute_batch(SCHEMA_V19)?;
         version = 19;
+    }
+    if version == 19 {
+        conn.execute_batch(SCHEMA_V20)?;
+        version = 20;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/keychain.rs
+++ b/src-tauri/src/keychain.rs
@@ -3,9 +3,14 @@ use serde::{Deserialize, Serialize};
 
 const SERVICE: &str = "com.margin.app";
 const ACCOUNT: &str = "anthropic-api-key";
+const FIRECRAWL_ACCOUNT: &str = "firecrawl-api-key";
 
 fn entry() -> Result<Entry, String> {
     Entry::new(SERVICE, ACCOUNT).map_err(|e| e.to_string())
+}
+
+fn firecrawl_entry() -> Result<Entry, String> {
+    Entry::new(SERVICE, FIRECRAWL_ACCOUNT).map_err(|e| e.to_string())
 }
 
 fn connector_entry(connector_id: &str) -> Result<Entry, String> {
@@ -68,6 +73,37 @@ pub fn has_anthropic_api_key() -> bool {
 #[allow(dead_code)]
 pub fn read_anthropic_api_key() -> Result<String, String> {
     entry()?.get_password().map_err(|e| e.to_string())
+}
+
+// ----- Firecrawl API key ------------------------------------------------
+
+#[tauri::command]
+pub fn set_firecrawl_api_key(key: String) -> Result<(), String> {
+    firecrawl_entry()?.set_password(&key).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn delete_firecrawl_api_key() -> Result<(), String> {
+    match firecrawl_entry()?.delete_credential() {
+        Ok(()) => Ok(()),
+        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+#[tauri::command]
+pub fn has_firecrawl_api_key() -> bool {
+    let e = match firecrawl_entry() {
+        Ok(e) => e,
+        Err(_) => return false,
+    };
+    matches!(e.get_password(), Ok(_))
+}
+
+/// Internal accessor for the link summarizer. Never via IPC.
+#[allow(dead_code)]
+pub fn read_firecrawl_api_key() -> Result<String, String> {
+    firecrawl_entry()?.get_password().map_err(|e| e.to_string())
 }
 
 // ----- Per-connector OAuth tokens (#60) ---------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -644,6 +644,9 @@ pub fn run() {
             keychain::set_anthropic_api_key,
             keychain::delete_anthropic_api_key,
             keychain::has_anthropic_api_key,
+            keychain::set_firecrawl_api_key,
+            keychain::delete_firecrawl_api_key,
+            keychain::has_firecrawl_api_key,
             start_meeting_recording,
             stop_meeting_recording,
             start_voice_recording,
@@ -698,6 +701,7 @@ pub fn run() {
             workstreams::commands::set_workstream_owner,
             workstreams::commands::list_workstream_links,
             workstreams::commands::add_workstream_link,
+            workstreams::commands::add_workstream_link_from_url,
             workstreams::commands::remove_workstream_link,
             workstreams::commands::set_workstream_parent
         ])

--- a/src-tauri/src/migrations/020_workstream_link_summary.sql
+++ b/src-tauri/src/migrations/020_workstream_link_summary.sql
@@ -1,0 +1,16 @@
+-- Add an AI-generated summary column to workstream_links.
+--
+-- After a link is added via the paste-only composer, a background
+-- task scrapes the URL via Firecrawl and asks Claude Haiku for a
+-- 2-3 sentence summary. The chip renders the summary as a second
+-- italic line; the AI-ask `read_workstream` output appends it after
+-- the markdown link.
+--
+-- Nullable: NULL means "not yet summarized" or "summarization failed
+-- silently" (no API key, network error, model error). The UI hides
+-- the second line when NULL and there's no retry — the user can
+-- remove + re-add to retry, or we'll add a manual regenerate later.
+
+ALTER TABLE workstream_links ADD COLUMN summary TEXT;
+
+UPDATE meta SET value = '20' WHERE key = 'schema_version';

--- a/src-tauri/src/workstreams/commands.rs
+++ b/src-tauri/src/workstreams/commands.rs
@@ -156,3 +156,53 @@ pub fn remove_workstream_link(
         .map(|_| ())
         .map_err(|e| e.to_string())
 }
+
+/// Paste-only link entry: the user supplies just a URL; Haiku
+/// categorizes it into a `(label, kind)` tuple, and we persist via the
+/// same `add_workstream_link` path. Categorization failures fall back
+/// to `{label: <hostname>, kind: "other"}` so the user still gets a
+/// usable chip — they can rename it later via the inline composer.
+///
+/// After the row lands, a fire-and-forget background task fetches the
+/// page via Firecrawl and asks Haiku for a 2–3 sentence summary; the
+/// result lands on the row and a `workstream-link-summarized` event
+/// fires so the frontend re-renders without a refetch.
+#[tauri::command]
+pub async fn add_workstream_link_from_url(
+    app: tauri::AppHandle,
+    workstream_id: String,
+    url: String,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<WorkstreamLink, String> {
+    let trimmed = url.trim().to_string();
+    if trimmed.is_empty() {
+        return Err("URL is required".into());
+    }
+    // Run the AI categorization OUTSIDE the connection lock — the
+    // network round-trip can take ~1s and we don't want to block
+    // other commands behind it.
+    let categorized = super::link_categorizer::categorize_or_fallback(&trimmed).await;
+    let now_ms = chrono::Local::now().timestamp_millis();
+    let link = {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        persist::add_workstream_link(
+            &c,
+            &workstream_id,
+            &categorized.label,
+            &trimmed,
+            Some(&categorized.kind),
+            now_ms,
+        )
+        .map_err(|e| e.to_string())?
+    };
+    // Fire-and-forget summarization. Skips silently if either key is
+    // missing or the scrape returns thin content; emits the
+    // `workstream-link-summarized` event on success.
+    let app_clone = app.clone();
+    let link_id = link.id.clone();
+    let url_clone = trimmed.clone();
+    tauri::async_runtime::spawn(async move {
+        super::link_summarizer::populate_summary(app_clone, link_id, url_clone).await;
+    });
+    Ok(link)
+}

--- a/src-tauri/src/workstreams/link_categorizer.rs
+++ b/src-tauri/src/workstreams/link_categorizer.rs
@@ -1,0 +1,303 @@
+//! AI-driven categorization for workstream link URLs.
+//!
+//! Given a URL the user pasted, we ask Claude Haiku for a short label
+//! (~3 words) and a `link_kinds::*` value. The single-shot prompt is
+//! deliberately tiny so cost + latency stay under ~$0.001 + ~1s per
+//! call.
+//!
+//! Failure semantics: any error (no API key, network, malformed JSON,
+//! invalid kind) falls back to `{label: <hostname>, kind: "other"}` so
+//! the user still gets a usable chip. The error is logged but the
+//! `add` flow still completes — the user can edit the label / kind
+//! later via the inline composer if they reopen it.
+//!
+//! No DB access. The caller wires this into `add_workstream_link`
+//! after the categorization round-trip.
+//!
+//! Model: claude-haiku-4-5 (see `crate::anthropic::HAIKU_MODEL`).
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use super::link_kinds;
+use crate::anthropic::{ANTHROPIC_VERSION, ENDPOINT, HAIKU_MODEL};
+
+/// Cap on the AI-returned label. The chip ellipsises on overflow but
+/// we trim here too so the DB doesn't carry stray model verbosity.
+const LABEL_MAX_CHARS: usize = 40;
+
+const SYSTEM_PROMPT: &str = "You categorize URLs into one of five kinds and pick a short, human \
+label for each.
+
+Kinds:
+- github: any github.com URL
+- linear: linear.app URLs
+- notion: notion.so or notion.site URLs
+- figma: figma.com URLs
+- other: everything else
+
+Label rules:
+- 1-4 words, ideally a recognizable name from the URL itself
+  (\"Margin repo\", \"Q3 sourcing doc\", \"Bridge wireframes\")
+- prefer proper nouns over generic descriptors
+- never include the domain or scheme
+- max 40 characters
+
+Output strict JSON, no prose, no markdown fences:
+{\"label\": \"...\", \"kind\": \"github\"|\"linear\"|\"notion\"|\"figma\"|\"other\"}";
+
+/// Result of a successful categorization. The caller persists this
+/// directly via `persist::add_workstream_link`.
+#[derive(Debug, Clone)]
+pub struct Categorized {
+    pub label: String,
+    pub kind: String,
+}
+
+/// Call Haiku to categorize the URL. On any error, returns the
+/// hostname-based fallback. Caller does not need to handle the
+/// failure case — the return type is always a usable `Categorized`.
+pub async fn categorize_or_fallback(url: &str) -> Categorized {
+    let url = url.trim();
+    let api_key = match crate::keychain::read_anthropic_api_key() {
+        Ok(k) => k,
+        Err(e) => {
+            eprintln!("[link-categorizer] no API key, using hostname fallback: {e}");
+            return fallback(url);
+        }
+    };
+    match call_haiku(&api_key, url).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("[link-categorizer] {e}, using hostname fallback for {url}");
+            fallback(url)
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ApiRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    stream: bool,
+    system: &'a str,
+    messages: Vec<ApiMessage<'a>>,
+}
+
+#[derive(Serialize)]
+struct ApiMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+async fn call_haiku(api_key: &str, url: &str) -> Result<Categorized, String> {
+    let body = ApiRequest {
+        model: HAIKU_MODEL,
+        max_tokens: 128,
+        stream: false,
+        system: SYSTEM_PROMPT,
+        messages: vec![ApiMessage {
+            role: "user",
+            content: url,
+        }],
+    };
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("client init: {e}"))?;
+    let resp = client
+        .post(ENDPOINT)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", ANTHROPIC_VERSION)
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("network: {e}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let raw = resp.text().await.unwrap_or_default();
+        return Err(format!("anthropic returned {status}: {raw}"));
+    }
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("anthropic response parse: {e}"))?;
+    let text = json
+        .get("content")
+        .and_then(|c| c.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .unwrap_or_default();
+    if text.is_empty() {
+        return Err("empty response text".into());
+    }
+    parse_categorized(&text)
+}
+
+#[derive(Deserialize)]
+struct RawCategorized {
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    kind: Option<String>,
+}
+
+/// Parse the model's JSON output into a validated `Categorized`.
+/// Tolerates optional ```json fences. Rejects empty labels and kinds
+/// outside the canonical set; the caller falls back to hostname/other
+/// in either case.
+pub fn parse_categorized(raw: &str) -> Result<Categorized, String> {
+    let stripped = strip_json_fences(raw);
+    let parsed: RawCategorized =
+        serde_json::from_str(&stripped).map_err(|e| format!("parse: {e}"))?;
+    let label = parsed
+        .label
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "missing label".to_string())?
+        .chars()
+        .take(LABEL_MAX_CHARS)
+        .collect::<String>();
+    let kind = parsed
+        .kind
+        .as_deref()
+        .map(str::trim)
+        .map(str::to_lowercase)
+        .ok_or_else(|| "missing kind".to_string())?;
+    if !is_canonical_kind(&kind) {
+        return Err(format!("unknown kind: {kind}"));
+    }
+    Ok(Categorized { label, kind })
+}
+
+fn is_canonical_kind(k: &str) -> bool {
+    matches!(
+        k,
+        link_kinds::GITHUB
+            | link_kinds::LINEAR
+            | link_kinds::NOTION
+            | link_kinds::FIGMA
+            | link_kinds::OTHER
+    )
+}
+
+fn strip_json_fences(s: &str) -> String {
+    let trimmed = s.trim();
+    let without_open = trimmed
+        .strip_prefix("```json")
+        .or_else(|| trimmed.strip_prefix("```"))
+        .unwrap_or(trimmed)
+        .trim_start();
+    without_open
+        .strip_suffix("```")
+        .unwrap_or(without_open)
+        .trim()
+        .to_string()
+}
+
+/// Last-resort categorization when the API call fails. Uses the URL's
+/// hostname (minus a leading "www.") as the label and `other` as the
+/// kind. The user can edit either via the inline composer.
+pub fn fallback(url: &str) -> Categorized {
+    let label = hostname_label(url).unwrap_or_else(|| "Link".to_string());
+    Categorized {
+        label,
+        kind: link_kinds::OTHER.to_string(),
+    }
+}
+
+fn hostname_label(url: &str) -> Option<String> {
+    let after_scheme = url.split("://").nth(1).unwrap_or(url);
+    let host = after_scheme.split('/').next()?.split(':').next()?;
+    let host = host.strip_prefix("www.").unwrap_or(host);
+    if host.is_empty() {
+        return None;
+    }
+    Some(host.chars().take(LABEL_MAX_CHARS).collect())
+}
+
+// ----- Tests --------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_categorized_accepts_canonical_response() {
+        let raw = r#"{"label": "Margin repo", "kind": "github"}"#;
+        let c = parse_categorized(raw).unwrap();
+        assert_eq!(c.label, "Margin repo");
+        assert_eq!(c.kind, "github");
+    }
+
+    #[test]
+    fn parse_categorized_strips_json_fences() {
+        let raw = "```json\n{\"label\":\"X\",\"kind\":\"linear\"}\n```";
+        let c = parse_categorized(raw).unwrap();
+        assert_eq!(c.label, "X");
+        assert_eq!(c.kind, "linear");
+    }
+
+    #[test]
+    fn parse_categorized_lowercases_and_validates_kind() {
+        let raw = r#"{"label": "Doc", "kind": "NOTION"}"#;
+        let c = parse_categorized(raw).unwrap();
+        assert_eq!(c.kind, "notion");
+    }
+
+    #[test]
+    fn parse_categorized_rejects_unknown_kind() {
+        let raw = r#"{"label": "Doc", "kind": "slack"}"#;
+        assert!(parse_categorized(raw).is_err());
+    }
+
+    #[test]
+    fn parse_categorized_rejects_empty_label() {
+        let raw = r#"{"label": "", "kind": "github"}"#;
+        assert!(parse_categorized(raw).is_err());
+    }
+
+    #[test]
+    fn parse_categorized_truncates_overlong_label() {
+        let raw = r#"{"label": "This is a very very very very very long label name", "kind": "other"}"#;
+        let c = parse_categorized(raw).unwrap();
+        assert_eq!(c.label.chars().count(), LABEL_MAX_CHARS);
+    }
+
+    #[test]
+    fn parse_categorized_returns_err_on_malformed_json() {
+        assert!(parse_categorized("not json").is_err());
+    }
+
+    #[test]
+    fn fallback_uses_hostname_minus_www() {
+        let c = fallback("https://www.linear.app/team/PROJ-123");
+        assert_eq!(c.label, "linear.app");
+        assert_eq!(c.kind, link_kinds::OTHER);
+    }
+
+    #[test]
+    fn fallback_handles_url_without_scheme() {
+        let c = fallback("github.com/owner/repo");
+        assert_eq!(c.label, "github.com");
+    }
+
+    #[test]
+    fn fallback_strips_port_from_host() {
+        let c = fallback("http://localhost:3000/x");
+        assert_eq!(c.label, "localhost");
+    }
+
+    #[test]
+    fn fallback_falls_back_when_url_is_garbage() {
+        let c = fallback("");
+        assert_eq!(c.label, "Link");
+    }
+}

--- a/src-tauri/src/workstreams/link_summarizer.rs
+++ b/src-tauri/src/workstreams/link_summarizer.rs
@@ -1,0 +1,364 @@
+//! AI summary for workstream link URLs.
+//!
+//! After a link is added via the paste-only composer, this module
+//! runs as a fire-and-forget background task: scrape the URL via
+//! Firecrawl, ask Claude Haiku for a 2–3 sentence summary, write
+//! the result back to the row, emit a `workstream-link-summarized`
+//! event so the frontend re-renders without refetching.
+//!
+//! Failure semantics: any error (no key, network, malformed
+//! response, scrape returns thin content) leaves `summary = NULL`.
+//! The chip just stays single-line — no retry, no surfaced error.
+//!
+//! Models: claude-haiku-4-5 (cheap, fast; 2–3 sentences from a
+//! single page is well within its strength).
+//!
+//! Firecrawl: `POST /v1/scrape` with `{url, formats: ["markdown"]}`.
+//! We pass `onlyMainContent: true` to drop nav/footer chrome.
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::anthropic::{ANTHROPIC_VERSION, ENDPOINT, HAIKU_MODEL};
+
+/// Hard cap on the rendered summary length. Haiku usually stays
+/// well under this; we trim defensively so an over-eager model
+/// can't bloat the chip.
+const SUMMARY_MAX_CHARS: usize = 280;
+
+/// Cap on scraped markdown sent to Haiku. Most pages fit; long
+/// articles are truncated and we accept that the summary may miss
+/// later sections. Bigger context = bigger spend, so we choose a
+/// balance.
+const SCRAPED_MARKDOWN_CAP: usize = 12_000;
+
+const FIRECRAWL_ENDPOINT: &str = "https://api.firecrawl.dev/v1/scrape";
+
+const SUMMARIZE_SYSTEM_PROMPT: &str = "Summarize what the linked page is, in 2-3 short sentences.
+
+Rules:
+- Lead with what the page IS (a repo, a doc, a blog post, a ticket).
+- Then what it's ABOUT — the artifact's purpose, not your own commentary.
+- 280 characters maximum, no markdown, no links.
+- Skip filler like \"This page is\" or \"This is a\".
+
+If the input looks like a login wall, paywall, error, or 404 page, return only the literal string: NO_SUMMARY";
+
+/// Public entry point. The caller spawns this on a Tokio task right
+/// after `add_workstream_link_from_url` inserts the row. Idempotent
+/// in the sense that if the link is gone by the time the work
+/// completes, the UPDATE no-ops.
+pub async fn populate_summary(app: AppHandle, link_id: String, url: String) {
+    let firecrawl_key = match crate::keychain::read_firecrawl_api_key() {
+        Ok(k) => k,
+        Err(_) => {
+            eprintln!("[link-summarizer] no Firecrawl key, skipping");
+            return;
+        }
+    };
+    let anthropic_key = match crate::keychain::read_anthropic_api_key() {
+        Ok(k) => k,
+        Err(_) => {
+            eprintln!("[link-summarizer] no Anthropic key, skipping");
+            return;
+        }
+    };
+    let scraped = match firecrawl_scrape(&firecrawl_key, &url).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[link-summarizer] scrape failed for {url}: {e}");
+            return;
+        }
+    };
+    if scraped.markdown.trim().len() < 80 {
+        eprintln!("[link-summarizer] scraped content too thin for {url}, skipping");
+        return;
+    }
+    let summary = match summarize_with_haiku(&anthropic_key, &scraped).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[link-summarizer] summarize failed for {url}: {e}");
+            return;
+        }
+    };
+    if summary.trim().is_empty() || summary.trim() == "NO_SUMMARY" {
+        eprintln!("[link-summarizer] model declined to summarize {url}");
+        return;
+    }
+    let summary = truncate_summary(&summary);
+    {
+        let conn_state = app.state::<std::sync::Mutex<rusqlite::Connection>>();
+        let conn = match conn_state.lock() {
+            Ok(g) => g,
+            Err(e) => {
+                eprintln!("[link-summarizer] conn lock failed: {e}");
+                return;
+            }
+        };
+        if let Err(e) =
+            super::persist::set_workstream_link_summary(&conn, &link_id, Some(&summary))
+        {
+            eprintln!("[link-summarizer] persist update failed for {link_id}: {e}");
+            return;
+        }
+    }
+    let _ = app.emit(
+        "workstream-link-summarized",
+        SummarizedEvent {
+            link_id: link_id.clone(),
+            summary: summary.clone(),
+        },
+    );
+}
+
+#[derive(Serialize, Clone)]
+struct SummarizedEvent {
+    link_id: String,
+    summary: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct Scraped {
+    pub title: Option<String>,
+    pub markdown: String,
+}
+
+#[derive(Serialize)]
+struct FirecrawlRequest<'a> {
+    url: &'a str,
+    formats: &'a [&'a str],
+    #[serde(rename = "onlyMainContent")]
+    only_main_content: bool,
+}
+
+#[derive(Deserialize)]
+struct FirecrawlResponse {
+    #[serde(default)]
+    success: Option<bool>,
+    #[serde(default)]
+    data: Option<FirecrawlData>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct FirecrawlData {
+    #[serde(default)]
+    markdown: Option<String>,
+    #[serde(default)]
+    metadata: Option<FirecrawlMetadata>,
+}
+
+#[derive(Deserialize)]
+struct FirecrawlMetadata {
+    #[serde(default)]
+    title: Option<String>,
+}
+
+pub async fn firecrawl_scrape(api_key: &str, url: &str) -> Result<Scraped, String> {
+    let body = FirecrawlRequest {
+        url,
+        formats: &["markdown"],
+        only_main_content: true,
+    };
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("client init: {e}"))?;
+    let resp = client
+        .post(FIRECRAWL_ENDPOINT)
+        .header("Authorization", format!("Bearer {api_key}"))
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("network: {e}"))?;
+    let status = resp.status();
+    let text = resp.text().await.map_err(|e| format!("read body: {e}"))?;
+    if !status.is_success() {
+        return Err(format!("firecrawl returned {status}: {text}"));
+    }
+    parse_firecrawl_response(&text)
+}
+
+/// Parse Firecrawl's `/v1/scrape` JSON envelope. Public for tests;
+/// the caller never has to construct one of these by hand.
+pub fn parse_firecrawl_response(raw: &str) -> Result<Scraped, String> {
+    let parsed: FirecrawlResponse =
+        serde_json::from_str(raw).map_err(|e| format!("parse: {e}"))?;
+    if parsed.success == Some(false) {
+        let reason = parsed.error.unwrap_or_else(|| "unknown error".to_string());
+        return Err(format!("firecrawl reported failure: {reason}"));
+    }
+    let data = parsed
+        .data
+        .ok_or_else(|| "firecrawl response missing data".to_string())?;
+    let markdown = data
+        .markdown
+        .map(|m| m.trim().to_string())
+        .filter(|m| !m.is_empty())
+        .ok_or_else(|| "firecrawl returned empty markdown".to_string())?;
+    let title = data.metadata.and_then(|m| m.title);
+    let markdown = if markdown.chars().count() > SCRAPED_MARKDOWN_CAP {
+        markdown
+            .chars()
+            .take(SCRAPED_MARKDOWN_CAP)
+            .collect::<String>()
+            + "…"
+    } else {
+        markdown
+    };
+    Ok(Scraped { title, markdown })
+}
+
+#[derive(Serialize)]
+struct ApiRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    stream: bool,
+    system: &'a str,
+    messages: Vec<ApiMessage<'a>>,
+}
+
+#[derive(Serialize)]
+struct ApiMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+async fn summarize_with_haiku(api_key: &str, scraped: &Scraped) -> Result<String, String> {
+    let user_message = match &scraped.title {
+        Some(t) if !t.trim().is_empty() => {
+            format!("Title: {t}\n\n{}", scraped.markdown)
+        }
+        _ => scraped.markdown.clone(),
+    };
+    let body = ApiRequest {
+        model: HAIKU_MODEL,
+        max_tokens: 200,
+        stream: false,
+        system: SUMMARIZE_SYSTEM_PROMPT,
+        messages: vec![ApiMessage {
+            role: "user",
+            content: &user_message,
+        }],
+    };
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("client init: {e}"))?;
+    let resp = client
+        .post(ENDPOINT)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", ANTHROPIC_VERSION)
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("network: {e}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let raw = resp.text().await.unwrap_or_default();
+        return Err(format!("anthropic returned {status}: {raw}"));
+    }
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("anthropic parse: {e}"))?;
+    let text = json
+        .get("content")
+        .and_then(|c| c.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .unwrap_or_default();
+    if text.is_empty() {
+        return Err("empty response text".into());
+    }
+    Ok(text.trim().to_string())
+}
+
+/// Char-aware truncation with an ellipsis suffix.
+pub fn truncate_summary(s: &str) -> String {
+    let trimmed = s.trim();
+    if trimmed.chars().count() <= SUMMARY_MAX_CHARS {
+        return trimmed.to_string();
+    }
+    let truncated: String = trimmed.chars().take(SUMMARY_MAX_CHARS).collect();
+    format!("{truncated}…")
+}
+
+// ----- Tests --------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_firecrawl_response_extracts_markdown_and_title() {
+        let raw = r#"{
+            "success": true,
+            "data": {
+                "markdown": "Hello world\n\nThis is the page body.",
+                "metadata": {"title": "Example Domain"}
+            }
+        }"#;
+        let s = parse_firecrawl_response(raw).unwrap();
+        assert_eq!(s.title.as_deref(), Some("Example Domain"));
+        assert!(s.markdown.starts_with("Hello world"));
+    }
+
+    #[test]
+    fn parse_firecrawl_response_rejects_failed_envelope() {
+        let raw = r#"{"success": false, "error": "scrape blocked"}"#;
+        let err = parse_firecrawl_response(raw).unwrap_err();
+        assert!(err.contains("scrape blocked"));
+    }
+
+    #[test]
+    fn parse_firecrawl_response_rejects_empty_markdown() {
+        let raw = r#"{"success": true, "data": {"markdown": "  "}}"#;
+        let err = parse_firecrawl_response(raw).unwrap_err();
+        assert!(err.contains("empty"));
+    }
+
+    #[test]
+    fn parse_firecrawl_response_handles_missing_data() {
+        let raw = r#"{"success": true}"#;
+        let err = parse_firecrawl_response(raw).unwrap_err();
+        assert!(err.contains("missing data"));
+    }
+
+    #[test]
+    fn parse_firecrawl_response_truncates_long_markdown() {
+        let big = "a".repeat(20_000);
+        let raw = format!(r#"{{"success": true, "data": {{"markdown": "{big}"}}}}"#);
+        let s = parse_firecrawl_response(&raw).unwrap();
+        // Cap + the appended ellipsis.
+        assert_eq!(s.markdown.chars().count(), SCRAPED_MARKDOWN_CAP + 1);
+        assert!(s.markdown.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_summary_passes_short_strings_through() {
+        assert_eq!(truncate_summary("Short summary."), "Short summary.");
+    }
+
+    #[test]
+    fn truncate_summary_appends_ellipsis_on_overflow() {
+        let s = "x".repeat(SUMMARY_MAX_CHARS + 50);
+        let out = truncate_summary(&s);
+        assert_eq!(out.chars().count(), SUMMARY_MAX_CHARS + 1);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_summary_trims_whitespace_first() {
+        assert_eq!(truncate_summary("   hi   "), "hi");
+    }
+}

--- a/src-tauri/src/workstreams/link_summarizer.rs
+++ b/src-tauri/src/workstreams/link_summarizer.rs
@@ -50,42 +50,74 @@ If the input looks like a login wall, paywall, error, or 404 page, return only t
 /// after `add_workstream_link_from_url` inserts the row. Idempotent
 /// in the sense that if the link is gone by the time the work
 /// completes, the UPDATE no-ops.
+///
+/// Always emits `workstream-link-summarized` exactly once — with the
+/// summary string on success, or `null` (+ a short reason) on every
+/// failure path. The frontend uses the null case to clear the
+/// "Summarizing…" spinner without leaving it spinning to the 60s
+/// safety timeout.
 pub async fn populate_summary(app: AppHandle, link_id: String, url: String) {
+    let outcome = run_summary(&app, &link_id, &url).await;
+    let event = match outcome {
+        SummaryOutcome::Ok(summary) => SummarizedEvent {
+            link_id,
+            summary: Some(summary),
+            reason: None,
+        },
+        SummaryOutcome::Failed(reason) => SummarizedEvent {
+            link_id,
+            summary: None,
+            reason: Some(reason),
+        },
+    };
+    let _ = app.emit("workstream-link-summarized", event);
+}
+
+enum SummaryOutcome {
+    Ok(String),
+    /// Short, user-displayable reason. The frontend can choose to
+    /// surface it or just clear the spinner.
+    Failed(String),
+}
+
+async fn run_summary(app: &AppHandle, link_id: &str, url: &str) -> SummaryOutcome {
     let firecrawl_key = match crate::keychain::read_firecrawl_api_key() {
         Ok(k) => k,
         Err(_) => {
             eprintln!("[link-summarizer] no Firecrawl key, skipping");
-            return;
+            return SummaryOutcome::Failed("Firecrawl API key not configured".into());
         }
     };
     let anthropic_key = match crate::keychain::read_anthropic_api_key() {
         Ok(k) => k,
         Err(_) => {
             eprintln!("[link-summarizer] no Anthropic key, skipping");
-            return;
+            return SummaryOutcome::Failed("Anthropic API key not configured".into());
         }
     };
-    let scraped = match firecrawl_scrape(&firecrawl_key, &url).await {
+    let scraped = match firecrawl_scrape(&firecrawl_key, url).await {
         Ok(s) => s,
         Err(e) => {
             eprintln!("[link-summarizer] scrape failed for {url}: {e}");
-            return;
+            return SummaryOutcome::Failed("Couldn't reach the page".into());
         }
     };
     if scraped.markdown.trim().len() < 80 {
         eprintln!("[link-summarizer] scraped content too thin for {url}, skipping");
-        return;
+        return SummaryOutcome::Failed("Page content was too thin to summarize".into());
     }
     let summary = match summarize_with_haiku(&anthropic_key, &scraped).await {
         Ok(s) => s,
         Err(e) => {
             eprintln!("[link-summarizer] summarize failed for {url}: {e}");
-            return;
+            return SummaryOutcome::Failed("Summarizer call failed".into());
         }
     };
     if summary.trim().is_empty() || summary.trim() == "NO_SUMMARY" {
         eprintln!("[link-summarizer] model declined to summarize {url}");
-        return;
+        return SummaryOutcome::Failed(
+            "No summary available (page may need login)".into(),
+        );
     }
     let summary = truncate_summary(&summary);
     {
@@ -94,29 +126,31 @@ pub async fn populate_summary(app: AppHandle, link_id: String, url: String) {
             Ok(g) => g,
             Err(e) => {
                 eprintln!("[link-summarizer] conn lock failed: {e}");
-                return;
+                return SummaryOutcome::Failed("Database busy".into());
             }
         };
         if let Err(e) =
-            super::persist::set_workstream_link_summary(&conn, &link_id, Some(&summary))
+            super::persist::set_workstream_link_summary(&conn, link_id, Some(&summary))
         {
             eprintln!("[link-summarizer] persist update failed for {link_id}: {e}");
-            return;
+            return SummaryOutcome::Failed("Couldn't save summary".into());
         }
     }
-    let _ = app.emit(
-        "workstream-link-summarized",
-        SummarizedEvent {
-            link_id: link_id.clone(),
-            summary: summary.clone(),
-        },
-    );
+    SummaryOutcome::Ok(summary)
 }
 
 #[derive(Serialize, Clone)]
 struct SummarizedEvent {
     link_id: String,
-    summary: String,
+    /// `Some(summary)` on success, `None` when no summary could be
+    /// produced — the frontend clears the in-flight spinner either
+    /// way; only the success case re-renders the chip with text.
+    summary: Option<String>,
+    /// Short user-readable explanation when `summary` is `None`.
+    /// Frontend surfaces this as a small muted "unavailable" line so
+    /// the user knows the system tried.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/src/workstreams/mod.rs
+++ b/src-tauri/src/workstreams/mod.rs
@@ -19,6 +19,8 @@ use serde::Serialize;
 use tokio::sync::Mutex;
 
 pub mod commands;
+pub mod link_categorizer;
+pub mod link_summarizer;
 pub mod persist;
 pub mod signals;
 pub mod synthesizer;
@@ -141,6 +143,11 @@ pub struct WorkstreamLink {
     pub kind: Option<String>,
     pub position: i64,
     pub created_ms: i64,
+    /// AI-generated 2–3 sentence summary of the linked page. Populated
+    /// by a background task (Firecrawl scrape + Haiku summarize) after
+    /// the link row is inserted; `None` while the task is in flight or
+    /// after a silent failure (missing keys, scrape error, etc.).
+    pub summary: Option<String>,
 }
 
 /// Canonical string values for `WorkstreamLink.kind`. Soft enum so

--- a/src-tauri/src/workstreams/persist.rs
+++ b/src-tauri/src/workstreams/persist.rs
@@ -357,7 +357,7 @@ pub fn list_workstream_links(
     workstream_id: &str,
 ) -> rusqlite::Result<Vec<WorkstreamLink>> {
     let mut stmt = conn.prepare(
-        "SELECT id, workstream_id, label, url, kind, position, created_ms \
+        "SELECT id, workstream_id, label, url, kind, position, created_ms, summary \
          FROM workstream_links \
          WHERE workstream_id = ?1 \
          ORDER BY position ASC, created_ms ASC",
@@ -371,6 +371,7 @@ pub fn list_workstream_links(
             kind: r.get(4)?,
             position: r.get(5)?,
             created_ms: r.get(6)?,
+            summary: r.get(7)?,
         })
     })?;
     let mut out = Vec::new();
@@ -444,7 +445,25 @@ pub fn add_workstream_link(
         kind: kind_owned,
         position: next_position,
         created_ms: now_ms,
+        summary: None,
     })
+}
+
+/// Update a link's AI-generated summary. Used by the background
+/// summarization task once Firecrawl + Haiku finish. Returns whether
+/// the update touched a row — false means the link was removed
+/// (or the workstream deleted) while the task was in flight; the
+/// caller treats that as a harmless no-op.
+pub fn set_workstream_link_summary(
+    conn: &Connection,
+    link_id: &str,
+    summary: Option<&str>,
+) -> rusqlite::Result<bool> {
+    let n = conn.execute(
+        "UPDATE workstream_links SET summary = ?2 WHERE id = ?1",
+        params![link_id, summary],
+    )?;
+    Ok(n > 0)
 }
 
 /// Delete a single link by id. Returns whether a row was actually
@@ -1243,6 +1262,8 @@ mod tests {
             .unwrap();
         conn.execute_batch(include_str!("../migrations/019_workstream_parent.sql"))
             .unwrap();
+        conn.execute_batch(include_str!("../migrations/020_workstream_link_summary.sql"))
+            .unwrap();
         conn
     }
 
@@ -2013,6 +2034,30 @@ mod tests {
         assert!(res.is_err());
         let listed = list_workstream_links(&conn, "ws_l").unwrap();
         assert!(listed.is_empty(), "no row inserted for invalid kind");
+    }
+
+    #[test]
+    fn set_workstream_link_summary_round_trips() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_l");
+        let added =
+            add_workstream_link(&conn, "ws_l", "Repo", "https://x", Some("github"), 100)
+                .unwrap();
+        assert!(added.summary.is_none());
+
+        let updated =
+            set_workstream_link_summary(&conn, &added.id, Some("It's a repo.")).unwrap();
+        assert!(updated);
+        let listed = list_workstream_links(&conn, "ws_l").unwrap();
+        assert_eq!(listed[0].summary.as_deref(), Some("It's a repo."));
+    }
+
+    #[test]
+    fn set_workstream_link_summary_no_op_when_link_missing() {
+        let conn = open_test_db();
+        let updated =
+            set_workstream_link_summary(&conn, "wsl_nonexistent", Some("anything")).unwrap();
+        assert!(!updated, "no row touched, no error");
     }
 
     #[test]

--- a/src-tauri/src/workstreams/persist.rs
+++ b/src-tauri/src/workstreams/persist.rs
@@ -384,6 +384,18 @@ pub fn list_workstream_links(
 /// `MAX(position) + 1` for the workstream so insertion order survives
 /// even when the caller skips it. Trims label / url / kind; rejects
 /// empty label or url.
+/// Canonical kind strings accepted by the link writers. Mirrors the
+/// soft enum in [`super::link_kinds`]; gives those constants their
+/// only Rust caller and lets the writer reject typos before hitting
+/// the schema (which itself stores `kind` as opaque TEXT).
+const ALLOWED_LINK_KINDS: &[&str] = &[
+    super::link_kinds::GITHUB,
+    super::link_kinds::LINEAR,
+    super::link_kinds::NOTION,
+    super::link_kinds::FIGMA,
+    super::link_kinds::OTHER,
+];
+
 pub fn add_workstream_link(
     conn: &Connection,
     workstream_id: &str,
@@ -403,6 +415,13 @@ pub fn add_workstream_link(
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string());
+    if let Some(k) = kind_owned.as_deref() {
+        if !ALLOWED_LINK_KINDS.contains(&k) {
+            return Err(rusqlite::Error::InvalidParameterName(format!(
+                "unknown link kind: {k}"
+            )));
+        }
+    }
     let next_position: i64 = conn
         .query_row(
             "SELECT COALESCE(MAX(position), -1) + 1 FROM workstream_links \
@@ -1953,6 +1972,47 @@ mod tests {
         seed_workstream(&mut conn, "ws_l");
         assert!(add_workstream_link(&conn, "ws_l", "  ", "https://x", None, 100).is_err());
         assert!(add_workstream_link(&conn, "ws_l", "Ok", "  ", None, 100).is_err());
+    }
+
+    #[test]
+    fn add_workstream_link_accepts_each_canonical_kind() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_l");
+        for kind in [
+            super::super::link_kinds::GITHUB,
+            super::super::link_kinds::LINEAR,
+            super::super::link_kinds::NOTION,
+            super::super::link_kinds::FIGMA,
+            super::super::link_kinds::OTHER,
+        ] {
+            let row = add_workstream_link(
+                &conn,
+                "ws_l",
+                "Label",
+                &format!("https://example.com/{kind}"),
+                Some(kind),
+                100,
+            )
+            .expect("canonical kind accepted");
+            assert_eq!(row.kind.as_deref(), Some(kind));
+        }
+    }
+
+    #[test]
+    fn add_workstream_link_rejects_unknown_kind() {
+        let mut conn = open_test_db();
+        seed_workstream(&mut conn, "ws_l");
+        let res = add_workstream_link(
+            &conn,
+            "ws_l",
+            "Label",
+            "https://x",
+            Some("slack"),
+            100,
+        );
+        assert!(res.is_err());
+        let listed = list_workstream_links(&conn, "ws_l").unwrap();
+        assert!(listed.is_empty(), "no row inserted for invalid kind");
     }
 
     #[test]

--- a/src/App.css
+++ b/src/App.css
@@ -5582,6 +5582,10 @@ button.workstream-external-chip:hover {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  /* Reserve the row height so the heading doesn't jump when the
+     "+ Add link" button hides on composer open. Matches the button's
+     1px border + ~6.5px vertical padding + 12px line-height. */
+  min-height: 28px;
 }
 .workstream-links-title {
   margin: 0;
@@ -5674,6 +5678,41 @@ button.workstream-external-chip:hover {
   background: var(--bg-soft, rgba(0, 0, 0, 0.04));
   color: var(--danger, #b00020);
 }
+
+/* Two-line variant — kicks in once the AI summary lands. The chip
+   stops being a pill (rounded rect makes the second line readable),
+   and the open button stacks header row + summary line vertically.
+   We allow up to ~2 rendered lines of summary via line-clamp; the
+   full text stays accessible via the title="" tooltip. */
+.workstream-link-chip.has-summary {
+  align-items: stretch;
+  border-radius: 10px;
+}
+.workstream-link-chip.has-summary .workstream-link-chip-open {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 6px 12px;
+  max-width: 360px;
+}
+.workstream-link-chip-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+}
+.workstream-link-chip-summary {
+  font-size: 11.5px;
+  font-style: italic;
+  color: var(--fg-muted);
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: left;
+}
 .workstream-link-composer {
   display: grid;
   grid-template-columns: 1fr 1fr 130px;
@@ -5683,6 +5722,32 @@ button.workstream-external-chip:hover {
   border: 1px solid var(--home-line);
   border-radius: 8px;
   background: var(--bg, #fff);
+}
+/* Paste-only variant: URL input + actions on a single inline row,
+   no chrome wrapper. Haiku derives label + kind in the background,
+   so the input is the whole UI. */
+.workstream-link-composer-pasted {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+.workstream-link-composer-pasted .workstream-link-composer-input {
+  flex: 1 1 240px;
+  min-width: 0;
+}
+.workstream-link-composer-pasted .workstream-link-composer-actions {
+  display: contents;
+}
+.workstream-link-composer-error {
+  flex-basis: 100%;
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: var(--danger, #b00020);
 }
 .workstream-link-composer-input,
 .workstream-link-composer-kind {

--- a/src/App.css
+++ b/src/App.css
@@ -5713,6 +5713,36 @@ button.workstream-external-chip:hover {
   text-overflow: ellipsis;
   text-align: left;
 }
+/* "Summarizing…" placeholder shown right after a link is added,
+   until the Firecrawl + Haiku background task fires the event. */
+.workstream-link-chip-summary-pending {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  opacity: 0.85;
+}
+/* "No summary available" line for links the summarizer tried but
+   couldn't produce text for (paywall, login wall, scrape error,
+   model declined). Lives at the same slot as a real summary so the
+   chip stays one shape; visually slightly more muted. */
+.workstream-link-chip-summary-unavailable {
+  font-style: normal;
+  opacity: 0.65;
+}
+.workstream-link-summary-spinner {
+  width: 10px;
+  height: 10px;
+  border: 1.5px solid var(--home-line);
+  border-top-color: var(--fg-muted);
+  border-radius: 50%;
+  animation: workstream-link-summary-spin 0.85s linear infinite;
+  display: inline-block;
+}
+@keyframes workstream-link-summary-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 .workstream-link-composer {
   display: grid;
   grid-template-columns: 1fr 1fr 130px;

--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -6,11 +6,14 @@ import {
   type ConnectorStatusEvent,
   deleteAnthropicApiKey,
   deleteConnector,
+  deleteFirecrawlApiKey,
   hasAnthropicApiKey,
+  hasFirecrawlApiKey,
   listConnectors,
   listOAuthProviders,
   type OAuthProviderInfo,
   setAnthropicApiKey,
+  setFirecrawlApiKey,
   startOAuthConnector,
 } from "./file";
 import {
@@ -518,8 +521,14 @@ function AISection({ ai, onChange }: AISectionProps) {
   const [saving, setSaving] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
+  const [hasFirecrawlKey, setHasFirecrawlKey] = useState<boolean>(false);
+  const [firecrawlDraft, setFirecrawlDraft] = useState<string>("");
+  const [firecrawlSaving, setFirecrawlSaving] = useState<boolean>(false);
+  const [firecrawlError, setFirecrawlError] = useState<string | null>(null);
+
   useEffect(() => {
     void hasAnthropicApiKey().then(setHasKey);
+    void hasFirecrawlApiKey().then(setHasFirecrawlKey);
   }, []);
 
   const onSaveKey = async () => {
@@ -555,6 +564,45 @@ function AISection({ ai, onChange }: AISectionProps) {
       setError(typeof e === "string" ? e : "Failed to remove key");
     } finally {
       setSaving(false);
+    }
+  };
+
+  const onSaveFirecrawl = async () => {
+    const value = firecrawlDraft.trim();
+    if (!value) return;
+    setFirecrawlSaving(true);
+    setFirecrawlError(null);
+    try {
+      await setFirecrawlApiKey(value);
+      setFirecrawlDraft("");
+      setHasFirecrawlKey(true);
+    } catch (e) {
+      setFirecrawlError(typeof e === "string" ? e : "Failed to save key");
+    } finally {
+      setFirecrawlSaving(false);
+    }
+  };
+
+  const onRemoveFirecrawl = async () => {
+    const ok = await ask(
+      "This will clear the Firecrawl API key from your keychain. Workstream link summaries will stop populating until you paste it back.",
+      {
+        title: "Remove Firecrawl key?",
+        kind: "warning",
+        okLabel: "Remove",
+        cancelLabel: "Cancel",
+      },
+    );
+    if (!ok) return;
+    setFirecrawlSaving(true);
+    setFirecrawlError(null);
+    try {
+      await deleteFirecrawlApiKey();
+      setHasFirecrawlKey(false);
+    } catch (e) {
+      setFirecrawlError(typeof e === "string" ? e : "Failed to remove key");
+    } finally {
+      setFirecrawlSaving(false);
     }
   };
 
@@ -597,6 +645,55 @@ function AISection({ ai, onChange }: AISectionProps) {
             </span>
           </div>
           {error && <div className="settings-error">{error}</div>}
+        </div>
+      </div>
+
+      <div className="settings-row">
+        <div className="settings-row-label">Firecrawl API key</div>
+        <div className="settings-row-control settings-row-control--col">
+          <div className="settings-actions">
+            <input
+              type="password"
+              className="settings-input"
+              placeholder={
+                hasFirecrawlKey ? "•••••••• (saved in Keychain)" : "fc-…"
+              }
+              value={firecrawlDraft}
+              onChange={(e) => setFirecrawlDraft(e.target.value)}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <button
+              className="ghost"
+              onClick={() => void onSaveFirecrawl()}
+              disabled={firecrawlSaving || !firecrawlDraft.trim()}
+            >
+              Save
+            </button>
+            {hasFirecrawlKey && (
+              <button
+                className="ghost"
+                onClick={() => void onRemoveFirecrawl()}
+                disabled={firecrawlSaving}
+              >
+                Remove
+              </button>
+            )}
+          </div>
+          <div className="settings-row-control">
+            <span
+              className={"settings-status " + (hasFirecrawlKey ? "ok" : "muted")}
+            >
+              {hasFirecrawlKey ? "Configured" : "Not configured"}
+            </span>
+            <span className="settings-hint">
+              Stored in macOS Keychain. Optional — without it, workstream
+              link chips won't populate AI-generated summaries.
+            </span>
+          </div>
+          {firecrawlError && (
+            <div className="settings-error">{firecrawlError}</div>
+          )}
         </div>
       </div>
 

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -38,7 +38,15 @@ import {
   setWorkstreamUserNotes,
 } from "./file";
 import { DueChip } from "./Home";
-import { IconCheck, IconChevLeft, IconLink, IconMore, IconPlus, IconTrash } from "./icons";
+import {
+  IconBrand,
+  IconCheck,
+  IconChevLeft,
+  IconLink,
+  IconMore,
+  IconPlus,
+  IconTrash,
+} from "./icons";
 import { avatarColor, initialsFromName } from "./initials";
 
 // ----- List view -----------------------------------------------------------
@@ -1462,7 +1470,7 @@ function LinksSection({
                 onClick={() => void handleOpen(link.url)}
                 title={link.url}
               >
-                <IconLink size={12} sw={1.8} />
+                <IconBrand kind={link.kind} size={12} />
                 <span className="workstream-link-chip-label">
                   {link.label}
                 </span>

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -9,20 +9,21 @@
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { listen } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
 import {
   AliasKind,
   type EmailMessage,
   type ExternalParticipant,
-  LinkKind,
   type TeamMember,
   type Workstream,
   type WorkstreamAction,
   type WorkstreamDetail,
   type WorkstreamLink,
+  type WorkstreamLinkSummarizedEvent,
   type WorkstreamStatus,
-  addWorkstreamLink,
+  addWorkstreamLinkFromUrl,
   createTeamMember,
   getEmailBody,
   getWorkstreamDetails,
@@ -1389,13 +1390,18 @@ function ExternalChipModal({
 
 // ----- User-curated links (#88) -------------------------------------------
 
-const LINK_KIND_OPTIONS: Array<{ value: string; label: string }> = [
-  { value: LinkKind.GitHub, label: "GitHub" },
-  { value: LinkKind.Linear, label: "Linear" },
-  { value: LinkKind.Notion, label: "Notion" },
-  { value: LinkKind.Figma, label: "Figma" },
-  { value: LinkKind.Other, label: "Other" },
-];
+/// Subscribe to the backend's `workstream-link-summarized` event,
+/// which fires after the Firecrawl + Haiku background task lands a
+/// row. Returns the unlisten handle so callers can clean up on
+/// unmount.
+async function listenForSummary(
+  cb: (payload: WorkstreamLinkSummarizedEvent) => void,
+): Promise<() => void> {
+  return listen<WorkstreamLinkSummarizedEvent>(
+    "workstream-link-summarized",
+    (event) => cb(event.payload),
+  );
+}
 
 function LinksSection({
   workstreamId,
@@ -1407,6 +1413,36 @@ function LinksSection({
   onLinksChanged: (next: WorkstreamLink[]) => void;
 }) {
   const [composerOpen, setComposerOpen] = useState(false);
+
+  // The summarization background task fires `workstream-link-summarized`
+  // when it lands a row. Refs keep the listener stable across renders
+  // while still seeing the freshest props.
+  const linksRef = useRef(links);
+  const onLinksChangedRef = useRef(onLinksChanged);
+  useEffect(() => {
+    linksRef.current = links;
+  }, [links]);
+  useEffect(() => {
+    onLinksChangedRef.current = onLinksChanged;
+  }, [onLinksChanged]);
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    void listenForSummary((payload) => {
+      const next = linksRef.current.map((l) =>
+        l.id === payload.link_id ? { ...l, summary: payload.summary } : l,
+      );
+      // Only re-render when this workstream actually owned the link;
+      // avoids unnecessary state updates on cross-workstream events.
+      if (next.some((l) => l.id === payload.link_id)) {
+        onLinksChangedRef.current(next);
+      }
+    }).then((stop) => {
+      unlisten = stop;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, []);
 
   const handleOpen = async (url: string) => {
     try {
@@ -1429,13 +1465,19 @@ function LinksSection({
     }
   };
 
-  const handleAdd = async (label: string, url: string, kind: string | null) => {
+  const handleAdd = async (url: string): Promise<string | null> => {
     try {
-      const created = await addWorkstreamLink(workstreamId, label, url, kind);
+      const created = await addWorkstreamLinkFromUrl(workstreamId, url);
       onLinksChanged([...links, created]);
       setComposerOpen(false);
+      return null;
     } catch (err) {
-      console.error("[workstreams] addWorkstreamLink failed", err);
+      console.error("[workstreams] addWorkstreamLinkFromUrl failed", err);
+      return typeof err === "string"
+        ? err
+        : err instanceof Error
+          ? err.message
+          : "Could not add link";
     }
   };
 
@@ -1463,20 +1505,33 @@ function LinksSection({
       {links.length > 0 ? (
         <div className="workstream-links-chips">
           {links.map((link) => (
-            <div className="workstream-link-chip" key={link.id}>
+            <div
+              className={
+                "workstream-link-chip" +
+                (link.summary ? " has-summary" : "")
+              }
+              key={link.id}
+            >
               <button
                 type="button"
                 className="workstream-link-chip-open"
                 onClick={() => void handleOpen(link.url)}
-                title={link.url}
+                title={link.summary ?? link.url}
               >
-                <IconBrand kind={link.kind} size={12} />
-                <span className="workstream-link-chip-label">
-                  {link.label}
+                <span className="workstream-link-chip-row">
+                  <IconBrand kind={link.kind} size={12} />
+                  <span className="workstream-link-chip-label">
+                    {link.label}
+                  </span>
+                  {link.kind ? (
+                    <span className="workstream-link-chip-kind">
+                      {link.kind}
+                    </span>
+                  ) : null}
                 </span>
-                {link.kind ? (
-                  <span className="workstream-link-chip-kind">
-                    {link.kind}
+                {link.summary ? (
+                  <span className="workstream-link-chip-summary">
+                    {link.summary}
                   </span>
                 ) : null}
               </button>
@@ -1496,7 +1551,7 @@ function LinksSection({
       {composerOpen ? (
         <LinkComposer
           onCancel={() => setComposerOpen(false)}
-          onSubmit={(label, url, kind) => void handleAdd(label, url, kind)}
+          onSubmit={(url) => handleAdd(url)}
         />
       ) : null}
     </section>
@@ -1508,73 +1563,55 @@ function LinkComposer({
   onSubmit,
 }: {
   onCancel: () => void;
-  onSubmit: (label: string, url: string, kind: string | null) => void;
+  /** Returns `null` on success (composer dismissed by parent), or an
+   *  error string the composer surfaces inline. */
+  onSubmit: (url: string) => Promise<string | null>;
 }) {
-  const [label, setLabel] = useState("");
   const [url, setUrl] = useState("");
-  const [kind, setKind] = useState<string>(LinkKind.Other);
-  const labelRef = useRef<HTMLInputElement | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const urlRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
-    labelRef.current?.focus();
+    urlRef.current?.focus();
   }, []);
 
-  const canSubmit = label.trim() !== "" && url.trim() !== "";
+  const canSubmit = url.trim() !== "" && !busy;
 
-  const submit = () => {
+  const submit = async () => {
     if (!canSubmit) return;
-    onSubmit(label.trim(), url.trim(), kind || null);
+    setBusy(true);
+    setError(null);
+    const err = await onSubmit(url.trim());
+    setBusy(false);
+    if (err) setError(err);
   };
 
   return (
-    <div className="workstream-link-composer">
+    <div className="workstream-link-composer workstream-link-composer-pasted">
       <input
-        ref={labelRef}
-        type="text"
-        className="workstream-link-composer-input"
-        placeholder="Label (e.g. Repo)"
-        value={label}
-        onChange={(e) => setLabel(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            submit();
-          } else if (e.key === "Escape") {
-            onCancel();
-          }
-        }}
-      />
-      <input
+        ref={urlRef}
         type="url"
         className="workstream-link-composer-input"
-        placeholder="https://…"
+        placeholder="Paste a URL — we'll name it for you"
         value={url}
+        disabled={busy}
         onChange={(e) => setUrl(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === "Enter") {
             e.preventDefault();
-            submit();
+            void submit();
           } else if (e.key === "Escape") {
             onCancel();
           }
         }}
       />
-      <select
-        className="workstream-link-composer-kind"
-        value={kind}
-        onChange={(e) => setKind(e.target.value)}
-      >
-        {LINK_KIND_OPTIONS.map((opt) => (
-          <option key={opt.value} value={opt.value}>
-            {opt.label}
-          </option>
-        ))}
-      </select>
       <div className="workstream-link-composer-actions">
         <button
           type="button"
           className="workstream-link-composer-cancel"
           onClick={onCancel}
+          disabled={busy}
         >
           Cancel
         </button>
@@ -1582,11 +1619,14 @@ function LinkComposer({
           type="button"
           className="workstream-link-composer-save"
           disabled={!canSubmit}
-          onClick={submit}
+          onClick={() => void submit()}
         >
-          Add
+          {busy ? "Naming…" : "Add"}
         </button>
       </div>
+      {error ? (
+        <p className="workstream-link-composer-error">{error}</p>
+      ) : null}
     </div>
   );
 }

--- a/src/Workstreams.tsx
+++ b/src/Workstreams.tsx
@@ -1413,6 +1413,17 @@ function LinksSection({
   onLinksChanged: (next: WorkstreamLink[]) => void;
 }) {
   const [composerOpen, setComposerOpen] = useState(false);
+  /** Link ids currently being summarized in the background. The
+   *  summary task fires `workstream-link-summarized` once per add
+   *  (success OR failure). The 60s ceiling is a belt-and-braces
+   *  fallback in case the event somehow never lands. */
+  const [pending, setPending] = useState<Set<string>>(() => new Set());
+  /** Per-link "couldn't generate" reason, surfaced as a muted line
+   *  on the chip when the summary task finished without producing
+   *  text (paywalled / login-walled / scrape failed / etc.). */
+  const [unavailable, setUnavailable] = useState<Map<string, string>>(
+    () => new Map(),
+  );
 
   // The summarization background task fires `workstream-link-summarized`
   // when it lands a row. Refs keep the listener stable across renders
@@ -1426,23 +1437,75 @@ function LinksSection({
     onLinksChangedRef.current = onLinksChanged;
   }, [onLinksChanged]);
   useEffect(() => {
+    // React StrictMode + HMR will mount → unmount → mount again. Track
+    // `cancelled` so that if the component unmounts before
+    // `listenForSummary` resolves, we immediately invoke `stop` from
+    // the resolution callback rather than stashing it on a stale
+    // closure (which then triggers `listeners[eventId].handlerId` on
+    // a torn-down listener).
+    let cancelled = false;
     let unlisten: (() => void) | undefined;
     void listenForSummary((payload) => {
-      const next = linksRef.current.map((l) =>
-        l.id === payload.link_id ? { ...l, summary: payload.summary } : l,
-      );
-      // Only re-render when this workstream actually owned the link;
-      // avoids unnecessary state updates on cross-workstream events.
-      if (next.some((l) => l.id === payload.link_id)) {
-        onLinksChangedRef.current(next);
+      // Success path: patch the link with the new summary text.
+      if (payload.summary) {
+        const next = linksRef.current.map((l) =>
+          l.id === payload.link_id ? { ...l, summary: payload.summary } : l,
+        );
+        if (next.some((l) => l.id === payload.link_id)) {
+          onLinksChangedRef.current(next);
+        }
+      } else if (payload.reason) {
+        // Failure path: surface the reason inline so the user knows
+        // the system tried, even though it couldn't produce text.
+        setUnavailable((prev) => {
+          const next = new Map(prev);
+          next.set(payload.link_id, payload.reason ?? "No summary available");
+          return next;
+        });
       }
+      // Clear the in-flight spinner regardless of outcome.
+      setPending((prev) => {
+        if (!prev.has(payload.link_id)) return prev;
+        const next = new Set(prev);
+        next.delete(payload.link_id);
+        return next;
+      });
     }).then((stop) => {
-      unlisten = stop;
+      if (cancelled) {
+        try {
+          stop();
+        } catch {
+          /* listener already torn down */
+        }
+      } else {
+        unlisten = stop;
+      }
     });
     return () => {
-      unlisten?.();
+      cancelled = true;
+      try {
+        unlisten?.();
+      } catch {
+        /* listener already torn down */
+      }
     };
   }, []);
+
+  /** Mark a link as in-flight and auto-expire after a generous
+   *  ceiling so a silently-failed summarization doesn't leave the
+   *  spinner spinning forever. The Firecrawl scrape is bounded at
+   *  30s and Haiku at 15s; 60s is the safe upper bound. */
+  const trackPending = (linkId: string) => {
+    setPending((prev) => new Set(prev).add(linkId));
+    window.setTimeout(() => {
+      setPending((prev) => {
+        if (!prev.has(linkId)) return prev;
+        const next = new Set(prev);
+        next.delete(linkId);
+        return next;
+      });
+    }, 60_000);
+  };
 
   const handleOpen = async (url: string) => {
     try {
@@ -1469,6 +1532,9 @@ function LinksSection({
     try {
       const created = await addWorkstreamLinkFromUrl(workstreamId, url);
       onLinksChanged([...links, created]);
+      // Backend just kicked off the summary task; show the
+      // "Summarizing…" placeholder until the event lands.
+      trackPending(created.id);
       setComposerOpen(false);
       return null;
     } catch (err) {
@@ -1508,7 +1574,11 @@ function LinksSection({
             <div
               className={
                 "workstream-link-chip" +
-                (link.summary ? " has-summary" : "")
+                (link.summary ||
+                pending.has(link.id) ||
+                unavailable.has(link.id)
+                  ? " has-summary"
+                  : "")
               }
               key={link.id}
             >
@@ -1523,15 +1593,19 @@ function LinksSection({
                   <span className="workstream-link-chip-label">
                     {link.label}
                   </span>
-                  {link.kind ? (
-                    <span className="workstream-link-chip-kind">
-                      {link.kind}
-                    </span>
-                  ) : null}
                 </span>
                 {link.summary ? (
                   <span className="workstream-link-chip-summary">
                     {link.summary}
+                  </span>
+                ) : pending.has(link.id) ? (
+                  <span className="workstream-link-chip-summary workstream-link-chip-summary-pending">
+                    <span className="workstream-link-summary-spinner" aria-hidden />
+                    Summarizing…
+                  </span>
+                ) : unavailable.has(link.id) ? (
+                  <span className="workstream-link-chip-summary workstream-link-chip-summary-unavailable">
+                    {unavailable.get(link.id)}
                   </span>
                 ) : null}
               </button>

--- a/src/file.ts
+++ b/src/file.ts
@@ -595,12 +595,15 @@ export type WorkstreamLink = {
 };
 
 /** Payload shape for the `workstream-link-summarized` Tauri event the
- *  backend emits after the summarization task lands a row. The
- *  detail view subscribes and patches its in-state link so the chip
- *  re-renders without a refetch. */
+ *  backend emits after the summarization task finishes — fires once
+ *  per add. `summary` is the rendered text on success; `null` on any
+ *  failure path (no key, scrape error, model declined, etc.) with
+ *  `reason` carrying a short user-displayable explanation. The
+ *  frontend clears its in-flight spinner either way. */
 export type WorkstreamLinkSummarizedEvent = {
   link_id: string;
-  summary: string;
+  summary: string | null;
+  reason?: string;
 };
 
 export const LinkKind = {

--- a/src/file.ts
+++ b/src/file.ts
@@ -49,6 +49,18 @@ export async function deleteAnthropicApiKey(): Promise<void> {
   await invoke<void>("delete_anthropic_api_key");
 }
 
+export async function hasFirecrawlApiKey(): Promise<boolean> {
+  return invoke<boolean>("has_firecrawl_api_key");
+}
+
+export async function setFirecrawlApiKey(key: string): Promise<void> {
+  await invoke<void>("set_firecrawl_api_key", { key });
+}
+
+export async function deleteFirecrawlApiKey(): Promise<void> {
+  await invoke<void>("delete_firecrawl_api_key");
+}
+
 // --- Notes (bundle abstraction) ------------------------------------------
 
 export type NoteRef = { id: string; note_path: string };
@@ -575,6 +587,20 @@ export type WorkstreamLink = {
   kind: string | null;
   position: number;
   created_ms: number;
+  /** AI-generated 2–3 sentence summary of the linked page. Populated
+   *  by a background task after the link row lands; `null` while in
+   *  flight or after a silent failure. The chip surfaces it as a
+   *  second muted italic line; absent when null. */
+  summary: string | null;
+};
+
+/** Payload shape for the `workstream-link-summarized` Tauri event the
+ *  backend emits after the summarization task lands a row. The
+ *  detail view subscribes and patches its in-state link so the chip
+ *  re-renders without a refetch. */
+export type WorkstreamLinkSummarizedEvent = {
+  link_id: string;
+  summary: string;
 };
 
 export const LinkKind = {
@@ -706,6 +732,21 @@ export async function addWorkstreamLink(
     label,
     url,
     kind: kind ?? null,
+  });
+}
+
+/** Paste-only link entry: backend asks Haiku to derive a `(label, kind)`
+ *  pair from the URL and persists via the same path as `addWorkstreamLink`.
+ *  Falls back to `(hostname, "other")` when categorization fails (no API
+ *  key, network blip, malformed model output) — the user always gets a
+ *  usable chip back. */
+export async function addWorkstreamLinkFromUrl(
+  workstreamId: string,
+  url: string,
+): Promise<WorkstreamLink> {
+  return invoke<WorkstreamLink>("add_workstream_link_from_url", {
+    workstreamId,
+    url,
   });
 }
 

--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { siFigma, siGithub, siLinear, siNotion } from "simple-icons";
 
 type IconProps = {
   size?: number;
@@ -70,6 +71,40 @@ export const IconLink = (p: Props) => (
     <path d="M14 10a4 4 0 00-5.6 0l-3 3a4 4 0 105.6 5.6l1-1" />
   </Icon>
 );
+
+/// Per-kind brand glyphs for workstream link chips. Maps each
+/// canonical `link_kinds::*` value to its Simple Icons path; falls
+/// back to the generic `IconLink` for `other` / null / unknown.
+/// Brand path uses `currentColor` so the chip's own color rules drive
+/// the glyph — keeps the palette consistent with the rest of the UI.
+const BRAND_PATHS: Record<string, string> = {
+  github: siGithub.path,
+  linear: siLinear.path,
+  notion: siNotion.path,
+  figma: siFigma.path,
+};
+
+export const IconBrand = ({
+  kind,
+  size = 12,
+}: {
+  kind: string | null;
+  size?: number;
+}) => {
+  const path = kind ? BRAND_PATHS[kind] : undefined;
+  if (!path) return <IconLink size={size} sw={1.8} />;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d={path} />
+    </svg>
+  );
+};
 export const IconBriefcase = (p: Props) => (
   <Icon {...p}>
     <rect x="3" y="7" width="18" height="13" rx="2" />


### PR DESCRIPTION
## Summary

Finishes the link-kind soft enum that was stubbed in #88 (Linked external URLs on workstreams):

- **Per-kind icons** for the link chip via [Simple Icons](https://simpleicons.org). Each canonical kind (`github` / `linear` / `notion` / `figma`) renders the brand mark; `other` / null / unknown fall back to the existing generic `IconLink`.
- **Server-side validation** on `add_workstream_link` — rejects non-null kinds that aren't in the canonical set. Gives the previously-unused `link_kinds::*` Rust constants their first caller and silences the dead-code warnings the release build was flagging.

## Approach

### Frontend

- Add `simple-icons` to `package.json`. Per-icon named imports (`import { siGithub, siLinear, siNotion, siFigma } from "simple-icons"`) tree-shake the rest of the catalog out — only the four paths we actually render ship.
- New `IconBrand` component in `src/icons.tsx` that maps a kind string to the matching path; falls back to `IconLink` when there's no mapping. Uses `fill="currentColor"` so the chip's hover/muted color rules drive the glyph — we deliberately ignore each brand's `hex` because a sea of multicolored chips would clash with the rest of the UI; the *shape* alone is recognizable.
- Workstream link chip in `Workstreams.tsx` swaps `IconLink` for `IconBrand kind={link.kind}`.

### Backend

- New `ALLOWED_LINK_KINDS: &[&str]` const in `persist.rs` references each `link_kinds::*` constant. Single source of truth for "what the writer accepts."
- `add_workstream_link` validates the trimmed kind against the set; returns a `rusqlite::Error::InvalidParameterName` with a clear "unknown link kind: <value>" message that the Tauri command surfaces verbatim to the UI.

## Test plan

- [x] `cargo test --lib` — 264 passed (was 262; +2 new).
  - `add_workstream_link_accepts_each_canonical_kind`: all five canonical strings round-trip.
  - `add_workstream_link_rejects_unknown_kind`: error path + zero rows inserted.
- [x] `bun run build` — TS + Vite clean. Bundle delta ~11 KB raw / ~5 KB gzip from the four brand paths.
- [ ] Manual: existing GitHub / Linear / Notion / Figma links render their brand glyph; an `other` or null-kind link renders the generic chain icon. Adding a link via direct invoke with `kind: "slack"` fails with the validation message.

## Out of scope (intentional, same as the original #88 cuts)

- Auto-detect kind from URL.
- Drag-and-drop reorder.
- Link previews / OG fetching.
- Coloring chips with each brand's hex (kept muted for palette consistency).