### PR TITLE
Rework the meeting summary prompt toward topic-based notes

### DIFF
--- a/src-tauri/src/reconcile.rs
+++ b/src-tauri/src/reconcile.rs
@@ -24,21 +24,26 @@ const EFFORT: &str = "medium";
 const SYSTEM_PROMPT: &str = "You are reconciling a user's hand-written meeting notes with a transcript of \
 the same meeting. The user's notes capture what they personally found important; \
 the transcript captures everything that was said. Produce a single Markdown \
-document that combines them.
+document of clear, human meeting notes that combines them — the kind of write-up \
+a thoughtful attendee leaves so a colleague who missed the meeting can grasp \
+what happened.
 
 ## Required output structure
 
-Use these exact `##` headings, in order, then a `---` divider, then preserve \
-the raw inputs:
+Emit a `# {title}` line, then a `## Summary`, then one `##` section per topic \
+discussed, then a `---` divider, then preserve the raw hand-notes:
 
 ```
 # {title}
 
 ## Summary
-2-4 sentences. Plain prose.
+2-4 sentences of plain prose. The at-a-glance overview of what the meeting was about and the gist of what happened.
 
-## Key decisions
-- Bullet list. Decisive verbs. _None._ if nothing decided.
+## {Topic}
+Notes on this topic the way a person would take them: what came up, the points that mattered, where it landed, and any next steps — woven into the prose, not split out.
+
+## {Another topic}
+...
 
 ---
 
@@ -46,10 +51,30 @@ the raw inputs:
 {verbatim user hand-notes — preserve formatting, headings, lists}
 ```
 
-The two reconciled sections at the top are *your* synthesis. The `## Notes` \
-block below the divider is reference material — preserve it verbatim. The raw \
-transcript is stored separately by the app; **do not** include a `## Transcript` \
-section, the transcript text, or any verbatim quotes longer than a phrase.
+The `## Summary` and the topic sections at the top are *your* synthesis. The \
+`## Notes` block below the divider is reference material — preserve it verbatim. \
+The raw transcript is stored separately by the app; **do not** include a \
+`## Transcript` section, the transcript text, or any verbatim quotes longer than \
+a phrase.
+
+## How to organize the notes
+
+- **Organize by topic.** Group the meeting into the handful of real topics or \
+threads that came up and give each a short, descriptive `##` heading drawn from \
+the content (e.g. `API contract`, `Hiring`, `Q3 roadmap`). One section per \
+distinct topic; don't force a fixed set of sections, and don't invent topics \
+that weren't discussed.
+- **Write like a human taking notes.** Capture the substance and flow of each \
+topic — the context, the points that mattered, and where it landed. Short prose \
+or bullets, whichever reads clearest.
+- **Weave decisions and to-dos inline.** When something was decided or someone \
+picked up a next step, note it right inside the topic it belongs to, phrased \
+naturally ('Decided on cursor pagination'; 'Sarah will take the SDK pass once \
+the spec is up'). Do NOT collect them into dedicated 'Decisions', 'Action \
+items', 'Next steps', 'To-dos', or 'Open questions' sections — the reader should \
+grasp what happened from the topic notes, not from a checklist.
+- **Don't manufacture to-dos or questions.** Only record a next step or open \
+thread if it genuinely came up, and keep it inline where it belongs.
 
 ## Reconciliation rules
 
@@ -61,11 +86,11 @@ exact decisions, deadlines, technical specifics.
 - **Preserve the user's notes verbatim** under `## Notes` — do not edit, \
 reformat, or 'improve' them. They go in as-is.
 - **Do NOT echo the transcript** into the document. The user has it stored \
-separately and can view it on demand. Distill it into the two reconciled \
+separately and can view it on demand. Distill it into the summary and topic \
 sections; never paste it.
-- **If the user's notes are empty**, produce the two sections from the \
-transcript alone. Skip the `## Notes` section content but keep the heading and \
-write `_(no hand-notes were taken)_`.
+- **If the user's notes are empty**, produce the summary and topic notes from \
+the transcript alone. Skip the `## Notes` section content but keep the heading \
+and write `_(no hand-notes were taken)_`.
 - **If the transcript is empty or unintelligible**, lean entirely on the \
 user's notes.
 - **First H1 line**: emit a `# {title}` line at the very top. Use the title \
@@ -74,18 +99,18 @@ provided in the user message; if none, infer one from the content.
 ## Style guidelines
 
 - **Summary**: 2-4 sentences of plain prose, third person, declarative. \
