### PR TITLE
Phase 2.1 — Action deletions log: schema + universal write path (#147)

### DIFF
--- a/src-tauri/src/action_deletions.rs
+++ b/src-tauri/src/action_deletions.rs
@@ -1,0 +1,399 @@
+//! Universal action deletion log (#147).
+//!
+//! Every path that removes an action row — user delete, user dismiss,
+//! worker auto-resolve at threshold — calls [`log_deletion`] inside the
+//! same transaction. Readers in #148/#149/#150 query this log to feed
+//! the user's rejections back into the LLM prompts that produce action
+//! items.
+//!
+//! The log row is a verbatim snapshot of the action's identity at the
+//! moment of deletion (text, origin metadata, subject, assignee) plus a
+//! `cause` discriminator. Snapshot fields are deliberately not FKs:
+//! the action row is gone by the time a reader cares, and dangling
+//! team-member ids don't break the learning signal.
+
+use rusqlite::{params, OptionalExtension, Transaction};
+
+/// Cause discriminator written into `action_deletions.cause`. Readers
+/// gate on these values — most consumers ignore [`Cause::AutoResolved`]
+/// because worker omissions are weak signal, not user intent.
+#[derive(Debug, Clone, Copy)]
+pub enum Cause {
+    /// User explicitly removed the row from any surface (Home, sidebar,
+    /// workstream detail, etc.).
+    UserDelete,
+    /// User pressed "Ignore" on a worker-extracted waiting action.
+    UserDismiss,
+    /// Profile worker's hysteresis threshold flipped `done = 1` after
+    /// repeated LLM omissions of the source ref.
+    AutoResolved,
+}
+
+impl Cause {
+    fn as_str(self) -> &'static str {
+        match self {
+            Cause::UserDelete => "user_delete",
+            Cause::UserDismiss => "user_dismiss",
+            Cause::AutoResolved => "auto_resolved",
+        }
+    }
+}
+
+/// Snapshot the action row identified by `action_id` and insert a row
+/// into `action_deletions`. No-op (returns Ok) when the action row is
+/// already gone — keeps the call safe to invoke optimistically before
+/// path-specific delete logic that may race.
+///
+/// `deleted_ms` is the current wall clock. Callers pass it in so the
+/// log timestamp matches whatever timestamp the surrounding write uses
+/// (e.g. the `auto_resolved_ms` stamp written by the worker on the
+/// same tick).
+pub fn log_deletion(
+    tx: &Transaction<'_>,
+    action_id: &str,
+    cause: Cause,
+    deleted_ms: i64,
+) -> rusqlite::Result<()> {
+    let row: Option<(
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        String,
+    )> = tx
+        .query_row(
+            "SELECT origin_kind, origin_synth_kind, origin_synth_id, \
+                    origin_note_id, subject_member_id, assignee_id, text \
+               FROM actions WHERE id = ?1",
+            params![action_id],
+            |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, Option<String>>(1)?,
+                    r.get::<_, Option<String>>(2)?,
+                    r.get::<_, Option<String>>(3)?,
+                    r.get::<_, Option<String>>(4)?,
+                    r.get::<_, Option<String>>(5)?,
+                    r.get::<_, String>(6)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((
+        origin_kind,
+        origin_synth_kind,
+        origin_synth_id,
+        origin_note_id,
+        subject_member_id,
+        assignee_id,
+        text,
+    )) = row
+    else {
+        return Ok(());
+    };
+
+    // series_master_id only makes sense for reconcile-origin rows —
+    // they're the ones tied to a meeting note bundle whose calendar
+    // event may be part of a recurring series. For other origins,
+    // leave NULL so #148 doesn't grab unrelated rows.
+    let source_series_master_id: Option<String> = if origin_kind == "reconcile" {
+        origin_note_id
+            .as_deref()
+            .and_then(|note_id| {
+                tx.query_row(
+                    "SELECT series_master_id FROM calendar_events \
+                      WHERE linked_note_id = ?1 \
+                        AND series_master_id IS NOT NULL \
+                      LIMIT 1",
+                    params![note_id],
+                    |r| r.get::<_, Option<String>>(0),
+                )
+                .optional()
+                .ok()
+                .flatten()
+                .flatten()
+            })
+    } else {
+        None
+    };
+
+    tx.execute(
+        "INSERT INTO action_deletions \
+            (deleted_ms, origin_kind, origin_synth_kind, origin_synth_id, \
+             origin_note_id, subject_member_id, assignee_id, text, \
+             source_series_master_id, cause) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        params![
+            deleted_ms,
+            origin_kind,
+            origin_synth_kind,
+            origin_synth_id,
+            origin_note_id,
+            subject_member_id,
+            assignee_id,
+            text,
+            source_series_master_id,
+            cause.as_str(),
+        ],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    /// Minimal schema replica for testing the helper in isolation.
+    /// Mirrors the columns the helper reads and writes — not a full
+    /// production schema. The real migration ladder is exercised by
+    /// the persist + notes test fixtures.
+    fn open_test_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "PRAGMA foreign_keys = ON;
+             CREATE TABLE actions (
+                 id                TEXT PRIMARY KEY,
+                 origin_kind       TEXT NOT NULL,
+                 origin_synth_kind TEXT,
+                 origin_synth_id   TEXT,
+                 origin_note_id    TEXT,
+                 subject_member_id TEXT,
+                 assignee_id       TEXT,
+                 text              TEXT NOT NULL
+             );
+             CREATE TABLE calendar_events (
+                 id                TEXT PRIMARY KEY,
+                 linked_note_id    TEXT,
+                 series_master_id  TEXT
+             );
+             CREATE TABLE action_deletions (
+                 id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+                 deleted_ms              INTEGER NOT NULL,
+                 origin_kind             TEXT NOT NULL,
+                 origin_synth_kind       TEXT,
+                 origin_synth_id         TEXT,
+                 origin_note_id          TEXT,
+                 subject_member_id       TEXT,
+                 assignee_id             TEXT,
+                 text                    TEXT NOT NULL,
+                 source_series_master_id TEXT,
+                 cause                   TEXT NOT NULL DEFAULT 'user_delete'
+             );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn seed_action(
+        conn: &Connection,
+        id: &str,
+        origin_kind: &str,
+        origin_synth_kind: Option<&str>,
+        origin_synth_id: Option<&str>,
+        origin_note_id: Option<&str>,
+        subject_member_id: Option<&str>,
+        assignee_id: Option<&str>,
+        text: &str,
+    ) {
+        conn.execute(
+            "INSERT INTO actions (id, origin_kind, origin_synth_kind, \
+                origin_synth_id, origin_note_id, subject_member_id, \
+                assignee_id, text) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                id,
+                origin_kind,
+                origin_synth_kind,
+                origin_synth_id,
+                origin_note_id,
+                subject_member_id,
+                assignee_id,
+                text,
+            ],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn log_records_user_delete_with_full_snapshot() {
+        let mut conn = open_test_db();
+        seed_action(
+            &conn,
+            "a1",
+            "synth",
+            Some("email_waiting"),
+            Some("e:42"),
+            None,
+            Some("tm:heike"),
+            Some("tm:self"),
+            "Reply to Heike re Q3 budget",
+        );
+        let tx = conn.transaction().unwrap();
+        log_deletion(&tx, "a1", Cause::UserDelete, 1_234).unwrap();
+        tx.commit().unwrap();
+
+        let row: (
+            i64,
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            String,
+            Option<String>,
+            String,
+        ) = conn
+            .query_row(
+                "SELECT deleted_ms, origin_kind, origin_synth_kind, \
+                        origin_synth_id, origin_note_id, subject_member_id, \
+                        assignee_id, text, source_series_master_id, cause \
+                   FROM action_deletions",
+                [],
+                |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get(4)?,
+                        r.get(5)?,
+                        r.get(6)?,
+                        r.get(7)?,
+                        r.get(8)?,
+                        r.get(9)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(row.0, 1_234);
+        assert_eq!(row.1, "synth");
+        assert_eq!(row.2.as_deref(), Some("email_waiting"));
+        assert_eq!(row.3.as_deref(), Some("e:42"));
+        assert!(row.4.is_none());
+        assert_eq!(row.5.as_deref(), Some("tm:heike"));
+        assert_eq!(row.6.as_deref(), Some("tm:self"));
+        assert_eq!(row.7, "Reply to Heike re Q3 budget");
+        assert!(
+            row.8.is_none(),
+            "synth-origin row has no series_master_id"
+        );
+        assert_eq!(row.9, "user_delete");
+    }
+
+    #[test]
+    fn log_records_user_dismiss_with_correct_cause() {
+        let mut conn = open_test_db();
+        seed_action(
+            &conn,
+            "a2",
+            "synth",
+            Some("teams_waiting"),
+            Some("t:7"),
+            None,
+            Some("tm:davis"),
+            Some("tm:self"),
+            "Follow up with Davis",
+        );
+        let tx = conn.transaction().unwrap();
+        log_deletion(&tx, "a2", Cause::UserDismiss, 2_000).unwrap();
+        tx.commit().unwrap();
+
+        let cause: String = conn
+            .query_row(
+                "SELECT cause FROM action_deletions WHERE text = ?1",
+                params!["Follow up with Davis"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(cause, "user_dismiss");
+    }
+
+    #[test]
+    fn log_populates_series_master_id_for_recurring_meeting_actions() {
+        let mut conn = open_test_db();
+        seed_action(
+            &conn,
+            "a3",
+            "reconcile",
+            None,
+            None,
+            Some("note:bundle-7"),
+            None,
+            Some("tm:self"),
+            "Confirm next week's agenda",
+        );
+        conn.execute(
+            "INSERT INTO calendar_events (id, linked_note_id, series_master_id) \
+             VALUES ('ev:1', 'note:bundle-7', 'series:weekly-standup')",
+            [],
+        )
+        .unwrap();
+
+        let tx = conn.transaction().unwrap();
+        log_deletion(&tx, "a3", Cause::UserDelete, 3_000).unwrap();
+        tx.commit().unwrap();
+
+        let series: Option<String> = conn
+            .query_row(
+                "SELECT source_series_master_id FROM action_deletions WHERE text = ?1",
+                params!["Confirm next week's agenda"],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(series.as_deref(), Some("series:weekly-standup"));
+    }
+
+    #[test]
+    fn log_leaves_series_null_when_event_is_oneoff() {
+        let mut conn = open_test_db();
+        seed_action(
+            &conn,
+            "a4",
+            "reconcile",
+            None,
+            None,
+            Some("note:bundle-9"),
+            None,
+            None,
+            "Send recap",
+        );
+        // Event linked to the bundle but with no series_master_id.
+        conn.execute(
+            "INSERT INTO calendar_events (id, linked_note_id, series_master_id) \
+             VALUES ('ev:2', 'note:bundle-9', NULL)",
+            [],
+        )
+        .unwrap();
+
+        let tx = conn.transaction().unwrap();
+        log_deletion(&tx, "a4", Cause::UserDelete, 4_000).unwrap();
+        tx.commit().unwrap();
+
+        let series: Option<String> = conn
+            .query_row(
+                "SELECT source_series_master_id FROM action_deletions",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(series.is_none(), "one-off meeting must not get a series id");
+    }
+
+    #[test]
+    fn log_handles_deletes_after_action_row_is_already_gone_gracefully() {
+        let mut conn = open_test_db();
+        // No seed — action 'phantom' does not exist.
+        let tx = conn.transaction().unwrap();
+        log_deletion(&tx, "phantom", Cause::UserDelete, 5_000).unwrap();
+        tx.commit().unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM action_deletions", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0, "missing rows must not be logged");
+    }
+}

--- a/src-tauri/src/actions_migration.rs
+++ b/src-tauri/src/actions_migration.rs
@@ -1,0 +1,623 @@
+//! Phase 1.4 (#146) — one-time backfill of pre-#144 reconciled notes.
+//!
+//! Walks every note that has a sibling `transcript.json` (proxied by
+//! `notes.duration_ms IS NOT NULL`) and an inline `## Action items`
+//! block in its `body_md`. For each such note: parses the block into
+//! reconcile-origin rows, preserves done/manual_override/assignee_id
+//! across the origin flip, strips the block from `body_md` via
+//! `upsert_in_tx`, and writes a per-note `.action-items-backup.md`
+//! snapshot of the original body for rollback.
+//!
+//! Idempotent: a subsequent run finds nothing to migrate because the
+//! `## Action items` heading is no longer in the body. Transactional
+//! per-note: a failure on one note doesn't abort the rest.
+
+use std::fs;
+
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::Serialize;
+
+const BACKUP_FILENAME: &str = ".action-items-backup.md";
+const FLAG_KEY: &str = "actions_migration_v1_completed";
+
+#[derive(Serialize, Default, Debug, Clone)]
+pub struct MigrationReport {
+    pub dry_run: bool,
+    /// Notes with a transcript and a `## Action items` substring in body.
+    pub candidates_scanned: u32,
+    /// Notes whose body actually contained a block we extracted.
+    pub notes_migrated: u32,
+    /// Reconcile-origin rows touched (inserted or replaced-with-preserved).
+    pub rows_created: u32,
+    /// New backup files written (i.e. ones that didn't already exist).
+    pub backups_written: u32,
+    /// Candidates that matched on the LIKE heuristic but had no real block.
+    pub notes_already_clean: u32,
+    /// Per-note error messages (the migration continues on per-note failure).
+    pub errors: Vec<String>,
+}
+
+struct Candidate {
+    note_id: String,
+    body_md: String,
+}
+
+pub fn run(conn: &mut Connection, dry_run: bool) -> Result<MigrationReport, String> {
+    let candidates = load_candidates(conn)?;
+    let mut report = MigrationReport {
+        dry_run,
+        ..Default::default()
+    };
+
+    let members = crate::team::list_team_members_raw(conn)?;
+    let resolver = crate::team::OwnerResolver::from_members(&members);
+    let self_id: Option<String> = conn
+        .query_row(
+            "SELECT id FROM team_members WHERE is_self = 1 LIMIT 1",
+            [],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(|e| e.to_string())?;
+
+    for cand in candidates {
+        report.candidates_scanned += 1;
+        match migrate_one(
+            conn,
+            &cand.note_id,
+            &cand.body_md,
+            &resolver,
+            self_id.as_deref(),
+            dry_run,
+        ) {
+            Ok(one) => {
+                if one.had_block {
+                    report.notes_migrated += 1;
+                    report.rows_created += one.rows_created;
+                    if one.backup_written {
+                        report.backups_written += 1;
+                    }
+                } else {
+                    report.notes_already_clean += 1;
+                }
+            }
+            Err(e) => report.errors.push(format!("{}: {}", cand.note_id, e)),
+        }
+    }
+
+    if !dry_run && report.errors.is_empty() {
+        conn.execute(
+            "UPDATE meta SET value = '1' WHERE key = ?1",
+            params![FLAG_KEY],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    Ok(report)
+}
+
+/// Boot-time wrapper. Reads the migration flag; if `'0'`, runs the
+/// migration with `dry_run=false` and (on success) flips the flag.
+/// Silent — failures are logged to stderr, never thrown. Mirrors the
+/// shape of `team::purge_profile_md_if_pending` at `team.rs:186`.
+pub fn run_if_pending(conn: &mut Connection) {
+    let pending = match read_flag(conn) {
+        Ok(v) => v == "0",
+        Err(e) => {
+            eprintln!("[actions_migration] read flag failed: {e}");
+            return;
+        }
+    };
+    if !pending {
+        return;
+    }
+    match run(conn, false) {
+        Ok(report) => {
+            if !report.errors.is_empty() {
+                eprintln!(
+                    "[actions_migration] completed with {} error(s):",
+                    report.errors.len()
+                );
+                for err in &report.errors {
+                    eprintln!("  - {err}");
+                }
+            } else if report.notes_migrated > 0 {
+                eprintln!(
+                    "[actions_migration] migrated {} note(s), {} row(s), {} backup(s)",
+                    report.notes_migrated, report.rows_created, report.backups_written,
+                );
+            } else {
+                eprintln!("[actions_migration] no candidates — flag set");
+            }
+        }
+        Err(e) => eprintln!("[actions_migration] failed: {e}"),
+    }
+}
+
+fn read_flag(conn: &Connection) -> Result<String, String> {
+    conn.query_row(
+        "SELECT value FROM meta WHERE key = ?1",
+        params![FLAG_KEY],
+        |r| r.get::<_, String>(0),
+    )
+    .optional()
+    .map(|v| v.unwrap_or_else(|| "1".to_string()))
+    .map_err(|e| e.to_string())
+}
+
+fn load_candidates(conn: &Connection) -> Result<Vec<Candidate>, String> {
+    // `duration_ms IS NOT NULL` is the cheap proxy for "has a sibling
+    // transcript.json" — `parse_indexable_from_body` only populates
+    // that column when the file exists. `body_md LIKE '%## Action
+    // items%'` is the cheap inclusion filter; false positives are
+    // harmless (the splitter returns empty raw_lines and we count the
+    // note as already-clean).
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, body_md FROM notes \
+              WHERE duration_ms IS NOT NULL \
+                AND body_md LIKE '%## Action items%' \
+              ORDER BY id",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |r| {
+            Ok(Candidate {
+                note_id: r.get(0)?,
+                body_md: r.get(1)?,
+            })
+        })
+        .map_err(|e| e.to_string())?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row.map_err(|e| e.to_string())?);
+    }
+    Ok(out)
+}
+
+struct MigrationOne {
+    rows_created: u32,
+    backup_written: bool,
+    had_block: bool,
+}
+
+fn migrate_one(
+    conn: &mut Connection,
+    note_id: &str,
+    body: &str,
+    resolver: &crate::team::OwnerResolver,
+    self_id: Option<&str>,
+    dry_run: bool,
+) -> Result<MigrationOne, String> {
+    let (stripped, raw_lines) = crate::reconcile::split_action_items_block(body);
+    if raw_lines.is_empty() {
+        return Ok(MigrationOne {
+            rows_created: 0,
+            backup_written: false,
+            had_block: false,
+        });
+    }
+
+    // Backup BEFORE any state change. Skipped on dry_run. Don't
+    // overwrite an existing backup — that one captures the
+    // first-migration body and is the user's true rollback target.
+    let mut backup_written = false;
+    if !dry_run {
+        let backup_path = std::path::Path::new(note_id)
+            .parent()
+            .ok_or_else(|| format!("no parent dir for note path: {note_id}"))?
+            .join(BACKUP_FILENAME);
+        if !backup_path.exists() {
+            // Make sure the parent dir exists. Normally it does (the
+            // note bundle), but in tempdir-based tests we may seed a
+            // note_id whose dir isn't on disk.
+            if let Some(parent) = backup_path.parent() {
+                fs::create_dir_all(parent)
+                    .map_err(|e| format!("create bundle dir: {e}"))?;
+            }
+            let header = "<!-- Margin action-items backup (#146).\n\
+                          Original body before reconcile-origin migration.\n\
+                          To roll back this note: copy the body below back into\n\
+                          note.md and delete this note's reconcile-origin actions\n\
+                          rows from the DB.\n\
+                          -->\n\n";
+            fs::write(&backup_path, format!("{header}{body}"))
+                .map_err(|e| format!("write backup: {e}"))?;
+            backup_written = true;
+        }
+    }
+
+    if dry_run {
+        let n = raw_lines
+            .iter()
+            .filter_map(|l| crate::notes::parse_action_line(l.trim_start()))
+            .count() as u32;
+        return Ok(MigrationOne {
+            rows_created: n,
+            backup_written: false,
+            had_block: true,
+        });
+    }
+
+    let tx = conn.transaction().map_err(|e| e.to_string())?;
+    let now_ms = crate::events::current_unix_ms();
+    let mut rows_created = 0u32;
+
+    for raw in &raw_lines {
+        let trimmed = raw.trim_start();
+        let Some((text, body_done, due_ms)) = crate::notes::parse_action_line(trimmed) else {
+            continue;
+        };
+        let id = crate::notes::action_id(note_id, &text);
+
+        // Preserve done / manual_override / assignee_id / created_ms
+        // from any existing row with this id. The pre-existing row is
+        // typically the note-origin row produced by the inline parser;
+        // on a re-run it's the reconcile-origin row from a prior pass.
+        let existing: Option<(i64, i64, Option<String>, i64)> = tx
+            .query_row(
+                "SELECT done, manual_override, assignee_id, created_ms \
+                   FROM actions WHERE id = ?1",
+                params![id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .optional()
+            .map_err(|e| e.to_string())?;
+
+        let had_existing = existing.is_some();
+        let (done, manual_override, assignee_id, created_ms) = match existing {
+            Some((d, m, a, c)) => (d != 0, m != 0, a, c),
+            None => {
+                let assignee = crate::notes::extract_owner_candidate(&text)
+                    .and_then(|c| resolver.resolve(&c));
+                (body_done, false, assignee, now_ms)
+            }
+        };
+
+        tx.execute("DELETE FROM actions WHERE id = ?1", params![id])
+            .map_err(|e| e.to_string())?;
+        tx.execute(
+            "INSERT INTO actions \
+                (id, origin_kind, origin_note_id, origin_line, text, done, \
+                 manual_override, created_ms, due_ms, assignee_id) \
+             VALUES (?1, 'reconcile', ?2, NULL, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                id,
+                note_id,
+                text,
+                done as i64,
+                manual_override as i64,
+                created_ms,
+                due_ms,
+                assignee_id,
+            ],
+        )
+        .map_err(|e| e.to_string())?;
+
+        if !had_existing {
+            let actor = assignee_id.as_deref().or(self_id);
+            let payload = serde_json::json!({"text": text, "note_id": note_id});
+            crate::events::emit(
+                &tx,
+                now_ms,
+                "action_created",
+                actor,
+                "action",
+                &id,
+                &payload,
+            )
+            .map_err(|e| e.to_string())?;
+        }
+
+        rows_created += 1;
+    }
+
+    // Refresh derived state against the stripped body. `upsert_in_tx`
+    // updates `notes.body_md`, refreshes FTS, and wipes-and-replaces
+    // note-origin rows for this note (scoped to origin_kind='note', so
+    // our just-inserted reconcile-origin rows are untouched).
+    let parsed = crate::index::parse_indexable_from_body(note_id, &stripped, now_ms);
+    crate::index::upsert_in_tx(&tx, note_id, &parsed).map_err(|e| e.to_string())?;
+
+    tx.commit().map_err(|e| e.to_string())?;
+
+    Ok(MigrationOne {
+        rows_created,
+        backup_written,
+        had_block: true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+    use tempfile::TempDir;
+
+    fn fresh_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::index::apply_migrations(&conn).unwrap();
+        conn
+    }
+
+    /// Seed a note row whose `id` is an absolute path under `dir/bundle/note.md`.
+    /// Creates the bundle directory on disk so backup writes land in the tempdir.
+    fn seed_note(
+        conn: &Connection,
+        dir: &TempDir,
+        bundle: &str,
+        body: &str,
+        has_transcript: bool,
+    ) -> String {
+        let bundle_dir = dir.path().join(bundle);
+        fs::create_dir_all(&bundle_dir).unwrap();
+        let note_id = bundle_dir.join("note.md").to_string_lossy().into_owned();
+        let duration: Option<i64> = if has_transcript { Some(60_000) } else { None };
+        conn.execute(
+            "INSERT INTO notes(id, bundle_id, title, modified_ms, body_size, \
+                                body_md, duration_ms) \
+             VALUES (?1, ?2, 'Title', 100, ?3, ?4, ?5)",
+            params![note_id, bundle, body.len() as i64, body, duration],
+        )
+        .unwrap();
+        note_id
+    }
+
+    fn body_with_block() -> String {
+        "# Meeting\n\
+         \n\
+         ## Summary\n\
+         \n\
+         We discussed plans.\n\
+         \n\
+         ## Action items\n\
+         \n\
+         - [ ] task one\n\
+         - [x] task two\n\
+         \n\
+         ## Open questions\n\
+         \n\
+         - [?] who owns deploy?\n"
+            .to_string()
+    }
+
+    #[test]
+    fn migrate_creates_reconcile_rows_and_strips_section() {
+        let dir = TempDir::new().unwrap();
+        let mut conn = fresh_conn();
+        let note_id = seed_note(&conn, &dir, "b1", &body_with_block(), true);
+
+        let report = run(&mut conn, false).unwrap();
+        assert!(report.errors.is_empty(), "errors: {:?}", report.errors);
+        assert_eq!(report.candidates_scanned, 1);
+        assert_eq!(report.notes_migrated, 1);
+        assert_eq!(report.rows_created, 2);
+
+        // Both rows are reconcile-origin, origin_line is NULL.
+        let mut stmt = conn
+            .prepare(
+                "SELECT origin_kind, origin_line, text, done FROM actions \
+                  WHERE origin_note_id = ?1 ORDER BY text",
+            )
+            .unwrap();
+        let rows: Vec<(String, Option<i64>, String, i64)> = stmt
+            .query_map(params![note_id], |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?))
+            })
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(rows.len(), 2);
+        for (kind, line, _text, _done) in &rows {
+            assert_eq!(kind, "reconcile");
+            assert!(line.is_none());
+        }
+        // body_md is stripped.
+        let body: String = conn
+            .query_row(
+                "SELECT body_md FROM notes WHERE id = ?1",
+                params![note_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(!body.contains("## Action items"));
+        assert!(body.contains("## Summary"));
+        assert!(body.contains("## Open questions"));
+    }
+
+    #[test]
+    fn migrate_preserves_done_state_on_already_completed_items() {
+        let dir = TempDir::new().unwrap();
+        let mut conn = fresh_conn();
+        let body = "## Action items\n\n- [x] task done\n";
+        let note_id = seed_note(&conn, &dir, "b1", body, true);
+
+        // Pre-seed the note-origin row that the inline parser would have
+        // created. done=1 because the body has [x].
+        let id = crate::notes::action_id(&note_id, "task done");
+        conn.execute(
+            "INSERT INTO actions(\
+                id, origin_kind, origin_note_id, origin_line, \
+                text, done, created_ms\
+             ) VALUES (?1, 'note', ?2, 1, 'task done', 1, 50)",
+            params![id, note_id],
+        )
+        .unwrap();
+
+        let report = run(&mut conn, false).unwrap();
+        assert!(report.errors.is_empty());
+
+        let (kind, done, created_ms): (String, i64, i64) = conn
+            .query_row(
+                "SELECT origin_kind, done, created_ms FROM actions WHERE id = ?1",
+                params![id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(kind, "reconcile");
+        assert_eq!(done, 1, "done flipped during migration");
+        assert_eq!(created_ms, 50, "created_ms preserved");
+    }
+
+    #[test]
+    fn migrate_preserves_manual_override_and_assignee() {
+        let dir = TempDir::new().unwrap();
+        let mut conn = fresh_conn();
+        // Seed a team member so a synthetic assignee_id passes the FK.
+        conn.execute(
+            "INSERT INTO team_members(id, display_name, role, is_self, created_ms, updated_ms) \
+             VALUES ('tm_x', 'X', '', 0, 100, 100)",
+            [],
+        )
+        .unwrap();
+        let body = "## Action items\n\n- [ ] task one\n";
+        let note_id = seed_note(&conn, &dir, "b1", body, true);
+        let id = crate::notes::action_id(&note_id, "task one");
+        conn.execute(
+            "INSERT INTO actions(\
+                id, origin_kind, origin_note_id, origin_line, \
+                text, done, manual_override, assignee_id, created_ms\
+             ) VALUES (?1, 'note', ?2, 1, 'task one', 0, 1, 'tm_x', 75)",
+            params![id, note_id],
+        )
+        .unwrap();
+
+        run(&mut conn, false).unwrap();
+
+        let (mo, assignee): (i64, Option<String>) = conn
+            .query_row(
+                "SELECT manual_override, assignee_id FROM actions WHERE id = ?1",
+                params![id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(mo, 1, "manual_override preserved");
+        assert_eq!(assignee.as_deref(), Some("tm_x"));
+    }
+
+    #[test]
+    fn migrate_is_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let mut conn = fresh_conn();
+        seed_note(&conn, &dir, "b1", &body_with_block(), true);
+
+        let r1 = run(&mut conn, false).unwrap();
+        assert_eq!(r1.notes_migrated, 1);
+
+        // body_md no longer contains the heading, so the candidate
+        // filter returns nothing.
+        let r2 = run(&mut conn, false).unwrap();
+        assert_eq!(r2.candidates_scanned, 0);
+        assert_eq!(r2.notes_migrated, 0);
+        assert_eq!(r2.rows_created, 0);
+    }
+
+    #[test]
+    fn migrate_skips_notes_without_transcript() {
+        let dir = TempDir::new().unwrap();
+        let mut conn = fresh_conn();
+        seed_note(&conn, &dir, "b1", &body_with_block(), false /* no transcript */);
+
+        let report = run(&mut conn, false).unwrap();
+        assert_eq!(report.candidates_scanned, 0);
+        assert_eq!(report.notes_migrated, 0);
+    }
+
+    #[test]
+    fn migrate_writes_backup_file_with_original_body() {
+        let dir = TempDir::new().unwrap();
+        let mut conn = fresh_conn();
+        let original = body_with_block();
+        let note_id = seed_note(&conn, &dir, "b1", &original, true);
+
+        run(&mut conn, false).unwrap();
+
+        let backup_path = std::path::Path::new(&note_id)
+            .parent()
+            .unwrap()
+            .join(BACKUP_FILENAME);
+        assert!(backup_path.exists(), "backup file missing: {:?}", backup_path);
+        let content = fs::read_to_string(&backup_path).unwrap();
+        assert!(content.starts_with("<!-- Margin action-items backup"));
+        assert!(content.contains(&original), "backup must contain original body");
+    }
+
+    #[test]
+    fn migrate_dry_run_does_not_mutate() {
+        let dir = TempDir::new().unwrap();
+        let mut conn = fresh_conn();
+        let note_id = seed_note(&conn, &dir, "b1", &body_with_block(), true);
+
+        let report = run(&mut conn, true).unwrap();
+        assert!(report.dry_run);
+        assert_eq!(report.notes_migrated, 1);
+        assert_eq!(report.rows_created, 2);
+        assert_eq!(report.backups_written, 0);
+
+        // Body unchanged.
+        let body: String = conn
+            .query_row(
+                "SELECT body_md FROM notes WHERE id = ?1",
+                params![note_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(body.contains("## Action items"));
+
+        // No reconcile-origin rows.
+        let n: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM actions WHERE origin_kind = 'reconcile'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 0);
+
+        // No backup file.
+        let backup_path = std::path::Path::new(&note_id)
+            .parent()
+            .unwrap()
+            .join(BACKUP_FILENAME);
+        assert!(!backup_path.exists());
+
+        // Flag still '0'.
+        assert_eq!(read_flag(&conn).unwrap(), "0");
+    }
+
+    #[test]
+    fn migrate_flips_flag_on_success() {
+        let mut conn = fresh_conn();
+        assert_eq!(read_flag(&conn).unwrap(), "0");
+        run(&mut conn, false).unwrap();
+        assert_eq!(read_flag(&conn).unwrap(), "1");
+
+        // run_if_pending is a no-op the second time.
+        let mut conn2 = fresh_conn();
+        run_if_pending(&mut conn2);
+        assert_eq!(read_flag(&conn2).unwrap(), "1");
+        // And again — definitely no-op.
+        run_if_pending(&mut conn2);
+        assert_eq!(read_flag(&conn2).unwrap(), "1");
+    }
+
+    #[test]
+    fn migrate_preserves_existing_backup() {
+        let dir = TempDir::new().unwrap();
+        let mut conn = fresh_conn();
+        let note_id = seed_note(&conn, &dir, "b1", &body_with_block(), true);
+        let backup_path = std::path::Path::new(&note_id)
+            .parent()
+            .unwrap()
+            .join(BACKUP_FILENAME);
+        let sentinel = "DO NOT TOUCH";
+        fs::write(&backup_path, sentinel).unwrap();
+
+        let report = run(&mut conn, false).unwrap();
+        assert_eq!(report.notes_migrated, 1);
+        assert_eq!(report.backups_written, 0, "existing backup must not be re-written");
+
+        let content = fs::read_to_string(&backup_path).unwrap();
+        assert_eq!(content, sentinel);
+    }
+}

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -70,7 +70,8 @@ const SCHEMA_V36: &str = include_str!("migrations/036_prompt_dumps.sql");
 const SCHEMA_V37: &str = include_str!("migrations/037_prompt_dumps_telemetry.sql");
 const SCHEMA_V38: &str = include_str!("migrations/038_prompt_cache_tokens.sql");
 const SCHEMA_V39: &str = include_str!("migrations/039_reconcile_origin.sql");
-const SCHEMA_VERSION: i64 = 39;
+const SCHEMA_V40: &str = include_str!("migrations/040_actions_migration_flag.sql");
+const SCHEMA_VERSION: i64 = 40;
 
 /// Register the sqlite-vec extension as an "auto extension" so every
 /// future `Connection::open*` in this process loads `vec0` (#104).
@@ -319,6 +320,10 @@ pub(crate) fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 38 {
         conn.execute_batch(SCHEMA_V39)?;
         version = 39;
+    }
+    if version == 39 {
+        conn.execute_batch(SCHEMA_V40)?;
+        version = 40;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -71,7 +71,8 @@ const SCHEMA_V37: &str = include_str!("migrations/037_prompt_dumps_telemetry.sql
 const SCHEMA_V38: &str = include_str!("migrations/038_prompt_cache_tokens.sql");
 const SCHEMA_V39: &str = include_str!("migrations/039_reconcile_origin.sql");
 const SCHEMA_V40: &str = include_str!("migrations/040_actions_migration_flag.sql");
-const SCHEMA_VERSION: i64 = 40;
+const SCHEMA_V41: &str = include_str!("migrations/041_action_deletions.sql");
+const SCHEMA_VERSION: i64 = 41;
 
 /// Register the sqlite-vec extension as an "auto extension" so every
 /// future `Connection::open*` in this process loads `vec0` (#104).
@@ -324,6 +325,10 @@ pub(crate) fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 39 {
         conn.execute_batch(SCHEMA_V40)?;
         version = 40;
+    }
+    if version == 40 {
+        conn.execute_batch(SCHEMA_V41)?;
+        version = 41;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -473,6 +473,60 @@ pub fn list_actions(
     Ok(out)
 }
 
+/// Per-note actions for the note-view sidebar (#145). Returns every
+/// row whose `origin_note_id` matches, regardless of `done`,
+/// regardless of `origin_kind`, ignoring the archived-note /
+/// inactive-workstream guards (the user is *looking at* the note —
+/// they should see its actions). Ordered created_ms DESC with
+/// `origin_line` as a stable tiebreaker for note-origin rows.
+pub fn list_actions_for_note(
+    conn: &Connection,
+    note_id: &str,
+) -> Result<Vec<ActionListItem>> {
+    let sql = "SELECT a.id, a.origin_kind, a.origin_note_id, a.origin_line, \
+                      a.origin_synth_kind, a.origin_synth_id, \
+                      a.workstream_id, a.text, a.done, a.due_ms, \
+                      a.assignee_id, a.created_ms, \
+                      n.title AS note_title, \
+                      w.title AS workstream_title, \
+                      t.display_name AS assignee_display_name, \
+                      a.subject_member_id, a.manual_override, a.auto_resolved_ms \
+                 FROM actions a \
+                 LEFT JOIN notes        n ON n.id = a.origin_note_id \
+                 LEFT JOIN workstreams  w ON w.id = a.workstream_id \
+                 LEFT JOIN team_members t ON t.id = a.assignee_id \
+                WHERE a.origin_note_id = ?1 \
+                ORDER BY a.created_ms DESC, a.origin_line ASC";
+    let mut stmt = conn.prepare(sql)?;
+    let rows = stmt.query_map(params![note_id], |r| {
+        Ok(ActionListItem {
+            id: r.get(0)?,
+            origin_kind: r.get(1)?,
+            origin_note_path: r.get(2)?,
+            origin_line: r.get(3)?,
+            origin_synth_kind: r.get(4)?,
+            origin_synth_id: r.get(5)?,
+            workstream_id: r.get(6)?,
+            text: r.get(7)?,
+            done: r.get::<_, i64>(8)? != 0,
+            due_ms: r.get(9)?,
+            assignee_id: r.get(10)?,
+            created_ms: r.get(11)?,
+            note_title: r.get(12)?,
+            workstream_title: r.get(13)?,
+            assignee_display_name: r.get(14)?,
+            subject_member_id: r.get(15)?,
+            manual_override: r.get::<_, i64>(16)? != 0,
+            auto_resolved_ms: r.get(17)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
 /// One ranked hit from `search_notes`. `source` carries which surface
 /// the match came from so the UI can label rows ("Title", "Body",
 /// "Transcript"). `snippet` is a short window around the match — already
@@ -2310,6 +2364,57 @@ mod tests {
             )
             .unwrap();
         assert_eq!(note_count, 1);
+    }
+
+    #[test]
+    fn list_actions_for_note_returns_all_origins_regardless_of_done() {
+        // The sidebar (#145) shows every action tied to the current
+        // note: both origins (reconcile + note), both done states.
+        // Synth rows on OTHER notes must not bleed in.
+        let conn = fresh_conn();
+        seed_note_row(&conn, "n_a", 100);
+        seed_note_row(&conn, "n_b", 100);
+
+        // Reconcile-origin row on n_a, done.
+        conn.execute(
+            "INSERT INTO actions(\
+                id, origin_kind, origin_note_id, origin_line, \
+                text, done, created_ms\
+             ) VALUES ('r:1', 'reconcile', 'n_a', NULL, 'recon done', 1, 200)",
+            [],
+        )
+        .unwrap();
+        // Note-origin row on n_a, open.
+        conn.execute(
+            "INSERT INTO actions(\
+                id, origin_kind, origin_note_id, origin_line, \
+                text, done, created_ms\
+             ) VALUES ('n_a:1', 'note', 'n_a', 1, 'hand task', 0, 100)",
+            [],
+        )
+        .unwrap();
+        // Note-origin row on a DIFFERENT note — must be excluded.
+        conn.execute(
+            "INSERT INTO actions(\
+                id, origin_kind, origin_note_id, origin_line, \
+                text, done, created_ms\
+             ) VALUES ('n_b:1', 'note', 'n_b', 1, 'unrelated', 0, 100)",
+            [],
+        )
+        .unwrap();
+
+        let got = list_actions_for_note(&conn, "n_a").unwrap();
+        let ids: Vec<&str> = got.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids.len(), 2, "expected 2 rows for n_a, got {ids:?}");
+        assert!(ids.contains(&"r:1"));
+        assert!(ids.contains(&"n_a:1"));
+        // created_ms DESC → reconcile row (200) before note row (100).
+        assert_eq!(ids[0], "r:1");
+        assert_eq!(ids[1], "n_a:1");
+
+        // Empty-note case returns []
+        let empty = list_actions_for_note(&conn, "/path/none").unwrap();
+        assert!(empty.is_empty());
     }
 
     // ----- #113 open questions integration ----------------------------------

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -69,7 +69,8 @@ const SCHEMA_V35: &str = include_str!("migrations/035_chat_conversations.sql");
 const SCHEMA_V36: &str = include_str!("migrations/036_prompt_dumps.sql");
 const SCHEMA_V37: &str = include_str!("migrations/037_prompt_dumps_telemetry.sql");
 const SCHEMA_V38: &str = include_str!("migrations/038_prompt_cache_tokens.sql");
-const SCHEMA_VERSION: i64 = 38;
+const SCHEMA_V39: &str = include_str!("migrations/039_reconcile_origin.sql");
+const SCHEMA_VERSION: i64 = 39;
 
 /// Register the sqlite-vec extension as an "auto extension" so every
 /// future `Connection::open*` in this process loads `vec0` (#104).
@@ -314,6 +315,10 @@ pub(crate) fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 37 {
         conn.execute_batch(SCHEMA_V38)?;
         version = 38;
+    }
+    if version == 38 {
+        conn.execute_batch(SCHEMA_V39)?;
+        version = 39;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod action_deletions;
 mod activity;
 mod actions_migration;
 mod anthropic;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod activity;
+mod actions_migration;
 mod anthropic;
 mod ask;
 mod audio;
@@ -434,6 +435,12 @@ pub fn run() {
                 eprintln!("profile.md purge failed at boot: {e}");
             }
 
+            // #146: one-shot backfill of pre-#144 reconciled notes —
+            // moves inline `## Action items` blocks into reconcile-origin
+            // rows + writes per-note backups. Gated by the
+            // actions_migration_v1_completed meta flag.
+            actions_migration::run_if_pending(&mut conn);
+
             // Connector registry: holds kind-factory mappings + live
             // connector instances. Real connector modules register
             // their factories at boot (Microsoft Graph in #63;
@@ -550,6 +557,7 @@ pub fn run() {
             notes::set_favorite,
             notes::list_actions,
             notes::list_actions_for_note,
+            notes::migrate_reconciled_notes_to_action_rows,
             notes::set_action_done,
             notes::undo_auto_resolved_action,
             notes::set_action_assignee,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -549,6 +549,7 @@ pub fn run() {
             notes::set_archived,
             notes::set_favorite,
             notes::list_actions,
+            notes::list_actions_for_note,
             notes::set_action_done,
             notes::undo_auto_resolved_action,
             notes::set_action_assignee,

--- a/src-tauri/src/migrations/039_reconcile_origin.sql
+++ b/src-tauri/src/migrations/039_reconcile_origin.sql
@@ -1,0 +1,21 @@
+PRAGMA foreign_keys = ON;
+
+-- Phase 1.1 of milestone #5 — declare 'reconcile' as a known action
+-- origin_kind. No structural change: the existing `actions` schema
+-- already carries `origin_kind TEXT NOT NULL` (mig 025) and
+-- `origin_note_id TEXT REFERENCES notes(id) ON DELETE CASCADE`
+-- (mig 026), with no CHECK constraint on origin_kind.
+--
+-- A reconcile-origin row, once #144 lands, has shape:
+--   origin_kind        = 'reconcile'
+--   origin_note_id     = <meeting note bundle id>   -- so the sidebar can query
+--   origin_line        = NULL                        -- no source line anymore
+--   origin_synth_kind  = NULL
+--   origin_synth_id    = NULL
+--   workstream_id      = NULL  (or set by user)
+--
+-- Bumping schema_version is the only DB change here. This pins the
+-- version below which 'reconcile' rows do not exist, which the
+-- one-time backfill in #146 keys off.
+
+UPDATE meta SET value = '39' WHERE key = 'schema_version';

--- a/src-tauri/src/migrations/040_actions_migration_flag.sql
+++ b/src-tauri/src/migrations/040_actions_migration_flag.sql
@@ -1,0 +1,12 @@
+PRAGMA foreign_keys = ON;
+
+-- Phase 1.4 of milestone #5 — flag that gates the one-time backfill
+-- of existing reconciled notes' inline `## Action items` blocks into
+-- reconcile-origin rows (#146). The boot sweep in
+-- `actions_migration::run_if_pending` flips this to '1' once the
+-- migration has run successfully. Manual re-runs via Settings ignore
+-- the flag (the underlying migration is idempotent).
+INSERT OR IGNORE INTO meta(key, value)
+  VALUES ('actions_migration_v1_completed', '0');
+
+UPDATE meta SET value = '40' WHERE key = 'schema_version';

--- a/src-tauri/src/migrations/041_action_deletions.sql
+++ b/src-tauri/src/migrations/041_action_deletions.sql
@@ -1,0 +1,45 @@
+PRAGMA foreign_keys = ON;
+
+-- Phase 2.1 of milestone #5 — universal deletion log (#147).
+--
+-- Replaces the synth-only `dismissed_action_sources` model with a
+-- per-row snapshot of every action that disappears, regardless of
+-- origin. Read by the reconcile prompt (#148), the profile worker
+-- (#149) and the workstream synthesizer (#150) so all three
+-- producers learn from the user's rejections.
+--
+-- Snapshot fields are kept verbatim rather than as FKs: by the time
+-- a reader cares about a deletion the underlying `actions` row is
+-- gone. Subject + assignee ids may dangle if a team member is later
+-- deleted; that's acceptable — the text + origin metadata is the
+-- learning signal, not the FK joinability.
+CREATE TABLE action_deletions (
+  id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+  deleted_ms              INTEGER NOT NULL,
+  origin_kind             TEXT NOT NULL,
+  origin_synth_kind       TEXT,
+  origin_synth_id         TEXT,
+  origin_note_id          TEXT,
+  subject_member_id       TEXT,
+  assignee_id             TEXT,
+  text                    TEXT NOT NULL,
+  -- For reconcile-origin rows tied to a recurring meeting, the master
+  -- id of the series. NULL for one-offs and non-reconcile origins.
+  -- Lets #148 suppress per-series rather than per-occurrence.
+  source_series_master_id TEXT,
+  -- Distinguishes user intent from worker sweeps so #148/#149/#150
+  -- can gate on `cause IN ('user_delete','user_dismiss')` and ignore
+  -- auto_resolved omissions (which are weak signal, not rejection).
+  cause                   TEXT NOT NULL DEFAULT 'user_delete'
+);
+
+CREATE INDEX idx_action_deletions_subject
+  ON action_deletions(subject_member_id, deleted_ms DESC)
+  WHERE subject_member_id IS NOT NULL;
+CREATE INDEX idx_action_deletions_series
+  ON action_deletions(source_series_master_id, deleted_ms DESC)
+  WHERE source_series_master_id IS NOT NULL;
+CREATE INDEX idx_action_deletions_recency
+  ON action_deletions(deleted_ms DESC);
+
+UPDATE meta SET value = '41' WHERE key = 'schema_version';

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -1616,7 +1616,7 @@ pub(crate) fn rewrite_action_owner(line: &str, new_owner: Option<&str>) -> Optio
     Some(format!("{indent}{bullet_char} {done_marker}{new_body}"))
 }
 
-fn parse_action_line(line: &str) -> Option<(String, bool, Option<i64>)> {
+pub(crate) fn parse_action_line(line: &str) -> Option<(String, bool, Option<i64>)> {
     let after_bullet = line
         .strip_prefix("- ")
         .or_else(|| line.strip_prefix("* "))

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -751,12 +751,19 @@ fn locate_action_line(
 ///
 /// `mutate` returns `Ok(Some(new_line))` to replace the line,
 /// `Ok(None)` to delete it, or `Err` to abort.
+///
+/// `log_delete_action_id` — when `Some`, snapshots the named action
+/// row into `action_deletions` with `cause='user_delete'` inside the
+/// same tx that performs the body rewrite. Used by `delete_action`
+/// so #148/#149/#150 can suppress future re-emissions of the same
+/// text. Other callers pass `None` (a checkbox toggle isn't a delete).
 fn mutate_note_action_body<F>(
     note_id: &str,
     cached_line: usize,
     want_text: &str,
     conn: &tauri::State<'_, std::sync::Mutex<rusqlite::Connection>>,
     mutate: F,
+    log_delete_action_id: Option<&str>,
 ) -> Result<(), String>
 where
     F: FnOnce(&str) -> Result<Option<String>, String>,
@@ -787,6 +794,15 @@ where
     let new_body = lines.join("\n");
     let now = current_unix_ms();
     let tx = c.transaction().map_err(|e| e.to_string())?;
+    if let Some(action_id) = log_delete_action_id {
+        crate::action_deletions::log_deletion(
+            &tx,
+            action_id,
+            crate::action_deletions::Cause::UserDelete,
+            now,
+        )
+        .map_err(|e| e.to_string())?;
+    }
     let parsed = crate::index::parse_indexable_from_body(note_id, &new_body, now);
     crate::index::upsert_in_tx(&tx, note_id, &parsed).map_err(|e| e.to_string())?;
     tx.commit().map_err(|e| e.to_string())?;
@@ -820,6 +836,7 @@ pub fn set_action_done(
         &dispatch.text,
         &conn,
         |line| Ok(Some(toggle_checkbox_marker(line, done))),
+        None,
     )
 }
 
@@ -888,11 +905,18 @@ pub fn set_action_assignee(
         None
     };
 
-    mutate_note_action_body(&note_id, cached_line, &dispatch.text, &conn, |line| {
-        rewrite_action_owner(line, new_owner_name.as_deref())
-            .map(Some)
-            .ok_or_else(|| "action line is not a recognizable checkbox".to_string())
-    })
+    mutate_note_action_body(
+        &note_id,
+        cached_line,
+        &dispatch.text,
+        &conn,
+        |line| {
+            rewrite_action_owner(line, new_owner_name.as_deref())
+                .map(Some)
+                .ok_or_else(|| "action line is not a recognizable checkbox".to_string())
+        },
+        None,
+    )
 }
 
 /// "Ignore" a worker-extracted waiting action: record the source in
@@ -925,6 +949,16 @@ pub fn dismiss_waiting_action(
         )
         .map_err(|e| e.to_string())?;
     }
+    // Universal deletion log (#147). Written alongside the legacy
+    // `dismissed_action_sources` insert above; #149 will read this
+    // log and deprecate the legacy table.
+    crate::action_deletions::log_deletion(
+        &tx,
+        &id,
+        crate::action_deletions::Cause::UserDismiss,
+        now,
+    )
+    .map_err(|e| e.to_string())?;
     tx.execute("DELETE FROM actions WHERE id = ?1", rusqlite::params![id])
         .map_err(|e| e.to_string())?;
     tx.commit().map_err(|e| e.to_string())?;
@@ -946,8 +980,8 @@ pub fn delete_action(
     };
 
     if dispatch.origin_kind != "note" {
-        let c = conn.lock().map_err(|e| e.to_string())?;
-        return crate::workstreams::persist::delete_action(&c, &id)
+        let mut c = conn.lock().map_err(|e| e.to_string())?;
+        return crate::workstreams::persist::delete_action(&mut c, &id)
             .map_err(|e| e.to_string());
     }
 
@@ -956,7 +990,14 @@ pub fn delete_action(
     })?;
     let cached_line = dispatch.origin_line.unwrap_or(0);
 
-    mutate_note_action_body(&note_id, cached_line, &dispatch.text, &conn, |_| Ok(None))
+    mutate_note_action_body(
+        &note_id,
+        cached_line,
+        &dispatch.text,
+        &conn,
+        |_| Ok(None),
+        Some(&id),
+    )
 }
 
 /// Attach an action to a workstream (or clear the attachment when

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -333,6 +333,18 @@ pub fn list_actions(
     .map_err(|e| e.to_string())
 }
 
+/// Per-note actions for the note-view sidebar (#145). Returns both
+/// origins (reconcile + note + any synth row pinned via origin_note_id)
+/// and both done states. Ordering: created_ms DESC.
+#[tauri::command]
+pub fn list_actions_for_note(
+    note_id: String,
+    conn: tauri::State<'_, std::sync::Mutex<rusqlite::Connection>>,
+) -> Result<Vec<ActionListItem>, String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    crate::index::list_actions_for_note(&c, &note_id).map_err(|e| e.to_string())
+}
+
 #[derive(Serialize)]
 pub struct NoteMeta {
     pub modified_ms: i64,

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -345,6 +345,18 @@ pub fn list_actions_for_note(
     crate::index::list_actions_for_note(&c, &note_id).map_err(|e| e.to_string())
 }
 
+/// Phase 1.4 (#146) — one-time backfill of pre-#144 reconciled notes
+/// into reconcile-origin rows. Idempotent. The boot sweep auto-runs
+/// this once; the Settings button re-runs it on demand.
+#[tauri::command]
+pub fn migrate_reconciled_notes_to_action_rows(
+    dry_run: bool,
+    conn: tauri::State<'_, std::sync::Mutex<rusqlite::Connection>>,
+) -> Result<crate::actions_migration::MigrationReport, String> {
+    let mut c = conn.lock().map_err(|e| e.to_string())?;
+    crate::actions_migration::run(&mut c, dry_run)
+}
+
 #[derive(Serialize)]
 pub struct NoteMeta {
     pub modified_ms: i64,

--- a/src-tauri/src/profiles/worker.rs
+++ b/src-tauri/src/profiles/worker.rs
@@ -543,6 +543,28 @@ fn auto_resolve_missing(
             // SQLite reads `auto_resolve_omissions` as the OLD value in
             // both the SET expression and the CASE; threshold compare
             // uses (old + 1) for both columns to stay consistent.
+            //
+            // Threshold-crossing tick is the moment the action becomes
+            // "auto-resolved." Log it to `action_deletions` (#147) so
+            // #150 has the signal, but #148/#149 ignore via `cause`
+            // filter — worker omissions are weak signal, not user
+            // intent. Done before the UPDATE so the helper can read
+            // the row's snapshot fields one last time.
+            let prior_omissions: i64 = tx
+                .query_row(
+                    "SELECT auto_resolve_omissions FROM actions WHERE id = ?1",
+                    rusqlite::params![id],
+                    |r| r.get(0),
+                )
+                .unwrap_or(0);
+            if prior_omissions + 1 >= AUTO_RESOLVE_THRESHOLD {
+                crate::action_deletions::log_deletion(
+                    tx,
+                    &id,
+                    crate::action_deletions::Cause::AutoResolved,
+                    now_ms,
+                )?;
+            }
             tx.execute(
                 "UPDATE actions \
                     SET auto_resolve_omissions = auto_resolve_omissions + 1, \
@@ -952,6 +974,56 @@ mod tests {
         auto_resolve_missing(&tx, "tm_alice", "tm_self", &live, 3_000).unwrap();
         tx.commit().unwrap();
 
+        assert_eq!(action_done(&conn, &id), Some(1));
+        assert_eq!(action_auto_resolved_ms(&conn, &id), Some(3_000));
+    }
+
+    /// Auto-resolve writes to the deletion log (#147) ONLY on the
+    /// threshold-crossing tick — not on every omission. Cause is
+    /// `auto_resolved` so #148/#149 can filter it out (worker
+    /// omissions are weak signal, not user intent).
+    #[test]
+    fn auto_resolve_logs_deletion_only_when_threshold_crossed() {
+        let mut conn = open_db();
+        seed_member(&conn, "tm_self", true);
+        seed_member(&conn, "tm_alice", false);
+        let tx = conn.transaction().unwrap();
+        let id = upsert_waiting_action(
+            &tx,
+            &waiting("teams", "msg1", "x"),
+            "tm_self",
+            "tm_alice",
+            1_000,
+        )
+        .unwrap()
+        .unwrap();
+        let live = std::collections::HashSet::new();
+
+        // First omission: counter bumps but threshold not yet crossed.
+        auto_resolve_missing(&tx, "tm_alice", "tm_self", &live, 2_000).unwrap();
+        let after_first: i64 = tx
+            .query_row("SELECT COUNT(*) FROM action_deletions", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            after_first, 0,
+            "first omission must not log; below threshold"
+        );
+
+        // Second omission: threshold crossed, log row written.
+        auto_resolve_missing(&tx, "tm_alice", "tm_self", &live, 3_000).unwrap();
+        tx.commit().unwrap();
+
+        let (count, cause, action_text): (i64, String, String) = conn
+            .query_row(
+                "SELECT COUNT(*), MAX(cause), MAX(text) FROM action_deletions",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "exactly one log row at threshold-crossing");
+        assert_eq!(cause, "auto_resolved");
+        assert_eq!(action_text, "x");
+        // Sanity check the worker's existing contract still holds.
         assert_eq!(action_done(&conn, &id), Some(1));
         assert_eq!(action_auto_resolved_ms(&conn, &id), Some(3_000));
     }

--- a/src-tauri/src/reconcile.rs
+++ b/src-tauri/src/reconcile.rs
@@ -1,5 +1,7 @@
+use std::collections::HashSet;
 use std::path::Path;
 
+use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager};
 
@@ -483,6 +485,167 @@ fn strip_observations_block(raw: &str) -> (String, Vec<ParsedObservation>) {
     (body, out)
 }
 
+/// Find the `## Action items` block in `body` and split it off (#144).
+/// Returns `(stripped_body, action_lines)` where `action_lines` is the
+/// raw lines inside the block — the caller filters them through
+/// `parse_action_line` to drop anything that isn't a real `- [ ]` item.
+///
+/// Block boundary: from the `## Action items` heading line (exclusive)
+/// to the next `## `-prefixed line or EOF. The heading line itself is
+/// removed; runs of >=3 consecutive newlines created by the cut are
+/// collapsed back to a single blank line so the stripped body has no
+/// awkward double gaps.
+///
+/// Only the first occurrence is processed. If the model ever emits two
+/// `## Action items` headings the second survives in the body; the
+/// caller's logging will surface that as a tail of un-persisted items.
+fn split_action_items_block(body: &str) -> (String, Vec<String>) {
+    const HEADING: &str = "## Action items";
+    let lines: Vec<&str> = body.split('\n').collect();
+    let start = lines.iter().position(|l| l.trim_end() == HEADING);
+    let Some(start) = start else {
+        return (body.to_string(), Vec::new());
+    };
+    let end = lines
+        .iter()
+        .enumerate()
+        .skip(start + 1)
+        .find_map(|(i, l)| l.trim_start().starts_with("## ").then_some(i))
+        .unwrap_or(lines.len());
+
+    let action_lines: Vec<String> = lines[start + 1..end]
+        .iter()
+        .map(|l| l.to_string())
+        .collect();
+
+    let mut kept = Vec::with_capacity(lines.len() - (end - start));
+    kept.extend(lines[..start].iter().copied());
+    kept.extend(lines[end..].iter().copied());
+    let joined = kept.join("\n");
+
+    // Collapse 3+ consecutive newlines (a blank line on each side of
+    // the cut) down to 2.
+    let mut stripped = String::with_capacity(joined.len());
+    let mut newlines = 0usize;
+    for ch in joined.chars() {
+        if ch == '\n' {
+            newlines += 1;
+            if newlines <= 2 {
+                stripped.push(ch);
+            }
+        } else {
+            newlines = 0;
+            stripped.push(ch);
+        }
+    }
+
+    (stripped, action_lines)
+}
+
+/// Extract the reconciled `## Action items` block from `body`, persist
+/// each line as an `origin_kind='reconcile'` row, and return the body
+/// with the block stripped (#144).
+///
+/// Idempotency: stable row id (`action_id(note_id, text)`) +
+/// `ON CONFLICT(id) DO NOTHING` means re-running reconcile on the same
+/// meeting preserves `done`, `manual_override`, and any user-assigned
+/// `assignee_id` on rows whose text didn't change. New text → new row.
+/// Stale rows from prior runs are intentionally left alone — sweep is
+/// deferred to Phase 2 (the deletion log).
+fn extract_and_persist_action_items(
+    conn_state: &std::sync::Mutex<rusqlite::Connection>,
+    note_id: &str,
+    body: &str,
+) -> Result<(String, usize), String> {
+    let (stripped, raw_lines) = split_action_items_block(body);
+    if raw_lines.is_empty() {
+        return Ok((body.to_string(), 0));
+    }
+
+    let mut c = conn_state.lock().map_err(|e| e.to_string())?;
+    let tx = c.transaction().map_err(|e| e.to_string())?;
+    let now_ms = crate::events::current_unix_ms();
+
+    let members = crate::team::list_team_members_raw(&tx)?;
+    let resolver = crate::team::OwnerResolver::from_members(&members);
+    let self_id: Option<String> = tx
+        .query_row(
+            "SELECT id FROM team_members WHERE is_self = 1 LIMIT 1",
+            [],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(|e| e.to_string())?;
+
+    // Snapshot existing reconcile-origin ids so `action_created`
+    // events fire only for genuinely new rows on re-reconciles.
+    let existing: HashSet<String> = {
+        let mut stmt = tx
+            .prepare(
+                "SELECT id FROM actions \
+                  WHERE origin_kind = 'reconcile' AND origin_note_id = ?1",
+            )
+            .map_err(|e| e.to_string())?;
+        let rows = stmt
+            .query_map(params![note_id], |r| r.get::<_, String>(0))
+            .map_err(|e| e.to_string())?;
+        rows.filter_map(|r| r.ok()).collect()
+    };
+
+    let mut count = 0usize;
+    {
+        let mut stmt = tx
+            .prepare_cached(
+                "INSERT INTO actions \
+                    (id, origin_kind, origin_note_id, origin_line, text, done, \
+                     created_ms, due_ms, assignee_id) \
+                 VALUES (?1, 'reconcile', ?2, NULL, ?3, ?4, ?5, ?6, ?7) \
+                 ON CONFLICT(id) DO NOTHING",
+            )
+            .map_err(|e| e.to_string())?;
+        for raw in &raw_lines {
+            let trimmed = raw.trim_start();
+            let Some((text, done, due_ms)) = crate::notes::parse_action_line(trimmed) else {
+                continue;
+            };
+            let id = crate::notes::action_id(note_id, &text);
+            let assignee_id = crate::notes::extract_owner_candidate(&text)
+                .and_then(|c| resolver.resolve(&c));
+            stmt.execute(params![
+                id,
+                note_id,
+                text,
+                done as i64,
+                now_ms,
+                due_ms,
+                assignee_id,
+            ])
+            .map_err(|e| e.to_string())?;
+            if !existing.contains(&id) {
+                let actor = assignee_id.as_deref().or(self_id.as_deref());
+                let payload = serde_json::json!({
+                    "text": text,
+                    "note_id": note_id,
+                });
+                crate::events::emit(
+                    &tx,
+                    now_ms,
+                    "action_created",
+                    actor,
+                    "action",
+                    &id,
+                    &payload,
+                )
+                .map_err(|e| e.to_string())?;
+            }
+            count += 1;
+        }
+    }
+
+    tx.commit().map_err(|e| e.to_string())?;
+    Ok((stripped, count))
+}
+
 /// Format the user's glossary as a small system-block addendum that nudges
 /// Claude to preserve domain spellings. Returns None for an empty glossary
 /// so the caller can skip pushing the block.
@@ -834,6 +997,28 @@ pub async fn reconcile_notes(
         }
     }
 
+    // Move LLM-emitted `## Action items` from the body into action rows
+    // with origin_kind='reconcile' (#144). On any failure, fall through
+    // with the original body so the LLM round isn't lost — the existing
+    // note-origin parse path will absorb the items on save (pre-#144
+    // behaviour). Requires a note_path because origin_note_id is the FK.
+    let final_body: String = if let Some(np) = note_path.as_deref() {
+        match extract_and_persist_action_items(&conn_state, np, &markdown_body) {
+            Ok((stripped, n)) => {
+                if n > 0 {
+                    eprintln!("[reconcile] persisted {n} reconcile-origin actions");
+                }
+                stripped
+            }
+            Err(e) => {
+                eprintln!("[reconcile] action persist failed, leaving block in body: {e}");
+                markdown_body.clone()
+            }
+        }
+    } else {
+        markdown_body.clone()
+    };
+
     // Stamp the transcript so the post-record banner can suppress its
     // Generate-notes CTA next time the note is opened. Failure to write
     // is non-fatal — the user got their reconciled output, the flag is
@@ -850,7 +1035,7 @@ pub async fn reconcile_notes(
     }
 
     let _ = app.emit("reconcile-progress", "done");
-    Ok(markdown_body)
+    Ok(final_body)
 }
 
 #[cfg(test)]
@@ -1075,5 +1260,272 @@ mod tests {
         let (body, obs) = strip_observations_block(raw);
         assert_eq!(body, "# Note\n\nBody.");
         assert!(obs.is_empty());
+    }
+
+    // ---------- split_action_items_block (#144) ------------------------
+
+    #[test]
+    fn split_action_items_block_extracts_and_strips() {
+        let body = "# Title\n\n## Summary\n\nProse.\n\n## Action items\n\n- [ ] do thing 1\n- [x] do thing 2\n- [ ] Heike — Send Q3 budget\n\n## Open questions\n\n- [?] who owns deploy?\n";
+        let (stripped, lines) = split_action_items_block(body);
+        assert_eq!(lines.len(), 5, "5 raw lines in block (3 actions + 2 blanks): {lines:?}");
+        // Stripped body has summary + open questions, no action items heading.
+        assert!(!stripped.contains("## Action items"));
+        assert!(stripped.contains("## Summary\n\nProse."));
+        assert!(stripped.contains("## Open questions\n\n- [?] who owns deploy?"));
+        // No triple-newline gaps left behind.
+        assert!(!stripped.contains("\n\n\n"));
+    }
+
+    #[test]
+    fn split_action_items_block_handles_eof_block() {
+        let body = "# Title\n\n## Summary\n\nProse.\n\n## Action items\n\n- [ ] last task\n";
+        let (stripped, lines) = split_action_items_block(body);
+        assert!(lines.iter().any(|l| l.contains("last task")));
+        assert!(!stripped.contains("## Action items"));
+        assert!(!stripped.contains("last task"));
+        assert!(stripped.contains("## Summary\n\nProse."));
+    }
+
+    #[test]
+    fn split_action_items_block_handles_missing_section() {
+        let body = "# Title\n\n## Summary\n\nProse only — no action items heading.\n";
+        let (stripped, lines) = split_action_items_block(body);
+        assert!(lines.is_empty());
+        assert_eq!(stripped, body, "no heading → body unchanged byte-for-byte");
+    }
+
+    #[test]
+    fn split_action_items_block_drops_non_checkbox_lines_in_block() {
+        let body = "# Title\n\n## Action items\n\nstray prose the model shouldn't emit\n- [ ] valid task\nmore prose\n\n## Next\n";
+        let (stripped, lines) = split_action_items_block(body);
+        // Captured: prose + checkbox + prose + blank (caller filters).
+        let parsed: Vec<_> = lines
+            .iter()
+            .filter_map(|l| crate::notes::parse_action_line(l.trim_start()))
+            .collect();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].0, "valid task");
+        assert!(!stripped.contains("## Action items"));
+        assert!(!stripped.contains("stray prose"));
+        assert!(stripped.contains("## Next"));
+    }
+
+    #[test]
+    fn split_action_items_block_only_strips_first_heading() {
+        let body = "# Title\n\n## Action items\n\n- [ ] one\n\n## Other\n\nstuff\n\n## Action items\n\n- [ ] two\n";
+        let (stripped, lines) = split_action_items_block(body);
+        // First block captured.
+        assert!(lines.iter().any(|l| l.contains("one")));
+        assert!(!lines.iter().any(|l| l.contains("two")));
+        // Second heading and its line survive in the stripped body.
+        assert!(stripped.contains("## Action items"));
+        assert!(stripped.contains("- [ ] two"));
+        assert!(!stripped.contains("- [ ] one"));
+    }
+
+    // ---------- extract_and_persist_action_items (#144) ----------------
+
+    fn db_with_note(note_id: &str) -> std::sync::Mutex<rusqlite::Connection> {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        crate::index::apply_migrations(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO notes(id, bundle_id, title, modified_ms, body_size) \
+             VALUES (?1, ?1, 'T', 100, 0)",
+            rusqlite::params![note_id],
+        )
+        .unwrap();
+        std::sync::Mutex::new(conn)
+    }
+
+    fn seed_team_member(
+        mutex: &std::sync::Mutex<rusqlite::Connection>,
+        id: &str,
+        display_name: &str,
+        is_self: bool,
+    ) {
+        let c = mutex.lock().unwrap();
+        c.execute(
+            "INSERT INTO team_members(id, display_name, role, is_self, created_ms, updated_ms) \
+             VALUES (?1, ?2, '', ?3, 100, 100)",
+            rusqlite::params![id, display_name, is_self as i64],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn persist_creates_reconcile_origin_rows_with_correct_shape() {
+        let note_id = "/n/note.md";
+        let mutex = db_with_note(note_id);
+        let body = "# T\n\n## Action items\n\n- [ ] one\n- [x] two\n\n## End\n";
+
+        let (stripped, n) = extract_and_persist_action_items(&mutex, note_id, body).unwrap();
+        assert_eq!(n, 2);
+        assert!(!stripped.contains("## Action items"));
+
+        let c = mutex.lock().unwrap();
+        let (kind, oni, line, done): (String, String, Option<i64>, i64) = c
+            .query_row(
+                "SELECT origin_kind, origin_note_id, origin_line, done \
+                 FROM actions WHERE text = 'one'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(kind, "reconcile");
+        assert_eq!(oni, note_id);
+        assert!(line.is_none(), "origin_line must be NULL");
+        assert_eq!(done, 0);
+
+        let done_two: i64 = c
+            .query_row(
+                "SELECT done FROM actions WHERE text = 'two'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(done_two, 1);
+    }
+
+    #[test]
+    fn persist_is_idempotent_on_rerun_preserving_done() {
+        let note_id = "/n/note.md";
+        let mutex = db_with_note(note_id);
+        let body = "## Action items\n\n- [ ] keep me\n";
+
+        let (_, n1) = extract_and_persist_action_items(&mutex, note_id, body).unwrap();
+        assert_eq!(n1, 1);
+
+        // User completes the action between runs.
+        {
+            let c = mutex.lock().unwrap();
+            c.execute(
+                "UPDATE actions SET done = 1, manual_override = 1 WHERE text = 'keep me'",
+                [],
+            )
+            .unwrap();
+        }
+
+        // Re-reconcile emits the same line.
+        let (_, n2) = extract_and_persist_action_items(&mutex, note_id, body).unwrap();
+        assert_eq!(n2, 1, "second run still attempts the upsert");
+
+        let c = mutex.lock().unwrap();
+        let (done, mo, row_count): (i64, i64, i64) = c
+            .query_row(
+                "SELECT done, manual_override, \
+                        (SELECT COUNT(*) FROM actions WHERE text = 'keep me') \
+                 FROM actions WHERE text = 'keep me'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(done, 1, "ON CONFLICT DO NOTHING preserves done=1");
+        assert_eq!(mo, 1, "manual_override preserved");
+        assert_eq!(row_count, 1, "no duplicate row");
+    }
+
+    #[test]
+    fn persist_resolves_owner_to_assignee() {
+        let note_id = "/n/note.md";
+        let mutex = db_with_note(note_id);
+        seed_team_member(&mutex, "tm_heike", "Heike", false);
+        let body = "## Action items\n\n- [ ] Heike — Send Q3 budget\n- [ ] anonymous task\n";
+
+        let (_, _) = extract_and_persist_action_items(&mutex, note_id, body).unwrap();
+
+        let c = mutex.lock().unwrap();
+        let assignee: Option<String> = c
+            .query_row(
+                "SELECT assignee_id FROM actions WHERE text LIKE 'Heike%'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(assignee.as_deref(), Some("tm_heike"));
+
+        let anon: Option<String> = c
+            .query_row(
+                "SELECT assignee_id FROM actions WHERE text = 'anonymous task'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(anon.is_none());
+    }
+
+    #[test]
+    fn persist_emits_action_created_once_per_new_id() {
+        let note_id = "/n/note.md";
+        let mutex = db_with_note(note_id);
+        let body = "## Action items\n\n- [ ] one\n- [ ] two\n";
+
+        extract_and_persist_action_items(&mutex, note_id, body).unwrap();
+        let first_count: i64 = mutex
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE kind = 'action_created'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(first_count, 2);
+
+        // Rerun with the same body — no new events.
+        extract_and_persist_action_items(&mutex, note_id, body).unwrap();
+        let second_count: i64 = mutex
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE kind = 'action_created'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(second_count, 2, "no new events on idempotent re-run");
+
+        // Add a new item — one new event.
+        let body2 = "## Action items\n\n- [ ] one\n- [ ] two\n- [ ] three\n";
+        extract_and_persist_action_items(&mutex, note_id, body2).unwrap();
+        let third_count: i64 = mutex
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE kind = 'action_created'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(third_count, 3);
+    }
+
+    #[test]
+    fn persist_returns_zero_when_no_block() {
+        let note_id = "/n/note.md";
+        let mutex = db_with_note(note_id);
+        let body = "# T\n\n## Summary\n\nNo action items section here.\n";
+
+        let (stripped, n) = extract_and_persist_action_items(&mutex, note_id, body).unwrap();
+        assert_eq!(n, 0);
+        assert_eq!(stripped, body);
+
+        let c = mutex.lock().unwrap();
+        let rows: i64 = c
+            .query_row(
+                "SELECT COUNT(*) FROM actions WHERE origin_kind = 'reconcile'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(rows, 0);
+        let events: i64 = c
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE kind = 'action_created'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(events, 0);
     }
 }

--- a/src-tauri/src/reconcile.rs
+++ b/src-tauri/src/reconcile.rs
@@ -499,7 +499,7 @@ fn strip_observations_block(raw: &str) -> (String, Vec<ParsedObservation>) {
 /// Only the first occurrence is processed. If the model ever emits two
 /// `## Action items` headings the second survives in the body; the
 /// caller's logging will surface that as a tail of un-persisted items.
-fn split_action_items_block(body: &str) -> (String, Vec<String>) {
+pub(crate) fn split_action_items_block(body: &str) -> (String, Vec<String>) {
     const HEADING: &str = "## Action items";
     let lines: Vec<&str> = body.split('\n').collect();
     let start = lines.iter().position(|l| l.trim_end() == HEADING);

--- a/src-tauri/src/workstreams/persist.rs
+++ b/src-tauri/src/workstreams/persist.rs
@@ -1261,17 +1261,29 @@ pub fn set_action_assignee(
     Ok(())
 }
 
-/// DB-only delete path for a synth-origin row in the unified
-/// `actions` table (#111). The synthesizer content-hashes ids over
-/// (workstream_id, text), so re-synthesis of the same text +
+/// DB-only delete path for a synth-origin or reconcile-origin row in
+/// the unified `actions` table (#111). The synthesizer content-hashes
+/// ids over (workstream_id, text), so re-synthesis of the same text +
 /// workstream pair will recreate it — same trade-off as `done`,
 /// which is preserved on conflict.
-pub fn delete_action(conn: &Connection, action_id: &str) -> rusqlite::Result<()> {
-    conn.execute(
+///
+/// Writes a snapshot to `action_deletions` (#147) in the same tx with
+/// `cause='user_delete'` so #148/#149/#150 can suppress future
+/// re-emissions of the same text.
+pub fn delete_action(conn: &mut Connection, action_id: &str) -> rusqlite::Result<()> {
+    let tx = conn.transaction()?;
+    let now = crate::events::current_unix_ms();
+    crate::action_deletions::log_deletion(
+        &tx,
+        action_id,
+        crate::action_deletions::Cause::UserDelete,
+        now,
+    )?;
+    tx.execute(
         "DELETE FROM actions WHERE id = ?1",
         params![action_id],
     )?;
-    Ok(())
+    tx.commit()
 }
 
 /// Apply a user-driven status change (#78). Stamps the appropriate
@@ -1822,6 +1834,11 @@ mod tests {
             "../migrations/034_workstream_signal_tombstone.sql"
         ))
         .unwrap();
+        // 041 adds the universal action_deletions log (#147). Required
+        // by delete_action and dismiss_waiting_action, which both write
+        // a snapshot row before deleting from `actions`.
+        conn.execute_batch(include_str!("../migrations/041_action_deletions.sql"))
+            .unwrap();
         conn
     }
 
@@ -2210,7 +2227,7 @@ mod tests {
         tx.commit().unwrap();
 
         let aid = action_id("ws1", "Send recap");
-        delete_action(&conn, &aid).unwrap();
+        delete_action(&mut conn, &aid).unwrap();
 
         let detail = get_workstream_detail(&conn, "ws1").unwrap().unwrap();
         assert!(detail.actions.is_empty(), "delete_action must remove the row");

--- a/src/App.css
+++ b/src/App.css
@@ -8522,3 +8522,77 @@ button.workstream-external-chip:hover {
   color: #c44a1f;
   font-weight: 600;
 }
+
+/* ---------- Note actions sidebar (#145) -------------------------- */
+
+.editor-and-rail {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+  overflow: hidden;
+}
+.editor-and-rail > :first-child {
+  flex: 1;
+  min-width: 0;
+}
+.note-sidebar {
+  flex: 0 0 280px;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border-muted);
+  background: var(--bg-muted);
+  overflow: hidden;
+}
+.note-sidebar.collapsed {
+  flex-basis: 36px;
+}
+.note-sidebar-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border: 0;
+  background: transparent;
+  color: var(--fg-muted);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+.note-sidebar-toggle:hover { color: var(--fg); }
+.note-sidebar.collapsed .note-sidebar-toggle {
+  justify-content: center;
+  padding: 12px 0;
+}
+.note-sidebar-chevron {
+  display: inline-flex;
+  transition: transform 120ms ease;
+}
+.note-sidebar-chevron.open {
+  transform: rotate(90deg);
+}
+.note-sidebar-title {
+  flex: 1;
+  text-align: left;
+}
+.note-sidebar-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 8px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.note-sidebar-empty {
+  padding: 14px 8px;
+  font-size: 13px;
+  color: var(--fg-muted);
+}
+.note-sidebar .home-action-row {
+  /* The default action row is tuned for the wider Home page. Tighten
+     padding so rows breathe at 280px. */
+  padding: 10px 10px;
+  gap: 10px;
+}
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { undo, redo } from "@codemirror/commands";
 import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { Editor } from "./Editor";
+import { NoteActionsSidebar } from "./NoteActionsSidebar";
 import { dispatchDiff } from "./editor/applyDiff";
 import { AssigneePopover } from "./editor/assigneePopover";
 import { DueDatePopover } from "./editor/dueDatePopover";
@@ -2040,16 +2041,32 @@ export default function App() {
 
       <main className="pane">
         {mode === "edit" && (
-          <Editor
-            ref={editorRef}
-            value={content}
-            onChange={setContent}
-            tabSize={tabSize}
-            useTabs={useTabs}
-            softWrap={softWrap}
-            fontSize={fontSize}
-            actions={noteActions}
-          />
+          <div className="editor-and-rail">
+            <Editor
+              ref={editorRef}
+              value={content}
+              onChange={setContent}
+              tabSize={tabSize}
+              useTabs={useTabs}
+              softWrap={softWrap}
+              fontSize={fontSize}
+              actions={noteActions}
+            />
+            <NoteActionsSidebar
+              notePath={path}
+              refreshKey={savedContent}
+              members={members}
+              workstreams={workstreams}
+              onOpenWorkstream={(id) => {
+                tryNavigate("home");
+                queueMicrotask(() => {
+                  window.dispatchEvent(
+                    new CustomEvent("margin:open-workstream", { detail: id }),
+                  );
+                });
+              }}
+            />
+          </div>
         )}
         {mode === "preview" && (
           <Preview source={content} theme={theme} onSourceChange={setContent} />

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1554,6 +1554,7 @@ export function ActionRow({
     ? stripLeadingOwnerPrefix(it.text)
     : it.text;
   const isSynth = it.origin_kind === "synth";
+  const isReconcile = it.origin_kind === "reconcile";
   const isWaiting =
     it.origin_synth_kind === "email_waiting"
     || it.origin_synth_kind === "teams_waiting"
@@ -1607,11 +1608,13 @@ export function ActionRow({
           <div className="home-action-origin">
             {isSynth ? (
               <IconBriefcase size={10} sw={1.7} />
+            ) : isReconcile ? (
+              <IconCalendar size={10} sw={1.7} />
             ) : (
               <IconFileText size={10} sw={1.7} />
             )}
             <span className="home-action-origin-label">
-              {isSynth ? "Workstream" : "Note"}
+              {isSynth ? "Workstream" : isReconcile ? "Reconcile" : "Note"}
             </span>
             <span className="home-action-origin-sep">·</span>
             <span className="home-action-origin-title">{originTitle}</span>

--- a/src/NoteActionsSidebar.tsx
+++ b/src/NoteActionsSidebar.tsx
@@ -1,0 +1,230 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type ActionListItem,
+  type TeamMember,
+  type Workstream,
+  deleteAction,
+  listActionsForNote,
+  setActionAssignee,
+  setActionDone,
+  setActionWorkstream,
+  undoAutoResolvedAction,
+} from "./file";
+import { IconChevRight } from "./icons";
+import { ActionRow } from "./Home";
+
+type Props = {
+  notePath: string | null;
+  /** Bumped by the parent whenever the saved body changes (reconcile
+   *  finished, manual save) so the sidebar refetches. */
+  refreshKey: number | string;
+  members: TeamMember[];
+  workstreams: Workstream[];
+  onOpenWorkstream: (id: string) => void;
+};
+
+const COLLAPSED_STORAGE_KEY = "note-sidebar-collapsed";
+
+function readCollapsedDefault(): boolean | null {
+  if (typeof localStorage === "undefined") return null;
+  const v = localStorage.getItem(COLLAPSED_STORAGE_KEY);
+  if (v === "1") return true;
+  if (v === "0") return false;
+  return null;
+}
+
+export function NoteActionsSidebar({
+  notePath,
+  refreshKey,
+  members,
+  workstreams,
+  onOpenWorkstream,
+}: Props) {
+  const [items, setItems] = useState<ActionListItem[]>([]);
+  // Tri-state on first render: respect stored preference if any; otherwise
+  // open by default and let the first fetch decide whether to auto-collapse
+  // when there are no actions to show.
+  const stored = useRef<boolean | null>(readCollapsedDefault());
+  const [collapsed, setCollapsed] = useState<boolean>(stored.current ?? false);
+  const sawFirstFetchRef = useRef(false);
+
+  // Fetch the per-note action list on note change / refresh signal.
+  useEffect(() => {
+    if (!notePath) {
+      setItems([]);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const next = await listActionsForNote(notePath);
+        if (cancelled) return;
+        setItems(next);
+        // On the first fetch for this mount, auto-collapse if the user
+        // has no stored preference AND there's nothing to show.
+        if (!sawFirstFetchRef.current && stored.current === null) {
+          sawFirstFetchRef.current = true;
+          if (next.length === 0) setCollapsed(true);
+        }
+      } catch (e) {
+        if (!cancelled) console.error("[note-sidebar] list failed:", e);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [notePath, refreshKey]);
+
+  const persistCollapsed = useCallback((next: boolean) => {
+    setCollapsed(next);
+    stored.current = next;
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(COLLAPSED_STORAGE_KEY, next ? "1" : "0");
+    }
+  }, []);
+
+  // ---- Mutations (optimistic + refetch on failure) -----------------------
+
+  const refetch = useCallback(async () => {
+    if (!notePath) return;
+    try {
+      const next = await listActionsForNote(notePath);
+      setItems(next);
+    } catch (e) {
+      console.error("[note-sidebar] refetch failed:", e);
+    }
+  }, [notePath]);
+
+  const onToggle = useCallback(
+    (id: string, nextDone: boolean) => {
+      setItems((curr) => curr.map((a) => (a.id === id ? { ...a, done: nextDone } : a)));
+      void (async () => {
+        try {
+          await setActionDone(id, nextDone);
+        } catch (e) {
+          console.error("[note-sidebar] toggle failed:", e);
+          void refetch();
+        }
+      })();
+    },
+    [refetch],
+  );
+
+  const onDelete = useCallback(
+    (id: string) => {
+      setItems((curr) => curr.filter((a) => a.id !== id));
+      void (async () => {
+        try {
+          await deleteAction(id);
+        } catch (e) {
+          console.error("[note-sidebar] delete failed:", e);
+          void refetch();
+        }
+      })();
+    },
+    [refetch],
+  );
+
+  const onReassign = useCallback(
+    (id: string, memberId: string | null) => {
+      const display = memberId
+        ? members.find((m) => m.id === memberId)?.display_name ?? null
+        : null;
+      setItems((curr) =>
+        curr.map((a) =>
+          a.id === id
+            ? { ...a, assignee_id: memberId, assignee_display_name: display }
+            : a,
+        ),
+      );
+      void (async () => {
+        try {
+          await setActionAssignee(id, memberId);
+        } catch (e) {
+          console.error("[note-sidebar] reassign failed:", e);
+          void refetch();
+        }
+      })();
+    },
+    [members, refetch],
+  );
+
+  const onReattachWorkstream = useCallback(
+    (id: string, wsId: string | null) => {
+      const title = wsId ? workstreams.find((w) => w.id === wsId)?.title ?? null : null;
+      setItems((curr) =>
+        curr.map((a) =>
+          a.id === id ? { ...a, workstream_id: wsId, workstream_title: title } : a,
+        ),
+      );
+      void (async () => {
+        try {
+          await setActionWorkstream(id, wsId);
+        } catch (e) {
+          console.error("[note-sidebar] reattach workstream failed:", e);
+          void refetch();
+        }
+      })();
+    },
+    [refetch, workstreams],
+  );
+
+  const onUndoAutoResolved = useCallback(
+    (id: string) => {
+      setItems((curr) =>
+        curr.map((a) =>
+          a.id === id ? { ...a, auto_resolved_ms: null, done: false } : a,
+        ),
+      );
+      void (async () => {
+        try {
+          await undoAutoResolvedAction(id);
+        } catch (e) {
+          console.error("[note-sidebar] undo auto-resolved failed:", e);
+          void refetch();
+        }
+      })();
+    },
+    [refetch],
+  );
+
+  return (
+    <aside className={`note-sidebar${collapsed ? " collapsed" : ""}`}>
+      <button
+        type="button"
+        className="note-sidebar-toggle"
+        onClick={() => persistCollapsed(!collapsed)}
+        aria-expanded={!collapsed}
+        title={collapsed ? "Show actions" : "Hide actions"}
+      >
+        <span className={`note-sidebar-chevron${collapsed ? "" : " open"}`}>
+          <IconChevRight size={12} sw={2} />
+        </span>
+        {!collapsed && <span className="note-sidebar-title">Actions ({items.length})</span>}
+      </button>
+      {!collapsed && (
+        <div className="note-sidebar-body">
+          {items.length === 0 ? (
+            <div className="note-sidebar-empty">No tracked actions for this note.</div>
+          ) : (
+            items.map((it) => (
+              <ActionRow
+                key={it.id}
+                it={it}
+                onToggle={onToggle}
+                onDelete={onDelete}
+                onOpenNote={() => {}}
+                onOpenWorkstream={onOpenWorkstream}
+                members={members}
+                workstreams={workstreams}
+                onReassign={onReassign}
+                onReattachWorkstream={onReattachWorkstream}
+                onUndoAutoResolved={onUndoAutoResolved}
+              />
+            ))
+          )}
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -9,6 +9,7 @@ import {
   deleteFirecrawlApiKey,
   deleteVoyageApiKey,
   exportNotes,
+  migrateReconciledNotesToActionRows,
   forceReindexEmbeddings,
   hasAnthropicApiKey,
   hasFirecrawlApiKey,
@@ -325,6 +326,35 @@ function DataSection() {
     }
   };
 
+  const onMigrateActionItems = async () => {
+    const confirmed = await ask(
+      "Move LLM-extracted action items from your existing reconciled meeting notes into the database? This strips the `## Action items` block from each note body and writes a per-note backup (.action-items-backup.md) for rollback. Safe to run multiple times — already-migrated notes are skipped.",
+      { title: "Migrate reconciled action items", kind: "info" },
+    );
+    if (!confirmed) return;
+    setBusy(true);
+    setStatus(null);
+    try {
+      const r = await migrateReconciledNotesToActionRows(false);
+      if (r.errors.length > 0) {
+        setStatus(
+          `Migration completed with ${r.errors.length} error${r.errors.length === 1 ? "" : "s"}. Migrated ${r.notes_migrated} note${r.notes_migrated === 1 ? "" : "s"} (${r.rows_created} row${r.rows_created === 1 ? "" : "s"}).`,
+        );
+      } else if (r.notes_migrated === 0) {
+        setStatus("Nothing to migrate — all reconciled notes are already in the new format.");
+      } else {
+        setStatus(
+          `Migrated ${r.notes_migrated} note${r.notes_migrated === 1 ? "" : "s"}, ${r.rows_created} action${r.rows_created === 1 ? "" : "s"}, wrote ${r.backups_written} backup file${r.backups_written === 1 ? "" : "s"}.`,
+        );
+      }
+    } catch (e) {
+      console.error("[settings] migrateReconciledNotesToActionRows failed:", e);
+      setStatus(`Migration failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
     <section className="settings-section">
       <h2>Data</h2>
@@ -341,6 +371,23 @@ function DataSection() {
           disabled={busy}
         >
           {busy ? "Exporting…" : "Export all notes…"}
+        </button>
+      </div>
+      <p className="settings-section-desc">
+        Pre-#144 reconciled meeting notes have an inline{" "}
+        <code>## Action items</code> block in their body. This migration moves
+        those items into the database (so the actions sidebar can show them)
+        and writes a per-note backup for rollback. It runs once automatically
+        at first launch; use this button to re-run it.
+      </p>
+      <div className="settings-row">
+        <button
+          type="button"
+          className="settings-btn"
+          onClick={onMigrateActionItems}
+          disabled={busy}
+        >
+          {busy ? "Migrating…" : "Migrate reconciled action items…"}
         </button>
       </div>
       {status && <p className="settings-helper">{status}</p>}

--- a/src/file.ts
+++ b/src/file.ts
@@ -317,11 +317,13 @@ export type ActionScope = "open" | "done" | "all";
 
 export type ActionListItem = {
   id: string;
-  /** Origin discriminator (#111). `"note"` for markdown-checkbox-backed
-   *  rows; `"synth"` for synthesizer-emitted rows. Drives click-
-   *  through routing; the unified write IPCs dispatch internally so
-   *  callers don't branch on this. */
-  origin_kind: "note" | "synth";
+  /** Origin discriminator (#111, #144). `"note"` for markdown-
+   *  checkbox-backed rows; `"synth"` for synthesizer-emitted rows;
+   *  `"reconcile"` for LLM-extracted rows from meeting reconciliation
+   *  (no body line). Drives click-through routing and badge rendering;
+   *  the unified write IPCs dispatch internally so callers don't
+   *  branch on this. */
+  origin_kind: "note" | "synth" | "reconcile";
   /** Source note path for note-origin rows; `null` for synth rows. */
   origin_note_path: string | null;
   /** 1-based source-line for note-origin rows; `null` for synth rows. */
@@ -398,6 +400,15 @@ export async function listActions(
     subjectMemberId: filters.subjectMemberId,
     originSynthKinds: filters.originSynthKinds,
   });
+}
+
+/** Per-note actions for the note-view sidebar (#145). Returns every
+ *  row whose `origin_note_path` matches `notePath`, regardless of
+ *  origin_kind or done state. Ordered created_ms DESC. */
+export async function listActionsForNote(
+  notePath: string,
+): Promise<ActionListItem[]> {
+  return invoke<ActionListItem[]>("list_actions_for_note", { noteId: notePath });
 }
 
 export async function setActionDone(id: string, done: boolean): Promise<void> {

--- a/src/file.ts
+++ b/src/file.ts
@@ -411,6 +411,28 @@ export async function listActionsForNote(
   return invoke<ActionListItem[]>("list_actions_for_note", { noteId: notePath });
 }
 
+/** Phase 1.4 (#146) — one-time backfill report. Auto-runs once at
+ *  boot when the meta flag is `'0'`; the Settings → Data button
+ *  re-runs it on demand (idempotent). */
+export type ActionsMigrationReport = {
+  dry_run: boolean;
+  candidates_scanned: number;
+  notes_migrated: number;
+  rows_created: number;
+  backups_written: number;
+  notes_already_clean: number;
+  errors: string[];
+};
+
+export async function migrateReconciledNotesToActionRows(
+  dryRun: boolean,
+): Promise<ActionsMigrationReport> {
+  return invoke<ActionsMigrationReport>(
+    "migrate_reconciled_notes_to_action_rows",
+    { dryRun },
+  );
+}
+
 export async function setActionDone(id: string, done: boolean): Promise<void> {
   await invoke<void>("set_action_done", { id, done });
 }


### PR DESCRIPTION
## Summary
- Adds migration 041 with the `action_deletions` table — verbatim snapshot of any action row at the moment of deletion plus a `cause` discriminator (`user_delete` / `user_dismiss` / `auto_resolved`).
- New `action_deletions::log_deletion(tx, id, cause, now)` helper. Reads the action row, resolves `source_series_master_id` for reconcile-origin rows via `calendar_events.linked_note_id`, inserts the snapshot. No-op when the row is already gone.
- Wires the helper into the three write paths called out in #147:
  - `notes::delete_action` (both note-origin via `mutate_note_action_body`, and synth/reconcile-origin via `workstreams::persist::delete_action`)
  - `notes::dismiss_waiting_action` (alongside the existing `dismissed_action_sources` insert — deprecation deferred to #149)
  - `profiles::worker::auto_resolve_missing` — logs only on the threshold-crossing tick, with `cause='auto_resolved'` so #148/#149 can filter out worker omissions as weak signal.

Unblocks #148, #149, #150.

## Design notes
- Snapshot fields are deliberately not FKs: by the time a reader cares, the action row is gone, and dangling team-member ids don't break the learning signal.
- `upsert_in_tx`'s wholesale `DELETE FROM actions WHERE origin_kind='note'` on body reparse is intentionally **not** logged — would false-positive on every note edit.
- The Phase 1.4 backfill's row replacement is also not logged — those rows are getting re-created with the same id under `'reconcile'`, not deleted by the user.

## Test plan
- [x] `cargo test --lib` — 541 pass (was 535; +6 new)
- [x] `log_records_user_delete_with_full_snapshot`
- [x] `log_records_user_dismiss_with_correct_cause`
- [x] `log_populates_series_master_id_for_recurring_meeting_actions`
- [x] `log_leaves_series_null_when_event_is_oneoff`
- [x] `log_handles_deletes_after_action_row_is_already_gone_gracefully`
- [x] `auto_resolve_logs_deletion_only_when_threshold_crossed`
- [ ] Manual: delete an action from Home, inspect `SELECT * FROM action_deletions` — snapshot present with `cause='user_delete'`
- [ ] Manual: dismiss a waiting action from Team profile pane — log row written with `cause='user_dismiss'`; legacy `dismissed_action_sources` row also written (deprecation in #149)
- [ ] Manual: trigger two consecutive worker recomputes that omit a waiting action — one log row appears on the second tick with `cause='auto_resolved'`

Closes #147.