### PR TITLE
Phase 2.3 — Profile worker: read deletion log; deprecate dismissed_action_sources (#149)

### DIFF
--- a/src-tauri/src/profiles/prompt.rs
+++ b/src-tauri/src/profiles/prompt.rs
@@ -132,7 +132,15 @@ pub async fn build_prompt_inputs(
     person_id: &str,
 ) -> Result<serde_json::Value, String> {
     let now_ms = crate::events::current_unix_ms();
-    let (member_block, edge_rows, event_rows, accepted_observations, waiting_from_me, waiting_for_them) = {
+    let (
+        member_block,
+        edge_rows,
+        event_rows,
+        accepted_observations,
+        waiting_from_me,
+        waiting_for_them,
+        recently_rejected_waiting,
+    ) = {
         let conn_state = app.state::<std::sync::Mutex<Connection>>();
         let c = conn_state.lock().map_err(|e| e.to_string())?;
         let accepted = crate::observations::persist::list_by_member(
@@ -146,6 +154,12 @@ pub async fn build_prompt_inputs(
             .map_err(|e| format!("from_me candidates: {e}"))?;
         let for_them = crate::profiles::signals::candidates_for_them(&c, person_id, now_ms)
             .map_err(|e| format!("for_them candidates: {e}"))?;
+        let rejected =
+            crate::profiles::signals::recently_rejected_waiting(&c, person_id, now_ms)
+                .unwrap_or_else(|e| {
+                    eprintln!("[profiles] rejected-waiting fetch failed: {e}");
+                    None
+                });
         (
             load_member(&c, person_id)?,
             load_edges(&c, person_id)?,
@@ -153,6 +167,7 @@ pub async fn build_prompt_inputs(
             projected,
             from_me,
             for_them,
+            rejected,
         )
     };
     let display_name = member_block.display_name.clone();
@@ -191,7 +206,7 @@ pub async fn build_prompt_inputs(
         Vec::new()
     };
 
-    Ok(serde_json::json!({
+    let mut payload = serde_json::json!({
         "member": member_block,
         "edges": edge_rows,
         "events": event_rows,
@@ -201,7 +216,16 @@ pub async fn build_prompt_inputs(
             "from_me": waiting_from_me,
             "for_them": waiting_for_them,
         },
-    }))
+    });
+    // Only insert the key when there's signal — keeps the prompt
+    // clean in the steady state and makes the JSON diff-friendly when
+    // a new rejection lands.
+    if let Some(rejected) = recently_rejected_waiting {
+        if let Some(obj) = payload.as_object_mut() {
+            obj.insert("recently_rejected_waiting".to_string(), rejected);
+        }
+    }
+    Ok(payload)
 }
 
 /// Project accepted-observation rows down to the three fields the worker
@@ -447,7 +471,13 @@ KEEP examples:\n\
     * Pending decision waiting on the user (\"Sollen wir mit X oder Y weitergehen?\").\n\
 \n\
 - Cap each direction at 5 items; if you have more substantive candidates than that, pick the highest-stakes (deadlines, decisions, blockers) over the smallest-ask ones.\n\
-- Never emit a source_ref_id that wasn't in the candidate set — the post-parse validator will drop it anyway.";
+- Never emit a source_ref_id that wasn't in the candidate set — the post-parse validator will drop it anyway.\n\
+\n\
+Recently rejected (user signal):\n\
+- The user message may include `recently_rejected_waiting`: keyed by `source_kind` (`email`/`teams`/`meeting`), each value is an array of short action-item texts the user previously deleted or dismissed for this person (last 30 days).\n\
+- These are strong signal that you proposed something the user didn't want. Be **much more selective** when emitting candidates that resemble them. Resemblance is your judgment — same topic, same recipient, same phrasing all count.\n\
+- When in doubt, DROP rather than re-emit. The user can always check the source candidate directly if needed; getting a rejected item back as a waiting action is worse than missing one.\n\
+- The field is omitted entirely when no matching rejections exist.";
 
 pub async fn call_anthropic(
     api_key: &str,

--- a/src-tauri/src/profiles/signals.rs
+++ b/src-tauri/src/profiles/signals.rs
@@ -211,6 +211,78 @@ fn sort_and_cap(items: &mut Vec<WaitingCandidate>, cap: usize) {
     items.truncate(cap);
 }
 
+/// Per-source-kind cap on rejected-waiting items fed to the worker
+/// prompt (#149). Recent first; older rows drop.
+pub const REJECTED_WAITING_PER_KIND_CAP: usize = 10;
+
+/// Build the per-person "recently rejected waiting actions" payload
+/// for the worker prompt (#149). Returns a JSON object keyed by short
+/// source_kind (`email` / `teams` / `meeting`); each value is an array
+/// of action-item text strings the user previously deleted or
+/// dismissed *about this person*, last 30 days.
+///
+/// Matches the person either via the action's counterparty
+/// (`subject_member_id = person_id`, which covers `waiting_from_me`
+/// rows where the user was assignee) OR via the assignee
+/// (`assignee_id = person_id`, which covers `waiting_for_them` rows
+/// where the user was waiting on them). Either direction is the same
+/// "we tried to surface a waiting action about this person and the
+/// user rejected it" signal.
+///
+/// Cause filter: `user_delete` / `user_dismiss` only. `auto_resolved`
+/// is excluded — worker omissions are weak signal; including them
+/// would create a feedback loop where the LLM hides items so the
+/// worker sweeps them, training the LLM to hide more.
+///
+/// Returns `None` (and the caller omits the key) when no kind has any
+/// matching rows — keeps the prompt clean for the steady state.
+pub fn recently_rejected_waiting(
+    conn: &Connection,
+    person_id: &str,
+    now_ms: i64,
+) -> rusqlite::Result<Option<serde_json::Value>> {
+    let cutoff = now_ms - RECENCY_WINDOW_MS;
+    const KINDS: &[(&str, &str)] = &[
+        ("email_waiting", "email"),
+        ("teams_waiting", "teams"),
+        ("meeting_waiting", "meeting"),
+    ];
+
+    let mut out = serde_json::Map::new();
+    for (synth_kind, short_kind) in KINDS {
+        let mut stmt = conn.prepare(
+            "SELECT text \
+               FROM action_deletions \
+              WHERE origin_synth_kind = ?1 \
+                AND (subject_member_id = ?2 OR assignee_id = ?2) \
+                AND cause IN ('user_delete', 'user_dismiss') \
+                AND deleted_ms > ?3 \
+              ORDER BY deleted_ms DESC \
+              LIMIT ?4",
+        )?;
+        let texts: Vec<String> = stmt
+            .query_map(
+                params![synth_kind, person_id, cutoff, REJECTED_WAITING_PER_KIND_CAP as i64],
+                |r| r.get::<_, String>(0),
+            )?
+            .filter_map(Result::ok)
+            .collect();
+        if !texts.is_empty() {
+            out.insert(
+                (*short_kind).to_string(),
+                serde_json::Value::Array(
+                    texts.into_iter().map(serde_json::Value::String).collect(),
+                ),
+            );
+        }
+    }
+    if out.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(serde_json::Value::Object(out)))
+    }
+}
+
 // ---------- Email ---------------------------------------------------------
 
 /// Person → self emails within the recency window. The previous
@@ -1266,5 +1338,188 @@ mod tests {
         hydrate_chat_participants(&conn, &mut cands).unwrap();
         assert!(cands[0].chat_participants.is_empty());
         assert!(cands[1].chat_participants.is_empty());
+    }
+
+    // ---------- Recently rejected waiting (#149) --------------------------
+
+    #[allow(clippy::too_many_arguments)]
+    fn seed_deletion(
+        conn: &Connection,
+        deleted_ms: i64,
+        origin_synth_kind: &str,
+        text: &str,
+        subject_member_id: Option<&str>,
+        assignee_id: Option<&str>,
+        cause: &str,
+    ) {
+        conn.execute(
+            "INSERT INTO action_deletions \
+                (deleted_ms, origin_kind, origin_synth_kind, \
+                 subject_member_id, assignee_id, text, cause) \
+             VALUES (?1, 'synth', ?2, ?3, ?4, ?5, ?6)",
+            params![
+                deleted_ms,
+                origin_synth_kind,
+                subject_member_id,
+                assignee_id,
+                text,
+                cause
+            ],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn worker_rejected_block_groups_by_synth_kind() {
+        let conn = open_db();
+        seed_self(&conn, "tm_self", "me@x.io");
+        seed_teammate(&conn, "tm_alice", "alice@x.io");
+        let now = 1_700_000_000_000;
+        // One row of each kind for the same counterparty.
+        seed_deletion(
+            &conn,
+            now - 1_000,
+            "email_waiting",
+            "Reply to Alice about Q3",
+            Some("tm_alice"),
+            Some("tm_self"),
+            "user_delete",
+        );
+        seed_deletion(
+            &conn,
+            now - 2_000,
+            "teams_waiting",
+            "Follow up on planning ping",
+            Some("tm_alice"),
+            Some("tm_self"),
+            "user_dismiss",
+        );
+        seed_deletion(
+            &conn,
+            now - 3_000,
+            "meeting_waiting",
+            "Write notes from 1:1",
+            Some("tm_self"),
+            Some("tm_alice"),
+            "user_delete",
+        );
+
+        let payload = recently_rejected_waiting(&conn, "tm_alice", now)
+            .unwrap()
+            .expect("expected payload with all three kinds populated");
+        let obj = payload.as_object().unwrap();
+        assert_eq!(obj.len(), 3);
+        assert!(obj.contains_key("email"));
+        assert!(obj.contains_key("teams"));
+        assert!(obj.contains_key("meeting"));
+        let emails = obj["email"].as_array().unwrap();
+        assert_eq!(emails.len(), 1);
+        assert_eq!(emails[0].as_str().unwrap(), "Reply to Alice about Q3");
+    }
+
+    #[test]
+    fn worker_rejected_block_filters_to_window() {
+        let conn = open_db();
+        seed_teammate(&conn, "tm_alice", "alice@x.io");
+        // `now` chosen large enough that `now - 90d` is positive — keeps
+        // the seeded `deleted_ms` non-negative, which matches production
+        // (ms-since-epoch is always positive).
+        let now: i64 = 100 * 24 * 60 * 60 * 1000; // 100 days
+        seed_deletion(
+            &conn,
+            now - 40 * 24 * 60 * 60 * 1000, // 40 days ago — outside 30-day window
+            "email_waiting",
+            "Stale rejection",
+            Some("tm_alice"),
+            None,
+            "user_delete",
+        );
+        seed_deletion(
+            &conn,
+            now - 5 * 24 * 60 * 60 * 1000, // 5 days ago — inside window
+            "email_waiting",
+            "Recent rejection",
+            Some("tm_alice"),
+            None,
+            "user_delete",
+        );
+        let payload = recently_rejected_waiting(&conn, "tm_alice", now).unwrap().unwrap();
+        let emails = payload["email"].as_array().unwrap();
+        assert_eq!(emails.len(), 1, "only the in-window row survives");
+        assert_eq!(emails[0].as_str().unwrap(), "Recent rejection");
+    }
+
+    #[test]
+    fn worker_rejected_block_excludes_auto_resolved() {
+        let conn = open_db();
+        seed_teammate(&conn, "tm_alice", "alice@x.io");
+        let now: i64 = 100 * 24 * 60 * 60 * 1000;
+        seed_deletion(
+            &conn,
+            now - 1_000,
+            "email_waiting",
+            "Worker swept this",
+            Some("tm_alice"),
+            None,
+            "auto_resolved",
+        );
+        let payload = recently_rejected_waiting(&conn, "tm_alice", now).unwrap();
+        assert!(payload.is_none(), "auto_resolved must not feed the prompt");
+    }
+
+    #[test]
+    fn worker_rejected_block_matches_by_assignee_for_for_them_rows() {
+        // `waiting_for_them` rows have assignee = person, subject = self.
+        // The query must catch those via the assignee_id arm.
+        let conn = open_db();
+        seed_self(&conn, "tm_self", "me@x.io");
+        seed_teammate(&conn, "tm_alice", "alice@x.io");
+        let now: i64 = 100 * 24 * 60 * 60 * 1000;
+        seed_deletion(
+            &conn,
+            now - 1_000,
+            "teams_waiting",
+            "Ping Alice for status",
+            Some("tm_self"),     // subject = self (it's a "for_them" row)
+            Some("tm_alice"),    // assignee = person
+            "user_delete",
+        );
+        let payload = recently_rejected_waiting(&conn, "tm_alice", now)
+            .unwrap()
+            .expect("for_them row must be visible when person is the assignee");
+        let teams = payload["teams"].as_array().unwrap();
+        assert_eq!(teams.len(), 1);
+    }
+
+    #[test]
+    fn worker_rejected_block_caps_per_kind() {
+        let conn = open_db();
+        seed_teammate(&conn, "tm_alice", "alice@x.io");
+        let now: i64 = 100 * 24 * 60 * 60 * 1000;
+        // Seed twice the cap; only the most recent REJECTED_WAITING_PER_KIND_CAP
+        // survive.
+        for i in 0..(REJECTED_WAITING_PER_KIND_CAP * 2) {
+            seed_deletion(
+                &conn,
+                now - (i as i64) * 1_000,
+                "email_waiting",
+                &format!("Item #{i:02}"),
+                Some("tm_alice"),
+                None,
+                "user_delete",
+            );
+        }
+        let payload = recently_rejected_waiting(&conn, "tm_alice", now).unwrap().unwrap();
+        let emails = payload["email"].as_array().unwrap();
+        assert_eq!(emails.len(), REJECTED_WAITING_PER_KIND_CAP);
+        // Newest survives, oldest dropped.
+        assert!(emails.iter().any(|v| v.as_str().unwrap().contains("#00")));
+        assert!(
+            !emails.iter().any(|v| v.as_str().unwrap().contains(&format!(
+                "#{:02}",
+                REJECTED_WAITING_PER_KIND_CAP * 2 - 1
+            ))),
+            "oldest row must be dropped past the cap"
+        );
     }
 }

--- a/src-tauri/src/profiles/worker.rs
+++ b/src-tauri/src/profiles/worker.rs
@@ -430,8 +430,26 @@ fn upsert_waiting_action(
         _ => return Ok(None),
     };
 
-    // Skip if the user explicitly dismissed this source.
-    let dismissed: bool = tx
+    // Skip if the user explicitly rejected this source. Consults both:
+    //   - the universal deletion log (#147), the new primary signal
+    //     populated by every delete/dismiss path.
+    //   - `dismissed_action_sources`, the pre-#147 legacy table. Kept
+    //     in service until we're confident the log covers every row
+    //     it used to gate; deprecation is a separate follow-up.
+    let dismissed_via_log: bool = tx
+        .query_row(
+            "SELECT 1 FROM action_deletions \
+              WHERE origin_synth_kind = ?1 \
+                AND origin_synth_id = ?2 \
+                AND (assignee_id = ?3 OR (assignee_id IS NULL AND ?3 IS NULL)) \
+                AND cause IN ('user_delete', 'user_dismiss') \
+              LIMIT 1",
+            rusqlite::params![synth_kind, w.source_ref_id, assignee_id],
+            |_| Ok(true),
+        )
+        .optional()?
+        .unwrap_or(false);
+    let dismissed_legacy: bool = tx
         .query_row(
             "SELECT 1 FROM dismissed_action_sources \
               WHERE origin_synth_kind = ?1 \
@@ -442,7 +460,7 @@ fn upsert_waiting_action(
         )
         .optional()?
         .unwrap_or(false);
-    if dismissed {
+    if dismissed_via_log || dismissed_legacy {
         return Ok(None);
     }
 
@@ -898,8 +916,12 @@ mod tests {
         assert_eq!(action_text(&conn, &id).as_deref(), Some("original"));
     }
 
+    /// Regression: the worker still honors the legacy
+    /// `dismissed_action_sources` table even after #149 added the
+    /// deletion-log path. Old rows from before #147 must keep blocking
+    /// re-emission until the legacy table is dropped in a follow-up.
     #[test]
-    fn upsert_skips_dismissed_source() {
+    fn upsert_still_honors_dismissed_action_sources_until_deprecated() {
         let mut conn = open_db();
         seed_member(&conn, "tm_self", true);
         seed_member(&conn, "tm_alice", false);
@@ -922,6 +944,74 @@ mod tests {
         tx.commit().unwrap();
         assert!(res.is_none(), "dismissed source returns None");
         assert_eq!(count_actions(&conn), 0);
+    }
+
+    /// New path (#149): a row in `action_deletions` with a
+    /// user-driven cause blocks the worker from re-emitting the same
+    /// (kind, ref_id, assignee) tuple. The deletion log is now the
+    /// primary signal; `dismissed_action_sources` is the legacy fallback.
+    #[test]
+    fn upsert_skips_when_action_deletions_log_records_user_delete() {
+        let mut conn = open_db();
+        seed_member(&conn, "tm_self", true);
+        seed_member(&conn, "tm_alice", false);
+        let tx = conn.transaction().unwrap();
+        tx.execute(
+            "INSERT INTO action_deletions \
+                (deleted_ms, origin_kind, origin_synth_kind, origin_synth_id, \
+                 assignee_id, text, cause) \
+             VALUES (1000, 'synth', 'teams_waiting', 'msg1', 'tm_self', 'x', 'user_delete')",
+            [],
+        )
+        .unwrap();
+        let res = upsert_waiting_action(
+            &tx,
+            &waiting("teams", "msg1", "x"),
+            "tm_self",
+            "tm_alice",
+            2_000,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        assert!(
+            res.is_none(),
+            "deletion log entry with user_delete cause must block re-emission"
+        );
+        assert_eq!(count_actions(&conn), 0);
+    }
+
+    /// Auto-resolved rows in the deletion log are NOT user signal —
+    /// they record the worker's own sweep. Re-emission must NOT be
+    /// blocked by them, or the LLM could never resurface a previously
+    /// auto-resolved item that became relevant again.
+    #[test]
+    fn upsert_does_not_skip_on_auto_resolved_log_entry() {
+        let mut conn = open_db();
+        seed_member(&conn, "tm_self", true);
+        seed_member(&conn, "tm_alice", false);
+        let tx = conn.transaction().unwrap();
+        tx.execute(
+            "INSERT INTO action_deletions \
+                (deleted_ms, origin_kind, origin_synth_kind, origin_synth_id, \
+                 assignee_id, text, cause) \
+             VALUES (1000, 'synth', 'teams_waiting', 'msg1', 'tm_self', 'x', 'auto_resolved')",
+            [],
+        )
+        .unwrap();
+        let res = upsert_waiting_action(
+            &tx,
+            &waiting("teams", "msg1", "x"),
+            "tm_self",
+            "tm_alice",
+            2_000,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+        assert!(
+            res.is_some(),
+            "auto_resolved entries are not user signal — re-emission must proceed"
+        );
+        assert_eq!(count_actions(&conn), 1);
     }
 
     /// First omission bumps the hysteresis counter but does NOT flip


### PR DESCRIPTION
## Summary
Two changes feed the universal deletion log (#147) into the per-person profile worker:

1. **Prompt input** — `signals::recently_rejected_waiting(conn, person_id, now_ms)` queries `action_deletions` for `_waiting`-kind rows that name this person (`subject_member_id = ?` for from_me rows OR `assignee_id = ?` for for_them rows), with `cause IN ('user_delete','user_dismiss')` over a 30-day window. Returns `Some(JSON)` keyed by short kind (`email`/`teams`/`meeting`), capped at 10 per kind. `build_prompt_inputs` includes the key only when there's signal. `SYSTEM_PROMPT` now teaches the model to be much more selective about candidates that resemble these rows.

2. **Dismissed-source upsert gate** — `upsert_waiting_action` now consults both the deletion log (new primary) and `dismissed_action_sources` (legacy) by exact tuple. Either match blocks re-emission. The legacy table stays in service until a follow-up deprecates it.

`cause='auto_resolved'` rows are deliberately **excluded** from both surfaces. Worker omissions are weak signal — including them would create a feedback loop where the LLM hides items, the worker sweeps, and the LLM trains to hide more.

Closes #149. Depends on #147 (merged).

## Test plan
- [x] `cargo test --lib` — 554 pass (was 547; +7 new)
- [x] `signals::tests::worker_rejected_block_groups_by_synth_kind`
- [x] `signals::tests::worker_rejected_block_filters_to_window`
- [x] `signals::tests::worker_rejected_block_excludes_auto_resolved`
- [x] `signals::tests::worker_rejected_block_matches_by_assignee_for_for_them_rows`
- [x] `signals::tests::worker_rejected_block_caps_per_kind`
- [x] `worker::tests::upsert_still_honors_dismissed_action_sources_until_deprecated` (regression)
- [x] `worker::tests::upsert_skips_when_action_deletions_log_records_user_delete`
- [x] `worker::tests::upsert_does_not_skip_on_auto_resolved_log_entry`
- [ ] Manual: delete 3 `email_waiting` actions for a teammate via Home; force-recompute their profile; inspect the prompt dump — `recently_rejected_waiting.email` lists those 3 texts
- [ ] Manual: re-emit a waiting candidate whose `(kind, ref_id, assignee)` tuple matches an `action_deletions` row — worker skips the upsert (no row recreated)