### PR TITLE
Add a GitHub changelog connector with AI PR insights

### DIFF
--- a/src-tauri/src/ask.rs
+++ b/src-tauri/src/ask.rs
@@ -108,6 +108,7 @@ const TOOL_NAMES: &[&str] = &[
     "read_email",
     "search_similar",
     "read_edges",
+    "search_changelog",
 ];
 /// Per-event-series cap on occurrences returned by `read_event_series`
 /// (#128). A weekly meeting that's been running 3 years has ~150 rows;
@@ -1196,7 +1197,7 @@ fn tool_definitions() -> serde_json::Value {
         },
         {
             "name": "search_similar",
-            "description": "Search the user's content semantically (via the Voyage embedding index, #104). Use this for questions like 'what was I working on around X', 'who said anything about Y last month', 'remind me what we decided about Z' — where keyword search would miss the answer because the user's wording differs from the original. Returns up to `limit` hits across notes, emails, calendar events, and workstreams, ranked by cosine similarity to the query.",
+            "description": "Search the user's content semantically (via the Voyage embedding index, #104). Use this for questions like 'what was I working on around X', 'who said anything about Y last month', 'remind me what we decided about Z' — where keyword search would miss the answer because the user's wording differs from the original. Returns up to `limit` hits across notes, emails, calendar events, workstreams, and GitHub contributions, ranked by cosine similarity to the query.",
             "input_schema": {
                 "type": "object",
                 "properties": {
@@ -1208,9 +1209,9 @@ fn tool_definitions() -> serde_json::Value {
                         "type": "array",
                         "items": {
                             "type": "string",
-                            "enum": ["note","email","event","workstream","teams_message"]
+                            "enum": ["note","email","event","workstream","teams_message","github"]
                         },
-                        "description": "Optional. Restrict results to a subset of entity kinds."
+                        "description": "Optional. Restrict results to a subset of entity kinds. Use \"github\" for the user's own pull requests and commits."
                     },
                     "limit": {
                         "type": "integer",
@@ -1239,6 +1240,30 @@ fn tool_definitions() -> serde_json::Value {
                     }
                 },
                 "required": ["node_kind", "node_id"]
+            }
+        },
+        {
+            "name": "search_changelog",
+            "description": "Search the user's own GitHub pull requests — the changelog built by the GitHub connector (#165). Merged PRs are delivered features; open/closed PRs are work in progress. Use for questions like 'what did I ship this week', 'what features have I delivered', 'what am I working on in repo X'. Returns matching PRs newest-first (by merge time for merged PRs, else creation time). Leave `query` empty to get the most recent activity.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Optional free-text filter matched against PR title, repository name, and body. Empty or omitted returns the most recent PRs."
+                    },
+                    "merged_only": {
+                        "type": "boolean",
+                        "description": "Optional. When true, return only merged PRs (delivered features). Default false."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 50,
+                        "description": "Max PRs to return. Default 15."
+                    }
+                },
+                "required": []
             }
         }
     ])
@@ -1593,6 +1618,11 @@ fn dispatch_tool(
     // loop which is already on a Tokio runtime).
     if name == "search_similar" {
         return dispatch_search_similar(app, input);
+    }
+    // search_changelog — GitHub contributions (#165). Direct DB query,
+    // no `n` index and no embedding round-trip.
+    if name == "search_changelog" {
+        return dispatch_search_changelog(app, input);
     }
 
     let n = match input.get("n").and_then(|v| v.as_u64()) {
@@ -2008,6 +2038,99 @@ fn dispatch_search_similar(app: &AppHandle, input: &serde_json::Value) -> ToolRe
             is_error: true,
         },
     }