-Capture the meeting's purpose and outcome. Skip filler.
-- **Key decisions**: a bullet list of decisions actually reached (something \
-committed to or rejected, not merely discussed). Decisive verbs (chose, will, \
-approved, rejected, deferred). One short sentence each.
+Capture the meeting's purpose and the gist of what happened. Skip filler.
+- **Topics**: short, descriptive headings; the notes under each should be \
+concrete and self-contained. Fold any decisions, conclusions, and next steps \
+into the prose of the topic they belong to, rather than into separate sections.
 - **Names**: preserve as written in the user's notes; check the transcript \
 when the user wrote initials or partial names. If unclear, omit owner rather \
 than guess.
 - **Technical jargon, product names, code identifiers**: preserve exactly. Do \
 not translate or paraphrase.
 - **Numbers, dates, deadlines**: include verbatim when stated.
-- **Length**: prefer compact. Three concrete bullets beat ten vague ones. The \
-reader is busy.
+- **Length**: prefer compact. A few clear topic sections beat an exhaustive \
+replay of the transcript. The reader is busy.
 
 ## Examples
 
@@ -118,15 +143,20 @@ once the spec is up. Tom: Wednesday for the spec.
 
 ## Summary
 
-The team locked in cursor-based pagination for v2 of the API and assigned the \
-spec and SDK passes. Charlie acknowledged a recurring build break caused by a \
-forgotten version bump. The contract must be finalized by Friday to unblock \
-SDK work.
+A quick sprint review covering a recurring build break and the v2 API contract. \
+The main thread was the API: v2 will use cursor-based pagination, and the \
+contract has to be locked by Friday to unblock the SDK team.
 
-## Key decisions
+## Build stability
 
-- v2 API will use cursor-based pagination (not offset).
-- API contract must be locked by Friday.
+The build pipeline went red twice this week. Charlie traced it to a forgotten \
+version-constant bump and is owning the fix so it doesn't recur.
+
+## v2 API contract
+
+Settled on cursor-based pagination (not offset) for v2. The contract needs to be \
+locked by Friday so the SDK team can start — Tom is aiming to have the spec up \
+by Wednesday, and Sarah will take the SDK pass once it's ready.
 
 ---
 
@@ -152,14 +182,20 @@ Sprint review
 
 ## Summary
 
-A solo brainstorm exploring why ~40% of post-signup users churn before \
-returning. Working hypothesis: the empty workspace is too sparse to drive \
-activation. Proposed fix is auto-creating a sample project on first login, \
-pending data validation and product-philosophy review.
+A solo brainstorm on why roughly 40% of post-signup users churn before \
+returning. The working hypothesis is that the empty workspace is too sparse to \
+drive activation.
 
-## Key decisions
+## Why new users churn
 
-_None._
+About 40% of users don't come back after signing up. The leading explanation is \
+that a blank workspace gives them nothing to engage with on day one.
+
+## Proposed fix
+
+Auto-creating a sample project on first login so the workspace isn't empty out \
+of the gate. Still needs data validation and a product-philosophy gut-check \
+before it's worth committing to.
 
 ---
 
@@ -170,11 +206,13 @@ _(no hand-notes were taken)_
 
 ## Final reminder
 
-Produce the entire output: `# {title}` line, then two `##` reconciled \
-sections, then `---`, then `## Notes` with the user's notes verbatim (or the \
-empty-notes placeholder). Stop there. Never emit a `## Transcript` section \
-and never paste the transcript text into the document. No preamble, no code \
-fences around the whole document, no commentary.";
+Produce the entire output: the `# {title}` line, a `## Summary`, one `##` \
+section per topic, then `---`, then `## Notes` with the user's notes verbatim \
+(or the empty-notes placeholder). Fold decisions and to-dos into the topic they \
+belong to — never emit dedicated `Decisions`, `Action items`, `Next steps`, or \
+`Open questions` sections. Never emit a `## Transcript` section and never paste \
+the transcript text into the document. No preamble, no code fences around the \
+whole document, no commentary.";
 
 /// Third cached system block (#48). Defines how the model should weigh the
 /// per-meeting `## Attendees` section in the user message and the


### PR DESCRIPTION
## What
Reframes the reconcile (meeting) prompt away from the rigid `## Summary` + `## Key decisions` structure toward clear, human meeting notes organized by the topics actually discussed — a graspable overview of what happened, with no dedicated action-item/follow-up sections.

## Changes (all in `reconcile.rs` `SYSTEM_PROMPT`)
- Keep `## Summary` as a 2–4 sentence at-a-glance overview.
- Replace the fixed `## Key decisions` section with one `##` section per topic, written the way an attendee would take notes (new "How to organize the notes" guidance).
- Fold decisions and to-dos inline into the topic they belong to; explicitly forbid dedicated `Decisions` / `Action items` / `Next steps` / `To-dos` / `Open questions` sections. To-dos are still captured — just not as a checklist — and the model is told not to manufacture them.
- Rewrite both worked examples to demonstrate the topic-based output.

## Unchanged
Reconciliation rules (prioritize the user's notes, fill detail from the transcript, preserve hand-notes verbatim, empty-input handling) and the attendee/observations policy blocks. No schema change.

## Verification
`cargo check` clean (12 pre-existing warnings, 0 new); 15 reconcile tests pass.