### PR TITLE
Resolve transcript path via Rust so reconcile finds it post-#112

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -553,6 +553,7 @@ pub fn run() {
             notes::discard_recording,
             notes::delete_note,
             notes::read_note,
+            notes::transcript_path_for,
             notes::write_note,
             notes::set_note_tags,
             notes::set_archived,

--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -290,6 +290,28 @@ pub fn list_notes(
     crate::index::list_all(&c, scope.unwrap_or_default()).map_err(|e| e.to_string())
 }
 
+/// Resolve a note's bundle id to the absolute filesystem path of its
+/// `transcript.json` sidecar. Returns `None` when the file isn't on
+/// disk (no recording yet, transcript pending, etc.).
+///
+/// After #112 notes live in the DB by `note_id` (= bundle id) and the
+/// frontend no longer holds filesystem paths. Audio + transcripts
+/// still live on disk under `<notes_dir>/<note_id>/`, so any code
+/// path that needs to read or reference the transcript by absolute
+/// path (reconcile prompt, transcript viewer, "Generate notes"
+/// affordance) routes through this helper.
+#[tauri::command]
+pub fn transcript_path_for(note_id: String) -> Option<String> {
+    let path = crate::paths::notes_dir()
+        .join(&note_id)
+        .join(TRANSCRIPT_FILENAME);
+    if path.exists() {
+        Some(path.to_string_lossy().into_owned())
+    } else {
+        None
+    }
+}
+
 /// Search across all non-archived owned notes (titles + bodies via the
 /// FTS5 index, plus per-bundle transcript.json segments). Returns a
 /// ranked list of `SearchHit`s. `limit` defaults to 20 and is clamped

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,8 +144,18 @@ function greet(name: string) {
 [^1]: Like this one.
 `;
 
-function transcriptPathFor(notePath: string): string {
-  return notePath.replace(/note\.md$/, "transcript.json");
+/// Resolve the absolute path of a note's `transcript.json` sidecar.
+/// After #112 the frontend's `notePath` is the DB bundle id (no
+/// `note.md` suffix), so we can't construct the on-disk path with a
+/// regex anymore — we ask Rust to do it. Returns `null` when the
+/// bundle has no transcript on disk yet.
+async function transcriptPathFor(noteId: string): Promise<string | null> {
+  try {
+    return (await invoke<string | null>("transcript_path_for", { noteId })) ?? null;
+  } catch (e) {
+    console.error("transcript_path_for failed:", e);
+    return null;
+  }
 }
 
 function deriveTitle(content: string, fallback: string): string {
@@ -508,19 +518,17 @@ export default function App() {
   // transcript has already been reconciled (`reconciled_at` set by
   // reconcile_notes), and reset banner state accordingly.
   const refreshRecordingState = useCallback(async (notePath: string | null) => {
-    if (!notePath || !notePath.endsWith("/note.md")) {
+    if (!notePath) {
       setRecording({ kind: "none", hasTranscript: false });
       return;
     }
-    const tp = transcriptPathFor(notePath);
-    let exists = false;
-    try {
-      exists = await invoke<boolean>("file_exists", { path: tp });
-    } catch {
-      exists = false;
-    }
+    // After #112 `notePath` is the DB bundle id, so we ask Rust to
+    // resolve `<notes_dir>/<id>/transcript.json` and report whether
+    // it's on disk. `null` here means "no transcript yet" — there's
+    // no separate file_exists hop.
+    const tp = await transcriptPathFor(notePath);
     let reconciled = false;
-    if (exists) {
+    if (tp) {
       try {
         const f = await readFile(tp);
         const parsed: Partial<Transcript> = JSON.parse(f.content);
@@ -531,8 +539,8 @@ export default function App() {
     }
     setRecording({
       kind: "none",
-      hasTranscript: exists,
-      transcriptPath: exists ? tp : undefined,
+      hasTranscript: tp != null,
+      transcriptPath: tp ?? undefined,
       reconciled,
     });
   }, []);
@@ -620,7 +628,7 @@ export default function App() {
       });
       try {
         await transcribe(wavPath, aiRef.current.glossary, aiRef.current.whisperModel);
-        const tp = transcriptPathFor(snapshot.notePath);
+        const tp = await transcriptPathFor(snapshot.notePath);
 
         // Notify regardless of where the user is now.
         pushNotificationAndPersist({
@@ -632,7 +640,7 @@ export default function App() {
         // Refresh the per-note quiescent state only if the user is
         // still on the source note. Otherwise loadFile will pick up
         // the new transcript next time they navigate back.
-        if (pathRef.current === snapshot.notePath) {
+        if (pathRef.current === snapshot.notePath && tp) {
           setRecording({ kind: "ready", transcriptPath: tp });
         }
       } catch (err) {


### PR DESCRIPTION
Fixes "Generate notes" failing with `read transcript: No such file or directory (os error 2)` right after recording.

## Cause
`transcriptPathFor(notePath)` was a frontend regex that replaced `note.md` with `transcript.json`. Pre-#112 `notePath` was the absolute filesystem path to the bundle's note.md, so the regex produced the correct sibling. After #112 `notePath` is the DB bundle id (a bare UUID), the regex is a no-op, and the IPC ended up reading a file literally named after the UUID at cwd.

Bonus: `refreshRecordingState` guarded on `notePath.endsWith("/note.md")`, always false for a bundle id — `hasTranscript` was permanently false on every reload, masking the bug except in the fresh-transcribe path.

## Fix
- New `#[tauri::command] transcript_path_for(note_id) -> Option<String>` in notes.rs. Builds `<notes_dir>/<note_id>/transcript.json` and returns it if the file exists. Registered in lib.rs.
- Frontend `transcriptPathFor` becomes an async wrapper around the IPC. `refreshRecordingState` drops the `.endsWith("/note.md")` guard and reads `tp != null` as the hasTranscript signal. `runTranscribe` awaits the resolved path before flipping state to `ready`.
- Removed a dead `invoke('file_exists', ...)` that was hitting a non-existent IPC and silently catching to `exists = false`.

## Test plan
- [x] `cargo test --lib` — 564 pass.
- [ ] Manual: record a meeting; after the transcript finishes, click Generate notes → participant modal → reconcile runs end to end.
- [ ] Manual: navigate to a previously-transcribed note from Home → Generate CTA appears (was hidden by the broken `endsWith` guard).
- [ ] Manual: navigate to a note with no transcript → CTA stays hidden, no errors.