+}
+
+/// GitHub changelog search (#165). Direct query against
+/// `github_contributions` — no embedding round-trip, so it works even
+/// before the Voyage index catches up (and with no Voyage key at all).
+fn dispatch_search_changelog(app: &AppHandle, input: &serde_json::Value) -> ToolResult {
+    let query = input
+        .get("query")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let merged_only = input
+        .get("merged_only")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let limit = input
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .map(|n| n.clamp(1, 50) as usize)
+        .unwrap_or(15);
+
+    let conn_state = app.state::<std::sync::Mutex<rusqlite::Connection>>();
+    let c = match conn_state.lock() {
+        Ok(g) => g,
+        Err(e) => {
+            return ToolResult {
+                content: format!("search_changelog: db lock: {e}"),
+                is_error: true,
+            }
+        }
+    };
+    let hits = match crate::connectors::github_contributions::search_contributions(
+        &c,
+        &query,
+        merged_only,
+        limit,
+    ) {
+        Ok(h) => h,
+        Err(e) => {
+            return ToolResult {
+                content: format!("search_changelog failed: {e}"),
+                is_error: true,
+            }
+        }
+    };
+
+    if hits.is_empty() {
+        let qpart = if query.trim().is_empty() {
+            String::new()
+        } else {
+            format!(" matching \"{}\"", query.trim())
+        };
+        return ToolResult {
+            content: format!(
+                "No pull requests{qpart}. The GitHub connector may not be configured (Settings → Connectors) or hasn't synced yet."
+            ),
+            is_error: false,
+        };
+    }
+
+    let mut out = format!("# {} pull request(s)\n\n", hits.len());
+    for (i, h) in hits.iter().enumerate() {
+        let (label, when) = if h.state == "merged" {
+            ("delivered feature (merged PR)", h.merged_at_ms.unwrap_or(h.created_at_ms))
+        } else {
+            ("open/closed PR (in progress)", h.created_at_ms)
+        };
+        let state_note = if h.state != "merged" {
+            format!(" [{}]", h.state)
+        } else {
+            String::new()
+        };
+        out.push_str(&format!(
+            "{idx}. **{title}** — {label}{state_note}\n   {repo} · {date} · {url}\n",
+            idx = i + 1,
+            title = h.title,
+            label = label,
+            state_note = state_note,
+            repo = h.repo,
+            date = fmt_changelog_day(when),
+            url = h.url,
+        ));
+    }
+    ToolResult {
+        content: out,
+        is_error: false,
+    }
+}
+
+fn fmt_changelog_day(ms: i64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp(ms / 1000, 0)
+        .map(|dt| dt.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "unknown date".to_string())
 }
 
 struct EdgeRow {

--- a/src-tauri/src/connectors/commands.rs
+++ b/src-tauri/src/connectors/commands.rs
@@ -436,6 +436,208 @@ pub async fn get_email_body(
     Ok(body)
 }
 
+// ----- GitHub connector (#165) -------------------------------------------
+
+/// Far-future expiry for the stored PAT. GitHub personal access tokens
+/// don't carry an expiry in the token response (classic tokens may never
+/// expire; fine-grained ones expire server-side and simply start
+/// returning 401, which surfaces as `reauth_needed`). We park the
+/// keychain `expires_at_ms` in the year ~3000 so no refresh is attempted.
+const GITHUB_TOKEN_EXPIRY_MS: i64 = 32_503_680_000_000;
+
+/// Connect a GitHub account from a pasted personal access token. Unlike
+/// `start_oauth_connector` there's no browser flow: we validate the
+/// token via `GET /user`, store it in the keychain, write the connector
+/// row, and mark it due so the runner backfills the last 30 days on its
+/// next tick. Re-running with a token for the same account rotates it.
+#[tauri::command]
+pub async fn connect_github(
+    app: AppHandle,
+    token: String,
+    conn: tauri::State<'_, Mutex<Connection>>,
+    registry: tauri::State<'_, Arc<ConnectorRegistry>>,
+) -> Result<String, String> {
+    let token = token.trim().to_string();
+    if token.is_empty() {
+        return Err("Paste a GitHub personal access token first.".to_string());
+    }
+
+    let identity = super::github::validate_token(&token)
+        .await
+        .map_err(|e| match e {
+            super::ConnectorError::ReauthNeeded(_) => {
+                "That token didn't work. Check it has `repo` (or read) scope and hasn't expired."
+                    .to_string()
+            }
+            other => other.to_string(),
+        })?;
+
+    let connector_id = format!("github:{}", identity.login);
+    let display_name = match identity.name.as_deref().map(str::trim) {
+        Some(n) if !n.is_empty() => format!("GitHub ({} · {n})", identity.login),
+        _ => format!("GitHub ({})", identity.login),
+    };
+
+    // Persist the PAT in the keychain — same slot the OAuth connectors
+    // use, so `delete_connector` cleans it up for free.
+    let tokens = crate::keychain::ConnectorTokens {
+        access_token: token,
+        refresh_token: None,
+        expires_at_ms: GITHUB_TOKEN_EXPIRY_MS,
+        scope: String::new(),
+    };
+    crate::keychain::write_connector_tokens(&connector_id, &tokens).map_err(|e| e.to_string())?;
+
+    let now_ms = current_unix_ms();
+    {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        c.execute(
+            "INSERT INTO connectors(id, kind, display_name, enabled, config_json, created_ms, updated_ms) \
+             VALUES (?1, 'github', ?2, 1, '{}', ?3, ?3) \
+             ON CONFLICT(id) DO UPDATE SET \
+                display_name = excluded.display_name, \
+                enabled = 1, \
+                updated_ms = excluded.updated_ms",
+            rusqlite::params![&connector_id, &display_name, now_ms],
+        )
+        .map_err(|e| e.to_string())?;
+        c.execute(
+            "INSERT INTO sync_status(connector_id, next_due_ms) \
+             VALUES (?1, 0) \
+             ON CONFLICT(connector_id) DO UPDATE SET next_due_ms = 0, last_error = NULL",
+            rusqlite::params![&connector_id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        if let Err(e) = registry.rebuild_instances(&app, &c) {
+            eprintln!("[connectors] rebuild after connect_github failed: {e}");
+        }
+    }
+
+    let _ = app.emit(
+        "connector-status",
+        serde_json::json!({
+            "connector_id": connector_id,
+            "state": "added",
+            "message": null,
+        }),
+    );
+
+    Ok(connector_id)
+}
+
+/// True when a GitHub connector is configured. Drives the Settings card
+/// (connect form vs connected state) and the changelog empty state.
+#[tauri::command]
+pub fn has_github_connector(
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<bool, String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    let n: i64 = c
+        .query_row(
+            "SELECT COUNT(*) FROM connectors WHERE kind = 'github'",
+            [],
+            |r| r.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+    Ok(n > 0)
+}
+
+/// Changelog feed query — pull requests only, newest-first.
+#[tauri::command]
+pub fn list_github_contributions(
+    limit: Option<u32>,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<Vec<super::github_contributions::Contribution>, String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    let lim = limit.unwrap_or(300) as usize;
+    super::github_contributions::list_contributions(&c, lim).map_err(|e| e.to_string())
+}
+
+/// AI changelog insight for one PR. Cached after first generation;
+/// `regenerate: true` forces a fresh pass. Generation needs the
+/// Anthropic key (keychain) and calls out to GitHub + Claude, so it's
+/// `async` and lazy (only when the user opens the detail view).
+#[derive(Serialize)]
+pub struct ContributionInsight {
+    pub summary: String,
+    pub highlight: Option<super::github::InsightHighlight>,
+    pub generated_ms: i64,
+    pub cached: bool,
+}
+
+#[tauri::command]
+pub async fn get_contribution_insight(
+    id: String,
+    regenerate: Option<bool>,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<ContributionInsight, String> {
+    let contribution = {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        super::github_contributions::get_contribution(&c, &id).map_err(|e| e.to_string())?
+    }
+    .ok_or_else(|| "contribution not found".to_string())?;
+
+    // Cached path — return the stored insight unless a regen is forced.
+    if !regenerate.unwrap_or(false) {
+        if let Some(gen_ms) = contribution.ai_generated_ms {
+            let highlight = contribution
+                .ai_highlight
+                .as_deref()
+                .and_then(|j| serde_json::from_str::<super::github::InsightHighlight>(j).ok());
+            return Ok(ContributionInsight {
+                summary: contribution.ai_summary.clone().unwrap_or_default(),
+                highlight,
+                generated_ms: gen_ms,
+                cached: true,
+            });
+        }
+    }
+
+    let number = contribution
+        .external_id
+        .rsplit('#')
+        .next()
+        .and_then(|s| s.parse::<u64>().ok())
+        .ok_or_else(|| format!("can't parse PR number from {}", contribution.external_id))?;
+
+    let generated = super::github::generate_pr_insight(
+        &contribution.connector_id,
+        &contribution.repo,
+        number,
+        &contribution.title,
+        contribution.body.as_deref(),
+    )
+    .await?;
+
+    let now_ms = current_unix_ms();
+    let highlight_json = generated
+        .highlight
+        .as_ref()
+        .and_then(|h| serde_json::to_string(h).ok());
+    {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        super::github_contributions::set_ai_insight(
+            &c,
+            &id,
+            &generated.summary,
+            highlight_json.as_deref(),
+            now_ms,
+        )
+        .map_err(|e| e.to_string())?;
+    }
+
+    Ok(ContributionInsight {
+        summary: generated.summary,
+        highlight: generated.highlight,
+        generated_ms: now_ms,
+        cached: false,
+    })
+}
+
 /// Minimal YAML string escape — sufficient for IDs / locations the
 /// connector hands us. If the value contains any special chars
 /// (colon, quotes, newline, leading/trailing whitespace) we wrap it

--- a/src-tauri/src/connectors/github.rs
+++ b/src-tauri/src/connectors/github.rs
@@ -1,0 +1,765 @@
+//! GitHub connector (#165) — polls the authenticated user's
+//! contributions and persists them as a changelog.
+//!
+//! Auth is a Personal Access Token (classic or fine-grained), pasted
+//! once in Settings and stored in the keychain as the connector's
+//! `access_token` (no refresh token, far-future expiry). Unlike the
+//! OAuth providers there's no browser flow — the `connect_github`
+//! command validates the token via `GET /user` and writes the row.
+//!
+//! Each sync re-scans a rolling 30-day window via the Search API:
+//!   - merged & open PRs authored by the user (`type:pr`) — merged PRs
+//!     are "delivered features" in the changelog
+//!   - commits authored by the user (`/search/commits`) — work in
+//!     progress
+//! The window doubles as the 30-day backfill: the very first sync after
+//! connecting covers the last 30 days. Storage is accumulate-only
+//! (see `github_contributions`), so the changelog grows past the window.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::anthropic::{ANTHROPIC_VERSION, DEFAULT_MODEL, ENDPOINT};
+
+use super::github_contributions::{self, Contribution};
+use super::registry::ConnectorRegistry;
+use super::{Connector, ConnectorError, ConnectorRow, SyncCtx, SyncReport};
+
+const KIND: &str = "github";
+const POLL_INTERVAL: Duration = Duration::from_secs(15 * 60);
+/// Rolling lookback window. Also the backfill depth on first sync.
+const WINDOW_DAYS: i64 = 30;
+const SEARCH_PER_PAGE: u32 = 100;
+/// Page cap per query. A personal account rarely exceeds 100
+/// contributions of one type in 30 days; 3 pages (300) is generous
+/// headroom without risking an unbounded crawl.
+const MAX_PAGES: u32 = 3;
+
+const USER_AGENT: &str = "Margin-Connector";
+const API_VERSION: &str = "2022-11-28";
+
+pub struct GitHubConnector {
+    id: String,
+    kind: String,
+    display_name: String,
+}
+
+impl GitHubConnector {
+    pub fn new(row: &ConnectorRow) -> Self {
+        Self {
+            id: row.id.clone(),
+            kind: row.kind.clone(),
+            display_name: row.display_name.clone(),
+        }
+    }
+
+    /// Login portion of the connector_id (`github:<login>`). The Search
+    /// API queries are scoped to this user.
+    fn login(&self) -> &str {
+        self.id.split_once(':').map(|(_, l)| l).unwrap_or(&self.id)
+    }
+
+    fn read_token(&self) -> Result<String, ConnectorError> {
+        match crate::keychain::read_connector_tokens(&self.id) {
+            Ok(Some(t)) => Ok(t.access_token),
+            Ok(None) => Err(ConnectorError::ReauthNeeded(
+                "no GitHub token stored — reconnect in Settings".into(),
+            )),
+            Err(e) => Err(ConnectorError::Other(format!("keychain read: {e}"))),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Connector for GitHubConnector {
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn kind(&self) -> &str {
+        &self.kind
+    }
+    fn display_name(&self) -> &str {
+        &self.display_name
+    }
+    fn poll_interval(&self) -> Duration {
+        POLL_INTERVAL
+    }
+
+    async fn sync(&self, ctx: SyncCtx<'_>) -> Result<SyncReport, ConnectorError> {
+        let token = self.read_token()?;
+        let login = self.login().to_string();
+        let since = ms_to_date(current_unix_ms() - WINDOW_DAYS * 24 * 3600 * 1000);
+
+        let client = build_client()?;
+
+        // Pull requests only — merged PRs are delivered features, open /
+        // closed PRs are work in progress. Commits proved too noisy
+        // (squash-merge commits duplicate their PR; release tags add
+        // chaff), so the changelog is PR-only.
+        let prs = fetch_pull_requests(&client, &token, &login, &since).await?;
+        let contributions: Vec<Contribution> =
+            prs.into_iter().filter_map(|p| map_pr(&self.id, p)).collect();
+
+        let report = {
+            let mut conn = ctx
+                .conn
+                .lock()
+                .map_err(|e| ConnectorError::Other(format!("conn lock: {e}")))?;
+            let r = github_contributions::upsert_contributions(&mut conn, &self.id, &contributions)
+                .map_err(|e| ConnectorError::Other(format!("upsert contributions: {e}")))?;
+            // Drain any commit rows left by the pre-PR-only build.
+            let pruned = github_contributions::prune_non_prs(&conn, &self.id)
+                .map_err(|e| ConnectorError::Other(format!("prune commits: {e}")))?;
+            (r, pruned)
+        };
+
+        Ok(SyncReport {
+            added: report.0.added,
+            updated: report.0.updated,
+            removed: report.1,
+            skipped: 0,
+        })
+    }
+}
+
+pub fn register(registry: &ConnectorRegistry) {
+    registry.register_kind(
+        KIND,
+        Arc::new(|row, _app| Ok(Arc::new(GitHubConnector::new(row)) as Arc<dyn Connector>)),
+    );
+}
+
+// ----- Token validation (for the connect_github command) -----------------
+
+#[derive(Debug, Clone)]
+pub struct GitHubIdentity {
+    pub login: String,
+    pub name: Option<String>,
+}
+
+/// Validate a PAT by calling `GET /user`. Returns the account's login
+/// (used to build `github:<login>`) and display name. Surfaces a
+/// `ReauthNeeded` on 401 so the UI can say "that token didn't work".
+pub async fn validate_token(token: &str) -> Result<GitHubIdentity, ConnectorError> {
+    let client = build_client()?;
+    let resp = client
+        .get("https://api.github.com/user")
+        .bearer_auth(token)
+        .send()
+        .await
+        .map_err(|e| ConnectorError::Network(format!("GET /user: {e}")))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let retry_after = parse_retry_after(resp.headers());
+        let rl_reset = parse_rate_limit_reset(resp.headers());
+        let body = resp.text().await.unwrap_or_default();
+        return Err(map_status(status, retry_after, rl_reset, body));
+    }
+    let user: RawUser = resp
+        .json()
+        .await
+        .map_err(|e| ConnectorError::Other(format!("/user parse: {e}")))?;
+    Ok(GitHubIdentity {
+        login: user.login,
+        name: user.name,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct RawUser {
+    login: String,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+// ----- Search API clients -------------------------------------------------
+
+fn build_client() -> Result<reqwest::Client, ConnectorError> {
+    reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(|e| ConnectorError::Network(format!("client init: {e}")))
+}
+
+async fn fetch_pull_requests(
+    client: &reqwest::Client,
+    token: &str,
+    login: &str,
+    since: &str,
+) -> Result<Vec<RawIssue>, ConnectorError> {
+    let q = format!("author:{login} type:pr updated:>={since}");
+    let mut all = Vec::new();
+    for page in 1..=MAX_PAGES {
+        let resp = client
+            .get("https://api.github.com/search/issues")
+            .bearer_auth(token)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", API_VERSION)
+            .query(&[
+                ("q", q.as_str()),
+                ("sort", "updated"),
+                ("order", "desc"),
+                ("per_page", &SEARCH_PER_PAGE.to_string()),
+                ("page", &page.to_string()),
+            ])
+            .send()
+            .await
+            .map_err(|e| ConnectorError::Network(format!("search/issues: {e}")))?;
+        let status = resp.status();
+        if !status.is_success() {
+            let retry_after = parse_retry_after(resp.headers());
+            let rl_reset = parse_rate_limit_reset(resp.headers());
+            let body = resp.text().await.unwrap_or_default();
+            return Err(map_status(status, retry_after, rl_reset, body));
+        }
+        let page_data: IssueSearch = resp
+            .json()
+            .await
+            .map_err(|e| ConnectorError::Other(format!("search/issues parse: {e}")))?;
+        let n = page_data.items.len();
+        all.extend(page_data.items);
+        if n < SEARCH_PER_PAGE as usize {
+            break;
+        }
+    }
+    Ok(all)
+}
+
+// ----- Raw response shapes ------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct IssueSearch {
+    #[serde(default)]
+    items: Vec<RawIssue>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawIssue {
+    number: i64,
+    title: String,
+    html_url: String,
+    state: String,
+    #[serde(default)]
+    body: Option<String>,
+    created_at: String,
+    updated_at: String,
+    repository_url: String,
+    #[serde(default)]
+    user: Option<RawAuthor>,
+    #[serde(default)]
+    pull_request: Option<RawPrInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPrInfo {
+    #[serde(default)]
+    merged_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawAuthor {
+    #[serde(default)]
+    login: Option<String>,
+    #[serde(default)]
+    avatar_url: Option<String>,
+}
+
+// ----- Mapping ------------------------------------------------------------
+
+fn map_pr(connector_id: &str, raw: RawIssue) -> Option<Contribution> {
+    let repo = repo_from_url(&raw.repository_url);
+    let merged_at_ms = raw
+        .pull_request
+        .as_ref()
+        .and_then(|p| p.merged_at.as_deref())
+        .and_then(iso_to_ms);
+    let state = if merged_at_ms.is_some() {
+        "merged".to_string()
+    } else {
+        // search/issues `state` is open|closed for the issue side of a PR.
+        raw.state.clone()
+    };
+    let external_id = format!("pr:{repo}#{}", raw.number);
+    let created_at_ms = iso_to_ms(&raw.created_at).unwrap_or_else(current_unix_ms);
+    let modified_ms = iso_to_ms(&raw.updated_at).unwrap_or(created_at_ms);
+    let (author_login, author_avatar_url) = match raw.user {
+        Some(u) => (u.login.unwrap_or_default(), u.avatar_url),
+        None => (String::new(), None),
+    };
+    Some(Contribution {
+        id: format!("{connector_id}::{external_id}"),
+        connector_id: connector_id.to_string(),
+        external_id,
+        kind: "pr".to_string(),
+        state,
+        title: first_line(&raw.title),
+        body: raw.body.filter(|b| !b.trim().is_empty()),
+        repo,
+        url: raw.html_url,
+        author_login,
+        author_avatar_url,
+        created_at_ms,
+        merged_at_ms,
+        modified_ms,
+        ai_summary: None,
+        ai_highlight: None,
+        ai_generated_ms: None,
+    })
+}
+
+/// `https://api.github.com/repos/owner/name` → `owner/name`.
+fn repo_from_url(url: &str) -> String {
+    url.split("/repos/")
+        .nth(1)
+        .map(|s| s.trim_end_matches('/').to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// First non-empty line, trimmed. Commit messages are subject + body;
+/// the changelog title is the subject only.
+fn first_line(s: &str) -> String {
+    let line = s.lines().find(|l| !l.trim().is_empty()).unwrap_or("");
+    let t = line.trim();
+    if t.is_empty() {
+        "(no title)".to_string()
+    } else {
+        t.to_string()
+    }
+}
+
+// ----- HTTP error mapping -------------------------------------------------
+
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+    headers
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(|secs| secs * 1000)
+}
+
+/// Epoch-seconds value of `X-RateLimit-Reset`, when present.
+fn parse_rate_limit_reset(headers: &reqwest::header::HeaderMap) -> Option<i64> {
+    headers
+        .get("x-ratelimit-reset")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<i64>().ok())
+}
+
+fn rate_limit_exhausted(headers: &reqwest::header::HeaderMap) -> bool {
+    headers
+        .get("x-ratelimit-remaining")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim() == "0")
+        .unwrap_or(false)
+}
+
+fn map_status(
+    status: reqwest::StatusCode,
+    retry_after_ms: Option<u64>,
+    rate_limit_reset_secs: Option<i64>,
+    body: String,
+) -> ConnectorError {
+    match status.as_u16() {
+        401 => ConnectorError::ReauthNeeded(format!("github 401 (bad token): {body}")),
+        403 | 429 => {
+            // 403 covers both primary rate limits (reset header) and
+            // secondary limits (Retry-After). 429 is the newer secondary
+            // signal. Compute a wait from whichever the response carries.
+            if let Some(ms) = retry_after_ms {
+                ConnectorError::RateLimited { retry_after_ms: ms }
+            } else if let Some(reset) = rate_limit_reset_secs {
+                let wait = (reset * 1000 - current_unix_ms()).max(1_000) as u64;
+                ConnectorError::RateLimited { retry_after_ms: wait }
+            } else if status.as_u16() == 403 {
+                // 403 without rate-limit headers → token lacks a scope.
+                ConnectorError::ReauthNeeded(format!("github 403 (forbidden): {body}"))
+            } else {
+                ConnectorError::RateLimited { retry_after_ms: 60_000 }
+            }
+        }
+        _ => ConnectorError::Other(format!("github {status}: {body}")),
+    }
+}
+
+// ----- Changelog insight (#165 follow-up) ---------------------------------
+
+/// A blog/LinkedIn-worthy angle on a PR. `None` at the call site means
+/// nothing cleared the bar.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InsightHighlight {
+    pub angle: String,
+    pub content: String,
+}
+
+/// What the model returns for one PR: a plain summary plus an optional
+/// high-bar highlight.
+#[derive(Debug, Clone, Serialize)]
+pub struct GeneratedInsight {
+    pub summary: String,
+    pub highlight: Option<InsightHighlight>,
+}
+
+const INSIGHT_SYSTEM_PROMPT: &str = "You write a personal changelog entry for the author of a merged GitHub pull request.
+
+You are given the PR title, description, and changed-file list. Produce STRICT JSON, no prose, no markdown fences:
+{\"summary\": \"...\", \"highlight\": null | {\"angle\": \"...\", \"content\": \"...\"}}
+
+summary: 1-3 sentences, plain language, describing what was implemented or changed and its architectural or user-facing effect. Past tense, factual, no hype or marketing adjectives. Don't just restate the title.
+
+highlight: an OPTIONAL angle for a short blog or LinkedIn post. Apply a HIGH bar. Return null unless the PR contains a genuinely interesting technical detail, a non-obvious design decision or tradeoff, a debugging war story, a clever solution, or a transferable learning other engineers would find worth reading. Routine work — version bumps, dependency updates, copy/UI tweaks, straightforward CRUD, small refactors, config or test-only changes — must return null. Do NOT invent or embellish; use only the provided material. When in doubt, return null.
+  angle: a crisp hook/headline for the post (max ~12 words).
+  content: 2-4 sentences on the insight and why it's worth sharing.";
+
+const INSIGHT_BODY_CAP: usize = 6000;
+const INSIGHT_MAX_FILES: usize = 60;
+
+/// Generate (and return) an AI insight for one merged/open PR. Fetches
+/// the PR's changed-file list for extra context (best-effort), then asks
+/// Claude for a summary + optional high-bar highlight. Errors propagate
+/// as strings for the command layer to surface.
+pub async fn generate_pr_insight(
+    connector_id: &str,
+    repo: &str,
+    number: u64,
+    title: &str,
+    body: Option<&str>,
+) -> Result<GeneratedInsight, String> {
+    let api_key = crate::keychain::read_anthropic_api_key()
+        .map_err(|e| format!("Anthropic API key not configured: {e}"))?;
+
+    // Best-effort changed-file context — a missing/forbidden token just
+    // means a body-only prompt, still useful.
+    let files = match crate::keychain::read_connector_tokens(connector_id) {
+        Ok(Some(t)) => {
+            let client = build_client().map_err(|e| e.to_string())?;
+            fetch_pr_files(&client, &t.access_token, repo, number)
+                .await
+                .unwrap_or_default()
+        }
+        _ => Vec::new(),
+    };
+
+    let user_prompt = build_insight_prompt(repo, title, body, &files);
+    call_anthropic_insight(&api_key, &user_prompt).await
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPrFile {
+    filename: String,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    additions: i64,
+    #[serde(default)]
+    deletions: i64,
+}
+
+async fn fetch_pr_files(
+    client: &reqwest::Client,
+    token: &str,
+    repo: &str,
+    number: u64,
+) -> Result<Vec<RawPrFile>, ConnectorError> {
+    let url = format!("https://api.github.com/repos/{repo}/pulls/{number}/files");
+    let resp = client
+        .get(&url)
+        .bearer_auth(token)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", API_VERSION)
+        .query(&[("per_page", "100")])
+        .send()
+        .await
+        .map_err(|e| ConnectorError::Network(format!("pulls/files: {e}")))?;
+    if !resp.status().is_success() {
+        return Ok(Vec::new());
+    }
+    resp.json::<Vec<RawPrFile>>()
+        .await
+        .map_err(|e| ConnectorError::Other(format!("pulls/files parse: {e}")))
+}
+
+fn build_insight_prompt(
+    repo: &str,
+    title: &str,
+    body: Option<&str>,
+    files: &[RawPrFile],
+) -> String {
+    let mut s = String::new();
+    s.push_str(&format!("Repository: {repo}\nPull request: {title}\n\n"));
+    if let Some(b) = body {
+        let b = b.trim();
+        if !b.is_empty() {
+            let capped: String = b.chars().take(INSIGHT_BODY_CAP).collect();
+            s.push_str("Description:\n");
+            s.push_str(&capped);
+            s.push_str("\n\n");
+        }
+    }
+    if !files.is_empty() {
+        s.push_str(&format!("Changed files ({}):\n", files.len()));
+        for f in files.iter().take(INSIGHT_MAX_FILES) {
+            s.push_str(&format!(
+                "- {} ({}, +{}/-{})\n",
+                f.filename,
+                f.status.as_deref().unwrap_or("modified"),
+                f.additions,
+                f.deletions
+            ));
+        }
+    }
+    s
+}
+
+#[derive(Serialize)]
+struct InsightApiRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    stream: bool,
+    system: &'a str,
+    messages: Vec<InsightApiMessage<'a>>,
+}
+
+#[derive(Serialize)]
+struct InsightApiMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+async fn call_anthropic_insight(
+    api_key: &str,
+    user_prompt: &str,
+) -> Result<GeneratedInsight, String> {
+    let body = InsightApiRequest {
+        model: DEFAULT_MODEL,
+        max_tokens: 700,
+        stream: false,
+        system: INSIGHT_SYSTEM_PROMPT,
+        messages: vec![InsightApiMessage {
+            role: "user",
+            content: user_prompt,
+        }],
+    };
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(45))
+        .build()
+        .map_err(|e| format!("client init: {e}"))?;
+    let resp = client
+        .post(ENDPOINT)
+        .header("x-api-key", api_key)
+        .header("anthropic-version", ANTHROPIC_VERSION)
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("network: {e}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let raw = resp.text().await.unwrap_or_default();
+        return Err(format!("anthropic returned {status}: {raw}"));
+    }
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("anthropic response parse: {e}"))?;
+    let text = json
+        .get("content")
+        .and_then(|c| c.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .unwrap_or_default();
+    if text.is_empty() {
+        return Err("empty response text".into());
+    }
+    parse_insight(&text)
+}
+
+#[derive(Deserialize)]
+struct RawInsight {
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    highlight: Option<RawHighlight>,
+}
+
+#[derive(Deserialize)]
+struct RawHighlight {
+    #[serde(default)]
+    angle: Option<String>,
+    #[serde(default)]
+    content: Option<String>,
+}
+
+/// Parse the model's JSON, tolerating optional ```json fences. A
+/// highlight missing either field collapses to None (below bar).
+fn parse_insight(raw: &str) -> Result<GeneratedInsight, String> {
+    let stripped = strip_json_fences(raw);
+    let parsed: RawInsight =
+        serde_json::from_str(&stripped).map_err(|e| format!("insight parse: {e}"))?;
+    let summary = parsed
+        .summary
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "missing summary".to_string())?
+        .to_string();
+    let highlight = parsed.highlight.and_then(|h| {
+        let angle = h.angle.as_deref().map(str::trim).filter(|s| !s.is_empty())?;
+        let content = h.content.as_deref().map(str::trim).filter(|s| !s.is_empty())?;
+        Some(InsightHighlight {
+            angle: angle.to_string(),
+            content: content.to_string(),
+        })
+    });
+    Ok(GeneratedInsight { summary, highlight })
+}
+
+fn strip_json_fences(s: &str) -> String {
+    let trimmed = s.trim();
+    let without_open = trimmed
+        .strip_prefix("```json")
+        .or_else(|| trimmed.strip_prefix("```"))
+        .unwrap_or(trimmed)
+        .trim_start();
+    without_open
+        .strip_suffix("```")
+        .unwrap_or(without_open)
+        .trim()
+        .to_string()
+}
+
+// ----- Time helpers -------------------------------------------------------
+
+fn iso_to_ms(s: &str) -> Option<i64> {
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc).timestamp_millis())
+}
+
+fn ms_to_date(ms: i64) -> String {
+    DateTime::<Utc>::from_timestamp(ms / 1000, 0)
+        .map(|dt| dt.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "1970-01-01".to_string())
+}
+
+fn current_unix_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+// ----- Tests --------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repo_from_url_parses_owner_name() {
+        assert_eq!(
+            repo_from_url("https://api.github.com/repos/octocat/hello-world"),
+            "octocat/hello-world"
+        );
+        assert_eq!(repo_from_url("garbage"), "unknown");
+    }
+
+    #[test]
+    fn first_line_takes_subject_only() {
+        assert_eq!(first_line("Fix the bug\n\nLong body here"), "Fix the bug");
+        assert_eq!(first_line("   \nSecond line"), "Second line");
+        assert_eq!(first_line(""), "(no title)");
+    }
+
+    #[test]
+    fn map_pr_marks_merged() {
+        let raw = RawIssue {
+            number: 42,
+            title: "Add feature".into(),
+            html_url: "https://github.com/o/r/pull/42".into(),
+            state: "closed".into(),
+            body: Some("desc".into()),
+            created_at: "2026-06-01T10:00:00Z".into(),
+            updated_at: "2026-06-02T10:00:00Z".into(),
+            repository_url: "https://api.github.com/repos/o/r".into(),
+            user: Some(RawAuthor {
+                login: Some("octocat".into()),
+                avatar_url: Some("https://avatars/x.png".into()),
+            }),
+            pull_request: Some(RawPrInfo {
+                merged_at: Some("2026-06-02T09:00:00Z".into()),
+            }),
+        };
+        let c = map_pr("github:octocat", raw).unwrap();
+        assert_eq!(c.kind, "pr");
+        assert_eq!(c.state, "merged");
+        assert_eq!(c.external_id, "pr:o/r#42");
+        assert_eq!(c.repo, "o/r");
+        assert!(c.merged_at_ms.is_some());
+        assert_eq!(c.author_login, "octocat");
+    }
+
+    #[test]
+    fn map_pr_open_keeps_state() {
+        let raw = RawIssue {
+            number: 7,
+            title: "WIP".into(),
+            html_url: "https://github.com/o/r/pull/7".into(),
+            state: "open".into(),
+            body: None,
+            created_at: "2026-06-01T10:00:00Z".into(),
+            updated_at: "2026-06-01T10:00:00Z".into(),
+            repository_url: "https://api.github.com/repos/o/r".into(),
+            user: None,
+            pull_request: Some(RawPrInfo { merged_at: None }),
+        };
+        let c = map_pr("github:octocat", raw).unwrap();
+        assert_eq!(c.state, "open");
+        assert!(c.merged_at_ms.is_none());
+    }
+
+    #[test]
+    fn parse_insight_with_highlight() {
+        let raw = r#"{"summary":"Did X.","highlight":{"angle":"Y","content":"Z because reasons."}}"#;
+        let g = parse_insight(raw).unwrap();
+        assert_eq!(g.summary, "Did X.");
+        let h = g.highlight.unwrap();
+        assert_eq!(h.angle, "Y");
+    }
+
+    #[test]
+    fn parse_insight_null_highlight_below_bar() {
+        let raw = "```json\n{\"summary\":\"Bumped a dep.\",\"highlight\":null}\n```";
+        let g = parse_insight(raw).unwrap();
+        assert_eq!(g.summary, "Bumped a dep.");
+        assert!(g.highlight.is_none());
+    }
+
+    #[test]
+    fn parse_insight_partial_highlight_collapses_to_none() {
+        let raw = r#"{"summary":"S","highlight":{"angle":"only angle"}}"#;
+        let g = parse_insight(raw).unwrap();
+        assert!(g.highlight.is_none());
+    }
+
+    #[test]
+    fn parse_insight_requires_summary() {
+        assert!(parse_insight(r#"{"highlight":null}"#).is_err());
+    }
+
+    #[test]
+    fn ms_to_date_formats_day() {
+        // 2026-06-14 ~ 1781740800 s. Just assert shape.
+        let d = ms_to_date(1_781_740_800_000);
+        assert_eq!(d.len(), 10);
+        assert_eq!(&d[4..5], "-");
+    }
+}

--- a/src-tauri/src/connectors/github_contributions.rs
+++ b/src-tauri/src/connectors/github_contributions.rs
@@ -1,0 +1,409 @@
+//! Provider-agnostic storage layer for GitHub contributions (#165).
+//!
+//! The `github` connector maps Search-API JSON into `Contribution` and
+//! calls `upsert_contributions` to persist into `github_contributions`.
+//! The changelog UI (`list_contributions`) and the AI `search_changelog`
+//! tool (`search_contributions`) read back through this module without
+//! caring how the data arrived — the `connector_id` foreign key carries
+//! that.
+//!
+//! Accumulate-only: re-syncing a rolling window never deletes rows that
+//! aged out, so the changelog is a growing historical record. The only
+//! mutation on re-sync is an in-place UPDATE (a PR flipping open→merged).
+
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::Serialize;
+
+/// One contribution row. `kind` is `"pr"` or `"commit"`; `state` is
+/// `"merged"` / `"open"` / `"closed"` (PRs) or `"committed"` (commits).
+#[derive(Debug, Clone, Serialize)]
+pub struct Contribution {
+    pub id: String,
+    pub connector_id: String,
+    pub external_id: String,
+    pub kind: String,
+    pub state: String,
+    pub title: String,
+    pub body: Option<String>,
+    pub repo: String,
+    pub url: String,
+    pub author_login: String,
+    pub author_avatar_url: Option<String>,
+    pub created_at_ms: i64,
+    pub merged_at_ms: Option<i64>,
+    pub modified_ms: i64,
+    /// AI changelog insight (#165 follow-up), generated lazily on first
+    /// detail-view open. `ai_summary` is a plain "what was implemented";
+    /// `ai_highlight` is JSON {"angle","content"} when a high-bar
+    /// blog/LinkedIn angle exists, else NULL. `ai_generated_ms` NULL
+    /// means not generated yet.
+    pub ai_summary: Option<String>,
+    pub ai_highlight: Option<String>,
+    pub ai_generated_ms: Option<i64>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct UpsertReport {
+    pub added: u64,
+    pub updated: u64,
+}
+
+/// Upsert a batch of contributions for `connector_id`. Accumulate-only
+/// (no orphan deletion). Emits a `github_contribution` event the first
+/// time each contribution is seen so the activity stream / profile
+/// worker pick it up. Runs in a single transaction.
+pub fn upsert_contributions(
+    conn: &mut Connection,
+    connector_id: &str,
+    items: &[Contribution],
+) -> rusqlite::Result<UpsertReport> {
+    let tx = conn.transaction()?;
+
+    // Self team member id for event attribution — these are the user's
+    // own contributions, so actor is always self. NULL when there's no
+    // `is_self` row yet.
+    let self_id: Option<String> = tx
+        .query_row(
+            "SELECT id FROM team_members WHERE is_self = 1 LIMIT 1",
+            [],
+            |r| r.get(0),
+        )
+        .ok();
+
+    let mut report = UpsertReport::default();
+    for c in items {
+        let pre_existed: bool = tx
+            .query_row(
+                "SELECT 1 FROM github_contributions WHERE id = ?1",
+                params![c.id],
+                |r| r.get::<_, i64>(0),
+            )
+            .ok()
+            .is_some();
+
+        tx.execute(
+            "INSERT INTO github_contributions(\
+                id, connector_id, external_id, kind, state, title, body, repo, url, \
+                author_login, author_avatar_url, created_at_ms, merged_at_ms, modified_ms\
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14) \
+             ON CONFLICT(id) DO UPDATE SET \
+                state = excluded.state, \
+                title = excluded.title, \
+                body = excluded.body, \
+                repo = excluded.repo, \
+                url = excluded.url, \
+                author_login = excluded.author_login, \
+                author_avatar_url = excluded.author_avatar_url, \
+                created_at_ms = excluded.created_at_ms, \
+                merged_at_ms = excluded.merged_at_ms, \
+                modified_ms = excluded.modified_ms",
+            params![
+                c.id,
+                c.connector_id,
+                c.external_id,
+                c.kind,
+                c.state,
+                c.title,
+                c.body,
+                c.repo,
+                c.url,
+                c.author_login,
+                c.author_avatar_url,
+                c.created_at_ms,
+                c.merged_at_ms,
+                c.modified_ms,
+            ],
+        )?;
+
+        if pre_existed {
+            report.updated += 1;
+        } else {
+            let ts = c.merged_at_ms.unwrap_or(c.created_at_ms);
+            let payload = serde_json::json!({
+                "title": c.title,
+                "repo": c.repo,
+                "kind": c.kind,
+                "state": c.state,
+                "url": c.url,
+            });
+            crate::events::emit(
+                &tx,
+                ts,
+                "github_contribution",
+                self_id.as_deref(),
+                "github",
+                &c.id,
+                &payload,
+            )?;
+            report.added += 1;
+        }
+    }
+
+    tx.commit()?;
+    Ok(report)
+}
+
+fn row_to_contribution(r: &rusqlite::Row<'_>) -> rusqlite::Result<Contribution> {
+    Ok(Contribution {
+        id: r.get(0)?,
+        connector_id: r.get(1)?,
+        external_id: r.get(2)?,
+        kind: r.get(3)?,
+        state: r.get(4)?,
+        title: r.get(5)?,
+        body: r.get(6)?,
+        repo: r.get(7)?,
+        url: r.get(8)?,
+        author_login: r.get(9)?,
+        author_avatar_url: r.get(10)?,
+        created_at_ms: r.get(11)?,
+        merged_at_ms: r.get(12)?,
+        modified_ms: r.get(13)?,
+        ai_summary: r.get(14)?,
+        ai_highlight: r.get(15)?,
+        ai_generated_ms: r.get(16)?,
+    })
+}
+
+const SELECT_COLS: &str = "id, connector_id, external_id, kind, state, title, body, repo, url, \
+     author_login, author_avatar_url, created_at_ms, merged_at_ms, modified_ms, \
+     ai_summary, ai_highlight, ai_generated_ms";
+
+/// List pull requests for the changelog feed, newest-first by their
+/// effective timestamp (merge time for merged PRs, else creation time).
+/// Commits are excluded — the changelog is PR-only (#165 follow-up).
+pub fn list_contributions(
+    conn: &Connection,
+    limit: usize,
+) -> rusqlite::Result<Vec<Contribution>> {
+    let sql = format!(
+        "SELECT {SELECT_COLS} FROM github_contributions WHERE kind = 'pr' \
+         ORDER BY COALESCE(merged_at_ms, created_at_ms) DESC LIMIT ?1"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params![limit as i64], row_to_contribution)?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// One contribution by id (for the detail view / insight command).
+pub fn get_contribution(conn: &Connection, id: &str) -> rusqlite::Result<Option<Contribution>> {
+    let sql = format!("SELECT {SELECT_COLS} FROM github_contributions WHERE id = ?1");
+    conn.query_row(&sql, params![id], row_to_contribution)
+        .optional()
+}
+
+/// Persist a generated AI insight onto a contribution. `highlight_json`
+/// is the serialized {"angle","content"} or None when nothing cleared
+/// the bar.
+pub fn set_ai_insight(
+    conn: &Connection,
+    id: &str,
+    summary: &str,
+    highlight_json: Option<&str>,
+    now_ms: i64,
+) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE github_contributions \
+         SET ai_summary = ?2, ai_highlight = ?3, ai_generated_ms = ?4 \
+         WHERE id = ?1",
+        params![id, summary, highlight_json, now_ms],
+    )?;
+    Ok(())
+}
+
+/// Delete this connector's non-PR rows. Called each sync so the
+/// historical commit rows from the pre-PR-only build drain away.
+/// Returns the number removed.
+pub fn prune_non_prs(conn: &Connection, connector_id: &str) -> rusqlite::Result<u64> {
+    let n = conn.execute(
+        "DELETE FROM github_contributions WHERE connector_id = ?1 AND kind != 'pr'",
+        params![connector_id],
+    )?;
+    Ok(n as u64)
+}
+
+/// Free-text search over title + repo + body for the AI
+/// `search_changelog` tool. `query` empty → most-recent. PR-only;
+/// `merged_only` narrows to delivered features.
+pub fn search_contributions(
+    conn: &Connection,
+    query: &str,
+    merged_only: bool,
+    limit: usize,
+) -> rusqlite::Result<Vec<Contribution>> {
+    let mut sql = format!("SELECT {SELECT_COLS} FROM github_contributions WHERE kind = 'pr'");
+    if !query.trim().is_empty() {
+        sql.push_str(" AND (title LIKE ?1 OR repo LIKE ?1 OR body LIKE ?1)");
+    }
+    if merged_only {
+        sql.push_str(" AND state = 'merged'");
+    }
+    sql.push_str(" ORDER BY COALESCE(merged_at_ms, created_at_ms) DESC LIMIT ?2");
+
+    let like = format!("%{}%", query.trim().replace('%', "\\%").replace('_', "\\_"));
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params![like, limit as i64], row_to_contribution)?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+/// True when at least one row exists — drives the changelog empty state.
+#[allow(dead_code)]
+pub fn count_contributions(conn: &Connection) -> rusqlite::Result<i64> {
+    conn.query_row("SELECT COUNT(*) FROM github_contributions", [], |r| r.get(0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn open_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::index::apply_migrations(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO connectors(id, kind, display_name, enabled, config_json, created_ms, updated_ms) \
+             VALUES ('github:octocat', 'github', 'GitHub (octocat)', 1, '{}', 0, 0)",
+            [],
+        )
+        .unwrap();
+        // Seed the self team member so event emission's FK holds.
+        conn.execute(
+            "INSERT INTO team_members(id, display_name, role, is_self, created_ms, updated_ms) \
+             VALUES ('me', 'Me', '', 1, 0, 0)",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn mk(id: &str, kind: &str, state: &str, created: i64, merged: Option<i64>) -> Contribution {
+        Contribution {
+            id: format!("github:octocat::{id}"),
+            connector_id: "github:octocat".into(),
+            external_id: id.into(),
+            kind: kind.into(),
+            state: state.into(),
+            title: format!("title {id}"),
+            body: Some("body".into()),
+            repo: "octocat/hello".into(),
+            url: format!("https://github.com/octocat/hello/{id}"),
+            author_login: "octocat".into(),
+            author_avatar_url: None,
+            created_at_ms: created,
+            merged_at_ms: merged,
+            modified_ms: created,
+            ai_summary: None,
+            ai_highlight: None,
+            ai_generated_ms: None,
+        }
+    }
+
+    #[test]
+    fn upsert_counts_added_then_updated() {
+        let mut conn = open_db();
+        let items = vec![
+            mk("pr:octocat/hello#1", "pr", "open", 1_000, None),
+            mk("commit:abc", "commit", "committed", 2_000, None),
+        ];
+        let r1 = upsert_contributions(&mut conn, "github:octocat", &items).unwrap();
+        assert_eq!(r1.added, 2);
+        assert_eq!(r1.updated, 0);
+
+        // Re-sync with the PR now merged — same id, in-place update.
+        let mut merged = items.clone();
+        merged[0].state = "merged".into();
+        merged[0].merged_at_ms = Some(3_000);
+        let r2 = upsert_contributions(&mut conn, "github:octocat", &merged).unwrap();
+        assert_eq!(r2.added, 0);
+        assert_eq!(r2.updated, 2);
+
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM github_contributions WHERE external_id = 'pr:octocat/hello#1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "merged");
+    }
+
+    #[test]
+    fn list_is_pr_only_and_orders_by_effective_timestamp() {
+        let mut conn = open_db();
+        upsert_contributions(
+            &mut conn,
+            "github:octocat",
+            &[
+                mk("commit:a", "commit", "committed", 5_000, None),
+                mk("pr:r#1", "pr", "merged", 1_000, Some(9_000)),
+                mk("pr:r#2", "pr", "open", 7_000, None),
+            ],
+        )
+        .unwrap();
+        let all = list_contributions(&conn, 10).unwrap();
+        // Commits excluded; PR merged at 9_000 sorts ahead of open PR at 7_000.
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[0].external_id, "pr:r#1");
+        assert_eq!(all[1].external_id, "pr:r#2");
+    }
+
+    #[test]
+    fn prune_removes_commits_only() {
+        let mut conn = open_db();
+        upsert_contributions(
+            &mut conn,
+            "github:octocat",
+            &[
+                mk("commit:a", "commit", "committed", 5_000, None),
+                mk("pr:r#1", "pr", "merged", 1_000, Some(9_000)),
+            ],
+        )
+        .unwrap();
+        let removed = prune_non_prs(&conn, "github:octocat").unwrap();
+        assert_eq!(removed, 1);
+        assert_eq!(list_contributions(&conn, 10).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn search_filters_by_query_and_merged() {
+        let mut conn = open_db();
+        upsert_contributions(
+            &mut conn,
+            "github:octocat",
+            &[
+                mk("pr:r#1", "pr", "merged", 1_000, Some(2_000)),
+                mk("pr:r#2", "pr", "open", 1_500, None),
+            ],
+        )
+        .unwrap();
+        let merged = search_contributions(&conn, "title", true, 10).unwrap();
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].external_id, "pr:r#1");
+    }
+
+    #[test]
+    fn set_and_read_ai_insight() {
+        let mut conn = open_db();
+        upsert_contributions(
+            &mut conn,
+            "github:octocat",
+            &[mk("pr:r#1", "pr", "merged", 1_000, Some(2_000))],
+        )
+        .unwrap();
+        let id = "github:octocat::pr:r#1";
+        set_ai_insight(&conn, id, "Did a thing.", Some("{\"angle\":\"a\",\"content\":\"c\"}"), 42)
+            .unwrap();
+        let c = get_contribution(&conn, id).unwrap().unwrap();
+        assert_eq!(c.ai_summary.as_deref(), Some("Did a thing."));
+        assert_eq!(c.ai_generated_ms, Some(42));
+        assert!(c.ai_highlight.unwrap().contains("angle"));
+    }
+}

--- a/src-tauri/src/connectors/mod.rs
+++ b/src-tauri/src/connectors/mod.rs
@@ -28,6 +28,8 @@ use serde::Serialize;
 pub mod calendar;
 pub mod commands;
 pub mod email;
+pub mod github;
+pub mod github_contributions;
 pub mod google;
 pub mod microsoft_graph;
 pub mod oauth;

--- a/src-tauri/src/embeddings/sources.rs
+++ b/src-tauri/src/embeddings/sources.rs
@@ -125,6 +125,20 @@ pub fn preview_for(conn: &Connection, ref_kind: &str, ref_id: &str) -> String {
                 _ => ref_id.to_string(),
             }
         }
+        "github" => {
+            let row: Option<(String, String)> = conn
+                .query_row(
+                    "SELECT repo, title FROM github_contributions WHERE id = ?1",
+                    params![ref_id],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+                .optional()
+                .unwrap_or(None);
+            match row {
+                Some((repo, title)) => format!("{repo}: {title}"),
+                None => ref_id.to_string(),
+            }
+        }
         _ => ref_id.to_string(),
     };
     truncate_chars(&raw, 100)
@@ -289,6 +303,33 @@ pub fn collect_work(conn: &Connection, model: &str) -> rusqlite::Result<Vec<Work
         }
         items.push(WorkItem {
             ref_kind: "workstream".into(),
+            ref_id: id,
+            source_hash: sha256_hex(&text),
+            text,
+        });
+    }
+
+    // ---- github contributions (#165) ----
+    let gh_rows: Vec<(String, String, Option<String>, String)> = {
+        let mut stmt = conn.prepare(
+            "SELECT g.id, g.title, g.body, g.repo FROM github_contributions g \
+             LEFT JOIN embeddings e \
+               ON e.ref_kind = 'github' AND e.ref_id = g.id AND e.model = ?1 \
+             WHERE e.indexed_ms IS NULL OR g.modified_ms > e.indexed_ms",
+        )?;
+        let rows = stmt.query_map(params![model], |r| {
+            Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?))
+        })?;
+        rows.filter_map(|r| r.ok()).collect()
+    };
+    for (id, title, body, repo) in gh_rows {
+        let body = body.unwrap_or_default();
+        let text = truncate_chars(&format!("{repo}: {title}\n{body}"), SOURCE_CHAR_CAP);
+        if text.trim().is_empty() {
+            continue;
+        }
+        items.push(WorkItem {
+            ref_kind: "github".into(),
             ref_id: id,
             source_hash: sha256_hex(&text),
             text,

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -72,7 +72,9 @@ const SCHEMA_V40: &str = include_str!("migrations/040_actions_migration_flag.sql
 const SCHEMA_V41: &str = include_str!("migrations/041_action_deletions.sql");
 const SCHEMA_V42: &str = include_str!("migrations/042_drop_actions.sql");
 const SCHEMA_V43: &str = include_str!("migrations/043_drop_open_questions.sql");
-const SCHEMA_VERSION: i64 = 43;
+const SCHEMA_V44: &str = include_str!("migrations/044_github.sql");
+const SCHEMA_V45: &str = include_str!("migrations/045_github_insight.sql");
+const SCHEMA_VERSION: i64 = 45;
 
 /// Register the sqlite-vec extension as an "auto extension" so every
 /// future `Connection::open*` in this process loads `vec0` (#104).
@@ -337,6 +339,14 @@ pub(crate) fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 42 {
         conn.execute_batch(SCHEMA_V43)?;
         version = 43;
+    }
+    if version == 43 {
+        conn.execute_batch(SCHEMA_V44)?;
+        version = 44;
+    }
+    if version == 44 {
+        conn.execute_batch(SCHEMA_V45)?;
+        version = 45;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -438,6 +438,7 @@ pub fn run() {
             let registry = std::sync::Arc::new(connectors::ConnectorRegistry::new());
             connectors::microsoft_graph::register(&registry);
             connectors::google::register(&registry);
+            connectors::github::register(&registry);
             if let Err(e) = registry.rebuild_instances(app.handle(), &conn) {
                 eprintln!("connector registry rebuild failed at boot: {e}");
             }
@@ -554,6 +555,10 @@ pub fn run() {
             connectors::commands::open_or_create_event_note,
             connectors::commands::list_email_messages,
             connectors::commands::get_email_body,
+            connectors::commands::connect_github,
+            connectors::commands::has_github_connector,
+            connectors::commands::list_github_contributions,
+            connectors::commands::get_contribution_insight,
             workstreams::commands::synthesize_workstreams,
             workstreams::commands::attach_signal_to_workstream,
             workstreams::commands::detach_signal_from_workstream,

--- a/src-tauri/src/migrations/044_github.sql
+++ b/src-tauri/src/migrations/044_github.sql
@@ -1,0 +1,39 @@
+-- GitHub contributions connector (#165).
+--
+-- One row per contribution the user authored, pulled from the GitHub
+-- Search API by the `github` connector:
+--   - kind = 'pr'     → a pull request (state 'merged' = a delivered
+--                        feature; 'open' / 'closed' otherwise)
+--   - kind = 'commit'  → a standalone commit (state 'committed') —
+--                        treated as work-in-progress in the changelog
+--
+-- Accumulate-only, mirroring email (#69): the connector re-scans a
+-- rolling 30-day window each poll and upserts; rows aging out of the
+-- window are NOT deleted so the changelog grows over time. Idempotent
+-- re-syncs key on (connector_id, external_id) — a PR flipping from open
+-- to merged updates the same row.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE github_contributions (
+  id                TEXT PRIMARY KEY,
+  connector_id      TEXT NOT NULL REFERENCES connectors(id) ON DELETE CASCADE,
+  external_id       TEXT NOT NULL,
+  kind              TEXT NOT NULL,            -- 'pr' | 'commit'
+  state             TEXT NOT NULL,            -- 'merged' | 'open' | 'closed' | 'committed'
+  title             TEXT NOT NULL,
+  body              TEXT,
+  repo              TEXT NOT NULL,            -- 'owner/name'
+  url               TEXT NOT NULL,            -- html_url on github.com
+  author_login      TEXT NOT NULL,
+  author_avatar_url TEXT,
+  created_at_ms     INTEGER NOT NULL,         -- PR created_at / commit author date
+  merged_at_ms      INTEGER,                  -- PR merge time; NULL for unmerged + commits
+  modified_ms       INTEGER NOT NULL          -- PR updated_at / commit date; dirty-checks embeddings
+);
+CREATE INDEX idx_ghc_connector ON github_contributions(connector_id);
+CREATE INDEX idx_ghc_kind ON github_contributions(kind);
+CREATE INDEX idx_ghc_created ON github_contributions(created_at_ms DESC);
+CREATE UNIQUE INDEX idx_ghc_extid ON github_contributions(connector_id, external_id);
+
+UPDATE meta SET value = '44' WHERE key = 'schema_version';

--- a/src-tauri/src/migrations/045_github_insight.sql
+++ b/src-tauri/src/migrations/045_github_insight.sql
@@ -1,0 +1,17 @@
+-- AI changelog insight per contribution (#165 follow-up).
+--
+-- Generated lazily when the user opens a PR's detail view: a plain
+-- summary of what was implemented, plus an optional high-bar
+-- "worth writing about" highlight (a technical detail / learning /
+-- story that could anchor a blog or LinkedIn post). `ai_highlight` is
+-- JSON {"angle","content"} when present, NULL when nothing cleared the
+-- bar. `ai_generated_ms` NULL means "not generated yet" (vs generated
+-- with no highlight).
+
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE github_contributions ADD COLUMN ai_summary TEXT;
+ALTER TABLE github_contributions ADD COLUMN ai_highlight TEXT;
+ALTER TABLE github_contributions ADD COLUMN ai_generated_ms INTEGER;
+
+UPDATE meta SET value = '45' WHERE key = 'schema_version';

--- a/src/App.css
+++ b/src/App.css
@@ -7309,3 +7309,423 @@ button.workstream-external-chip:hover {
   font-weight: 600;
 }
 
+/* ---------- GitHub changelog (#165) ---------------------------------- */
+.changelog-view {
+  padding: 22px 32px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.changelog-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.changelog-filters {
+  display: flex;
+  gap: 6px;
+}
+
+.changelog-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 11px;
+  border-radius: 999px;
+  border: 0.5px solid var(--home-line);
+  background: var(--bg);
+  color: var(--fg-muted);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+.changelog-filter:hover {
+  background: var(--home-chip);
+  color: var(--fg);
+}
+.changelog-filter.active {
+  background: var(--home-accent-soft);
+  border-color: var(--home-accent-border);
+  color: var(--accent);
+}
+.changelog-filter-count {
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  opacity: 0.75;
+}
+
+.changelog-sync {
+  padding: 5px 12px;
+  border-radius: 7px;
+  border: 0.5px solid var(--home-line);
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.changelog-sync:hover:not(:disabled) {
+  background: var(--home-card-hover);
+}
+.changelog-sync:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.changelog-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+.changelog-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.changelog-day {
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  padding-left: 2px;
+}
+.changelog-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.changelog-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  text-align: left;
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 0.5px solid var(--home-line);
+  background: var(--home-card);
+  cursor: pointer;
+  transition: background 120ms ease, box-shadow 120ms ease;
+}
+.changelog-row:hover,
+.changelog-row:focus-visible {
+  background: var(--home-card-hover);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--fg) 4%, transparent);
+  outline: none;
+}
+
+.changelog-icon {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: var(--home-chip);
+  color: var(--fg);
+}
+.changelog-icon-pr {
+  color: var(--accent);
+}
+
+.changelog-row-body {
+  flex: 1;
+  min-width: 0;
+}
+.changelog-row-title {
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.changelog-row-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+  font-size: 11.5px;
+  color: var(--fg-muted);
+}
+.changelog-repo {
+  font-family: var(--font-mono, ui-monospace, "JetBrains Mono Variable", monospace);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 340px;
+}
+.changelog-sep {
+  opacity: 0.5;
+}
+
+.changelog-badge {
+  flex-shrink: 0;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  border: 0.5px solid transparent;
+}
+.changelog-badge-delivered {
+  color: #1a7f37;
+  background: color-mix(in srgb, #1a7f37 12%, transparent);
+  border-color: color-mix(in srgb, #1a7f37 30%, transparent);
+}
+[data-theme="dark"] .changelog-badge-delivered {
+  color: #4ac26b;
+}
+.changelog-badge-wip {
+  color: var(--fg-muted);
+  background: var(--home-chip);
+}
+.changelog-badge-open {
+  color: var(--accent);
+  background: var(--home-accent-soft);
+  border-color: var(--home-accent-border);
+}
+.changelog-badge-closed {
+  color: #c44a1f;
+  background: color-mix(in srgb, #c44a1f 12%, transparent);
+}
+
+.changelog-connect-cta {
+  margin-top: 12px;
+  align-self: flex-start;
+  padding: 7px 14px;
+  border-radius: 8px;
+  border: 0.5px solid var(--home-accent-border);
+  background: var(--home-accent-soft);
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.changelog-connect-cta:hover {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+/* GitHub connect card in Settings → Connectors */
+.github-card {
+  margin-top: 14px;
+  padding: 14px;
+  border: 0.5px solid var(--home-line);
+  border-radius: 10px;
+  background: var(--bg);
+}
+.github-card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.github-card-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.github-card-badge {
+  margin-left: auto;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: #1a7f37;
+  background: color-mix(in srgb, #1a7f37 12%, transparent);
+}
+[data-theme="dark"] .github-card-badge {
+  color: #4ac26b;
+}
+.github-card .settings-actions {
+  margin-top: 8px;
+}
+.github-card code {
+  font-family: var(--font-mono, ui-monospace, "JetBrains Mono Variable", monospace);
+  font-size: 11.5px;
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: var(--home-chip);
+}
+
+/* changelog: small "insight ready" marker on a list row */
+.changelog-insight-dot {
+  color: var(--accent);
+  font-size: 10px;
+  margin-left: 2px;
+}
+
+/* ---------- Changelog PR detail view --------------------------------- */
+.changelog-detail {
+  padding: 18px 32px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  max-width: 760px;
+}
+
+.changelog-detail-back {
+  align-self: flex-start;
+  padding: 4px 8px 4px 4px;
+  border: none;
+  background: transparent;
+  color: var(--fg-muted);
+  font-size: 12.5px;
+  cursor: pointer;
+  border-radius: 6px;
+}
+.changelog-detail-back:hover {
+  color: var(--fg);
+  background: var(--home-chip);
+}
+
+.changelog-detail-head {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.changelog-detail-badges {
+  display: flex;
+  gap: 6px;
+}
+.changelog-detail-title {
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--fg);
+  margin: 0;
+}
+.changelog-detail-meta {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
+  font-size: 12.5px;
+  color: var(--fg-muted);
+}
+.changelog-detail-link {
+  border: none;
+  background: transparent;
+  color: var(--accent);
+  font-size: 12.5px;
+  cursor: pointer;
+  padding: 0;
+}
+.changelog-detail-link:hover {
+  text-decoration: underline;
+}
+
+/* AI insight block */
+.changelog-insight {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px 18px;
+  border: 0.5px solid var(--home-line);
+  border-radius: 12px;
+  background: var(--home-card);
+}
+.changelog-insight-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.changelog-insight-h {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin: 0;
+}
+.changelog-insight-summary {
+  font-size: 14.5px;
+  line-height: 1.55;
+  color: var(--fg);
+  margin: 0;
+}
+.changelog-insight-loading {
+  font-size: 13.5px;
+  color: var(--fg-muted);
+  margin: 0;
+}
+.changelog-insight-none {
+  font-size: 13px;
+  color: var(--fg-muted);
+  font-style: italic;
+  margin: 4px 0 0;
+}
+.changelog-insight-error {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 13px;
+  color: #c44a1f;
+}
+.changelog-regen {
+  align-self: flex-start;
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 0.5px solid var(--home-line);
+  background: var(--bg);
+  color: var(--fg-muted);
+  font-size: 12px;
+  cursor: pointer;
+}
+.changelog-regen:hover {
+  background: var(--home-card-hover);
+  color: var(--fg);
+}
+
+/* the high-bar "worth writing about" highlight */
+.changelog-highlight {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 12px 14px;
+  margin-top: 4px;
+  border-radius: 10px;
+  border: 0.5px solid var(--home-accent-border);
+  background: var(--home-accent-soft);
+}
+.changelog-highlight-tag {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.changelog-highlight-angle {
+  font-size: 15px;
+  font-weight: 650;
+  line-height: 1.3;
+  color: var(--fg);
+}
+.changelog-highlight-content {
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--fg);
+  margin: 0;
+}
+
+/* PR description markdown — constrain the shared markdown-body */
+.changelog-body-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.changelog-body.markdown-body {
+  font-size: 13.5px;
+  background: transparent;
+  color: var(--fg);
+}
+

--- a/src/Changelog.tsx
+++ b/src/Changelog.tsx
@@ -1,0 +1,437 @@
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  type ConnectorStatusEvent,
+  type ContributionInsight,
+  type GithubContribution,
+  getContributionInsight,
+  hasGithubConnector,
+  listConnectors,
+  listGithubContributions,
+  syncConnectorNow,
+} from "./file";
+import { IconBrand } from "./icons";
+import { render as renderMarkdown } from "./markdown";
+
+type FilterId = "all" | "delivered" | "wip";
+
+/// A merged PR is a "delivered feature"; an open / closed PR is work in
+/// progress. (Commits were dropped — the changelog is PR-only.)
+function isDelivered(c: GithubContribution): boolean {
+  return c.state === "merged";
+}
+
+/// The timestamp the changelog sorts and groups by: merge time for
+/// merged PRs, otherwise creation time.
+function effectiveMs(c: GithubContribution): number {
+  return c.merged_at_ms ?? c.created_at_ms;
+}
+
+function badge(c: GithubContribution): { label: string; cls: string } {
+  if (c.state === "merged") return { label: "Delivered", cls: "delivered" };
+  if (c.state === "open") return { label: "Open PR", cls: "open" };
+  return { label: "Closed PR", cls: "closed" };
+}
+
+function dayKey(ms: number): string {
+  const d = new Date(ms);
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+}
+
+function dayLabel(ms: number): string {
+  const d = new Date(ms);
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(today.getDate() - 1);
+  if (dayKey(ms) === dayKey(today.getTime())) return "Today";
+  if (dayKey(ms) === dayKey(yesterday.getTime())) return "Yesterday";
+  return d.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: d.getFullYear() === today.getFullYear() ? undefined : "numeric",
+  });
+}
+
+function timeLabel(ms: number): string {
+  return new Date(ms).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function fullDateLabel(ms: number): string {
+  return new Date(ms).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+type DayGroup = { key: string; label: string; items: GithubContribution[] };
+
+function groupByDay(items: GithubContribution[]): DayGroup[] {
+  const groups: DayGroup[] = [];
+  let current: DayGroup | null = null;
+  for (const c of items) {
+    const ms = effectiveMs(c);
+    const key = dayKey(ms);
+    if (!current || current.key !== key) {
+      current = { key, label: dayLabel(ms), items: [] };
+      groups.push(current);
+    }
+    current.items.push(c);
+  }
+  return groups;
+}
+
+/// The GitHub changelog feed (#165). PR-only. Reads
+/// `github_contributions`, refetches on every `connector-status` event,
+/// and drills into a per-PR detail view with an AI summary + a high-bar
+/// "worth writing about" highlight.
+export function ChangelogView({ onOpenSettings }: { onOpenSettings: () => void }) {
+  const [items, setItems] = useState<GithubContribution[]>([]);
+  const [hasConnector, setHasConnector] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<FilterId>("all");
+  const [syncing, setSyncing] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const refresh = async () => {
+    try {
+      const [connected, list] = await Promise.all([
+        hasGithubConnector(),
+        listGithubContributions(),
+      ]);
+      setHasConnector(connected);
+      setItems(list);
+    } catch (e) {
+      console.error("[changelog] refresh failed:", e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+    void (async () => {
+      const fn = await listen<ConnectorStatusEvent>("connector-status", () => {
+        void refresh();
+      });
+      if (cancelled) fn();
+      else unlisten = fn;
+    })();
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  const onSyncNow = async () => {
+    setSyncing(true);
+    try {
+      const conns = await listConnectors();
+      const gh = conns.find((c) => c.kind === "github");
+      if (gh) await syncConnectorNow(gh.id);
+    } catch (e) {
+      console.error("[changelog] sync now failed:", e);
+    } finally {
+      setTimeout(() => setSyncing(false), 1500);
+    }
+  };
+
+  const deliveredCount = useMemo(() => items.filter(isDelivered).length, [items]);
+  const wipCount = items.length - deliveredCount;
+
+  const filtered = useMemo(() => {
+    if (filter === "delivered") return items.filter(isDelivered);
+    if (filter === "wip") return items.filter((c) => !isDelivered(c));
+    return items;
+  }, [items, filter]);
+
+  const groups = useMemo(() => groupByDay(filtered), [filtered]);
+
+  // Detail view takes over the panel when a PR is selected.
+  const selected = useMemo(
+    () => items.find((c) => c.id === selectedId) ?? null,
+    [items, selectedId],
+  );
+  if (selected) {
+    return (
+      <ChangelogDetail
+        contribution={selected}
+        onBack={() => setSelectedId(null)}
+      />
+    );
+  }
+
+  return (
+    <div className="changelog-view">
+      <div className="changelog-toolbar">
+        <div className="changelog-filters">
+          <button
+            type="button"
+            className={"changelog-filter" + (filter === "all" ? " active" : "")}
+            onClick={() => setFilter("all")}
+          >
+            All <span className="changelog-filter-count">{items.length}</span>
+          </button>
+          <button
+            type="button"
+            className={"changelog-filter" + (filter === "delivered" ? " active" : "")}
+            onClick={() => setFilter("delivered")}
+          >
+            Delivered <span className="changelog-filter-count">{deliveredCount}</span>
+          </button>
+          <button
+            type="button"
+            className={"changelog-filter" + (filter === "wip" ? " active" : "")}
+            onClick={() => setFilter("wip")}
+          >
+            In progress <span className="changelog-filter-count">{wipCount}</span>
+          </button>
+        </div>
+        {hasConnector && (
+          <button
+            type="button"
+            className="changelog-sync"
+            onClick={onSyncNow}
+            disabled={syncing}
+            title="Pull the latest PRs now (otherwise polled every 15 min)"
+          >
+            {syncing ? "Syncing…" : "Sync now"}
+          </button>
+        )}
+      </div>
+
+      {loading ? (
+        <p className="settings-placeholder">Loading…</p>
+      ) : hasConnector === false ? (
+        <div className="settings-empty">
+          <div className="settings-empty-title">GitHub not connected</div>
+          <div className="settings-empty-body">
+            Connect a GitHub account in Settings → Connectors to build your
+            changelog. Margin polls every 15 minutes for your pull requests —
+            merged PRs are delivered features, open ones are work in progress —
+            and backfills the last 30 days on first connect.
+          </div>
+          <button
+            type="button"
+            className="changelog-connect-cta"
+            onClick={onOpenSettings}
+          >
+            Open Settings
+          </button>
+        </div>
+      ) : items.length === 0 ? (
+        <div className="settings-empty">
+          <div className="settings-empty-title">No pull requests yet</div>
+          <div className="settings-empty-body">
+            Connected — the first sync (backfilling the last 30 days) runs
+            within 15 seconds. Hit “Sync now” to pull immediately.
+          </div>
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="settings-empty">
+          <div className="settings-empty-title">Nothing here</div>
+          <div className="settings-empty-body">
+            No {filter === "delivered" ? "delivered features" : "in-progress PRs"}{" "}
+            in your changelog yet.
+          </div>
+        </div>
+      ) : (
+        <div className="changelog-groups">
+          {groups.map((g) => (
+            <div key={g.key} className="changelog-group">
+              <div className="changelog-day">{g.label}</div>
+              <div className="changelog-list">
+                {g.items.map((c) => {
+                  const b = badge(c);
+                  return (
+                    <button
+                      key={c.id}
+                      type="button"
+                      className="changelog-row"
+                      onClick={() => setSelectedId(c.id)}
+                      title="View summary & insight"
+                    >
+                      <span className="changelog-icon changelog-icon-pr">
+                        <IconBrand kind="github" size={15} />
+                      </span>
+                      <div className="changelog-row-body">
+                        <div className="changelog-row-title">{c.title}</div>
+                        <div className="changelog-row-meta">
+                          <span className="changelog-repo">{c.repo}</span>
+                          <span className="changelog-sep">·</span>
+                          <span>{timeLabel(effectiveMs(c))}</span>
+                          {c.ai_generated_ms != null && (
+                            <span
+                              className="changelog-insight-dot"
+                              title="Insight ready"
+                            >
+                              ✦
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <span className={`changelog-badge changelog-badge-${b.cls}`}>
+                        {b.label}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/// Per-PR detail: title, repo, GitHub link, the AI summary + optional
+/// high-bar highlight, and the PR description rendered as markdown.
+function ChangelogDetail({
+  contribution,
+  onBack,
+}: {
+  contribution: GithubContribution;
+  onBack: () => void;
+}) {
+  const c = contribution;
+  const b = badge(c);
+  const [insight, setInsight] = useState<ContributionInsight | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async (regenerate: boolean) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await getContributionInsight(c.id, regenerate);
+      setInsight(r);
+    } catch (e) {
+      setError(
+        typeof e === "string"
+          ? e
+          : e instanceof Error
+          ? e.message
+          : "Failed to generate insight",
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [c.id]);
+
+  const theme = document.documentElement.dataset.theme || "light";
+  const when =
+    c.state === "merged" && c.merged_at_ms != null
+      ? `Merged ${fullDateLabel(c.merged_at_ms)}`
+      : `Opened ${fullDateLabel(c.created_at_ms)}`;
+  const bodyHtml = useMemo(
+    () => (c.body ? renderMarkdown(c.body) : ""),
+    [c.body],
+  );
+
+  return (
+    <div className="changelog-detail">
+      <button type="button" className="changelog-detail-back" onClick={onBack}>
+        ← Changelog
+      </button>
+
+      <div className="changelog-detail-head">
+        <div className="changelog-detail-badges">
+          <span className={`changelog-badge changelog-badge-${b.cls}`}>{b.label}</span>
+        </div>
+        <h1 className="changelog-detail-title">{c.title}</h1>
+        <div className="changelog-detail-meta">
+          <span className="changelog-repo">{c.repo}</span>
+          <span className="changelog-sep">·</span>
+          <span>{when}</span>
+          <span className="changelog-sep">·</span>
+          <button
+            type="button"
+            className="changelog-detail-link"
+            onClick={() => void openUrl(c.url)}
+          >
+            Open on GitHub ↗
+          </button>
+        </div>
+      </div>
+
+      <section className="changelog-insight">
+        <div className="changelog-insight-head">
+          <h2 className="changelog-insight-h">Summary</h2>
+          {insight && !loading && (
+            <button
+              type="button"
+              className="changelog-regen"
+              onClick={() => void load(true)}
+              title="Generate a fresh insight"
+            >
+              Regenerate
+            </button>
+          )}
+        </div>
+
+        {loading ? (
+          <p className="changelog-insight-loading">Analyzing this PR…</p>
+        ) : error ? (
+          <div className="changelog-insight-error">
+            {error.includes("API key")
+              ? "Add your Anthropic API key in Settings → AI to generate changelog insights."
+              : error}
+            <button
+              type="button"
+              className="changelog-regen"
+              onClick={() => void load(false)}
+            >
+              Retry
+            </button>
+          </div>
+        ) : insight ? (
+          <>
+            <p className="changelog-insight-summary">{insight.summary}</p>
+            {insight.highlight ? (
+              <div className="changelog-highlight">
+                <div className="changelog-highlight-tag">✦ Worth writing about</div>
+                <div className="changelog-highlight-angle">
+                  {insight.highlight.angle}
+                </div>
+                <p className="changelog-highlight-content">
+                  {insight.highlight.content}
+                </p>
+              </div>
+            ) : (
+              <p className="changelog-insight-none">
+                No standout angle for a post here.
+              </p>
+            )}
+          </>
+        ) : null}
+      </section>
+
+      {c.body && c.body.trim() ? (
+        <section className="changelog-body-section">
+          <h2 className="changelog-insight-h">Description</h2>
+          <article
+            className="markdown-body changelog-body"
+            data-theme={theme}
+            dangerouslySetInnerHTML={{ __html: bodyHtml }}
+          />
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -15,12 +15,14 @@ import { MoreMenu } from "./MoreMenu";
 import { type NotificationRecord, unreadCount } from "./notifications";
 import { NotificationsPanel } from "./NotificationsPanel";
 import { ChatPage } from "./ChatPage";
+import { ChangelogView } from "./Changelog";
 import { SearchPalette } from "./SearchPalette";
 import { TeamView } from "./Team";
 import { WorkstreamsView } from "./Workstreams";
 import {
   IconArchive,
   IconBell,
+  IconBrand,
   IconBriefcase,
   IconChevRight,
   IconHome,
@@ -81,6 +83,7 @@ type NavId =
   | "home"
   | "chat"
   | "workstreams"
+  | "changelog"
   | "favorites"
   | "archive"
   | "team";
@@ -432,6 +435,7 @@ export function Home({
       "home",
       "chat",
       "workstreams",
+      "changelog",
       "favorites",
       "archive",
       "team",
@@ -682,6 +686,8 @@ export function Home({
             onOpenNote={onOpen}
             onChanged={onWorkstreamsChanged}
           />
+        ) : nav === "changelog" ? (
+          <ChangelogView onOpenSettings={onOpenSettings} />
         ) : (
           <>
             <NotesFeed
@@ -776,6 +782,12 @@ function Sidebar({
           label="Workstreams"
           active={active === "workstreams"}
           onClick={() => onSelect("workstreams")}
+        />
+        <NavItem
+          icon={<IconBrand kind="github" size={14} />}
+          label="Changelog"
+          active={active === "changelog"}
+          onClick={() => onSelect("changelog")}
         />
         <NavItem
           icon={<IconUser size={14} sw={1.7} />}
@@ -1015,6 +1027,7 @@ function renderScopedActions(
           </button>
         </>
       );
+    case "changelog":
     case "favorites":
     case "archive":
     case "home":
@@ -1027,6 +1040,8 @@ function pageHeaderTitle(nav: NavId): string {
   switch (nav) {
     case "workstreams":
       return "Workstreams";
+    case "changelog":
+      return "Changelog";
     case "team":
       return "Team";
     case "favorites":

--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -4,6 +4,7 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
   type ConnectorInfo,
   type ConnectorStatusEvent,
+  connectGithub,
   deleteAnthropicApiKey,
   deleteConnector,
   deleteFirecrawlApiKey,
@@ -27,6 +28,7 @@ import {
 import { PromptInspector } from "./PromptInspector";
 import type { ChatMessageView } from "./ChatMessage";
 import {
+  IconBrand,
   IconChevLeft,
   IconEdit,
   IconHome,
@@ -468,6 +470,10 @@ function ConnectorsSection() {
           ))}
         </div>
       )}
+      <GitHubConnectCard
+        connected={connectors.some((c) => c.kind === "github")}
+        onConnected={() => void refresh()}
+      />
       {pickerOpen && (
         <ConnectorPickerModal
           providers={providers}
@@ -475,6 +481,87 @@ function ConnectorsSection() {
         />
       )}
     </section>
+  );
+}
+
+/// GitHub connects via a personal access token rather than OAuth (no
+/// build-time client id needed), so it gets its own card below the OAuth
+/// connectors. Once connected it also shows up as a regular connector
+/// row above — this card stays for rotating the token.
+function GitHubConnectCard({
+  connected,
+  onConnected,
+}: {
+  connected: boolean;
+  onConnected: () => void;
+}) {
+  const [token, setToken] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onConnect = async () => {
+    const value = token.trim();
+    if (!value) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await connectGithub(value);
+      setToken("");
+      onConnected();
+    } catch (e) {
+      setError(
+        typeof e === "string"
+          ? e
+          : e instanceof Error
+          ? e.message
+          : "Failed to connect GitHub",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="github-card">
+      <div className="github-card-head">
+        <IconBrand kind="github" size={16} />
+        <span className="github-card-title">GitHub</span>
+        {connected && <span className="github-card-badge">Connected</span>}
+      </div>
+      <p className="settings-section-intro">
+        {connected
+          ? "Connected. Paste a new token to rotate it — or manage / remove the connector above."
+          : "Build a changelog from your GitHub activity: merged pull requests as delivered features, commits as work in progress. Polled every 15 minutes; the last 30 days are backfilled on connect."}
+      </p>
+      <div className="settings-actions">
+        <input
+          type="password"
+          className="settings-input"
+          placeholder="ghp_… or github_pat_…"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void onConnect();
+          }}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <button
+          className="ghost"
+          onClick={() => void onConnect()}
+          disabled={busy || !token.trim()}
+        >
+          {busy ? "Connecting…" : connected ? "Update token" : "Connect"}
+        </button>
+      </div>
+      {error && <div className="settings-error">{error}</div>}
+      <span className="settings-hint">
+        Create a token at GitHub → Settings → Developer settings → Personal
+        access tokens. Classic tokens need the <code>repo</code> scope (or{" "}
+        <code>public_repo</code> for public repos only). Stored only in your
+        macOS keychain.
+      </span>
+    </div>
   );
 }
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -688,6 +688,78 @@ export async function syncConnectorNow(connectorId: string): Promise<void> {
   return invoke<void>("sync_connector_now", { connectorId });
 }
 
+// --- GitHub connector + changelog (#165) ---------------------------------
+
+/** One GitHub contribution: a pull request (`kind: "pr"`) or a commit
+ *  (`kind: "commit"`). Merged PRs (`state: "merged"`) are delivered
+ *  features; everything else is work in progress. */
+export type GithubContribution = {
+  id: string;
+  connector_id: string;
+  external_id: string;
+  kind: "pr";
+  state: "merged" | "open" | "closed";
+  title: string;
+  body: string | null;
+  repo: string;
+  url: string;
+  author_login: string;
+  author_avatar_url: string | null;
+  created_at_ms: number;
+  merged_at_ms: number | null;
+  modified_ms: number;
+  ai_summary: string | null;
+  ai_highlight: string | null;
+  ai_generated_ms: number | null;
+};
+
+/** A blog/LinkedIn-worthy angle on a PR. Present only when the AI
+ *  cleared a deliberately high bar. */
+export type InsightHighlight = {
+  angle: string;
+  content: string;
+};
+
+/** AI changelog insight for one PR. `highlight` is null when nothing
+ *  rose to the "worth writing about" bar. */
+export type ContributionInsight = {
+  summary: string;
+  highlight: InsightHighlight | null;
+  generated_ms: number;
+  cached: boolean;
+};
+
+/** Validate a GitHub personal access token, store it, and create the
+ *  `github:<login>` connector. The runner backfills the last 30 days on
+ *  its next tick. Resolves to the new connector id; rejects with a
+ *  human-readable message if the token is invalid. */
+export async function connectGithub(token: string): Promise<string> {
+  return invoke<string>("connect_github", { token });
+}
+
+/** True when a GitHub connector is configured. */
+export async function hasGithubConnector(): Promise<boolean> {
+  return invoke<boolean>("has_github_connector");
+}
+
+/** Changelog feed — pull requests only, newest-first. */
+export async function listGithubContributions(
+  limit?: number,
+): Promise<GithubContribution[]> {
+  return invoke<GithubContribution[]>("list_github_contributions", { limit });
+}
+
+/** Fetch (and cache) the AI insight for one PR: a summary plus an
+ *  optional high-bar "worth writing about" highlight. Generated on
+ *  first call (needs the Anthropic key); pass `regenerate: true` to
+ *  force a fresh pass. */
+export async function getContributionInsight(
+  id: string,
+  regenerate = false,
+): Promise<ContributionInsight> {
+  return invoke<ContributionInsight>("get_contribution_insight", { id, regenerate });
+}
+
 // --- Calendar events (#63) -----------------------------------------------
 
 export type CalendarAttendee = {


### PR DESCRIPTION
## What

A GitHub integration that polls the authenticated user's pull requests every ~15 minutes and builds a changelog from them — **merged PRs = delivered features, open/closed PRs = work in progress**. The first sync backfills the last 30 days (rolling 30-day Search API window that also catches new PRs and state changes each poll). Auth is a **personal access token** in the keychain (no OAuth app / build-time client id).

## Highlights

- **DB**: migrations `044` (`github_contributions`) + `045` (lazy AI insight columns); accumulate-only upsert keyed on `(connector_id, external_id)`.
- **Connector**: `GitHubConnector` (15-min poll), Search API client, token validation, commit-row pruning (PR-only).
- **Search + AI**: contributions indexed into embeddings (`ref_kind: "github"`, surfaced by `search_similar`) **plus** a dedicated `search_changelog` tool the assistant can call.
- **Click-through detail**: a Claude-generated **summary** of what was implemented, and a **"worth writing about"** blog/LinkedIn angle shown only when it clears a high bar (grounded in the PR body + changed-file list; lazy + cached; regenerate available).
- **UI**: a `Changelog` sidebar page (day-grouped, `All / Delivered / In progress` filters, `Sync now`) and a Settings GitHub connect card.

## Verification

- `cargo test --lib`: **462 passed, 0 failed**
- `tsc` + `vite build`: clean
- Built, installed to `/Applications`, live DB migrated to schema v45.