### PR TITLE
Add an integrated todo list with due dates and reminders

### DIFF
--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -74,7 +74,8 @@ const SCHEMA_V42: &str = include_str!("migrations/042_drop_actions.sql");
 const SCHEMA_V43: &str = include_str!("migrations/043_drop_open_questions.sql");
 const SCHEMA_V44: &str = include_str!("migrations/044_github.sql");
 const SCHEMA_V45: &str = include_str!("migrations/045_github_insight.sql");
-const SCHEMA_VERSION: i64 = 45;
+const SCHEMA_V46: &str = include_str!("migrations/046_todos.sql");
+const SCHEMA_VERSION: i64 = 46;
 
 /// Register the sqlite-vec extension as an "auto extension" so every
 /// future `Connection::open*` in this process loads `vec0` (#104).
@@ -347,6 +348,10 @@ pub(crate) fn apply_migrations(conn: &Connection) -> Result<()> {
     if version == 44 {
         conn.execute_batch(SCHEMA_V45)?;
         version = 45;
+    }
+    if version == 45 {
+        conn.execute_batch(SCHEMA_V46)?;
+        version = 46;
     }
     if version != SCHEMA_VERSION {
         // Future: bump SCHEMA_VERSION and add another step above.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,9 +17,11 @@ mod observations;
 mod paths;
 mod profiles;
 mod reconcile;
+mod reminders;
 mod sharing;
 mod sysaudio;
 mod team;
+mod todos;
 mod transcribe;
 mod voice;
 mod workstreams;
@@ -491,6 +493,11 @@ pub fn run() {
             // Anthropic API key is configured.
             profiles::start_worker(app.handle().clone());
 
+            // Todo due-date reminder ticker (#166). Ticks every 30s,
+            // fires an OS notification per newly-due todo. Idle until a
+            // todo with a due date exists.
+            reminders::start(app.handle().clone());
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -585,6 +592,11 @@ pub fn run() {
             workstreams::commands::set_workstream_parent,
             activity::get_daily_activity,
             activity::list_recent_activity,
+            todos::list_todos,
+            todos::create_todo,
+            todos::update_todo,
+            todos::set_todo_done,
+            todos::delete_todo,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/migrations/046_todos.sql
+++ b/src-tauri/src/migrations/046_todos.sql
@@ -1,0 +1,28 @@
+-- Standalone todo list (#166).
+--
+-- A fresh, self-contained to-do feature — NOT the note-derived "actions"
+-- system that was removed in #162. Items are created directly (on the
+-- Todos page or via the command palette, by text or voice), carry an
+-- optional due date, and fire an OS notification when due.
+--
+-- `notified_ms` is stamped when the due reminder fires so the ticker
+-- never double-notifies. `source` records where the item came from
+-- ('page' | 'palette' | 'voice') for light analytics / debugging.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE todos (
+  id           TEXT PRIMARY KEY,
+  text         TEXT NOT NULL,
+  done         INTEGER NOT NULL DEFAULT 0,
+  due_ms       INTEGER,
+  created_ms   INTEGER NOT NULL,
+  modified_ms  INTEGER NOT NULL,
+  completed_ms INTEGER,
+  notified_ms  INTEGER,
+  source       TEXT NOT NULL DEFAULT 'page'
+);
+CREATE INDEX idx_todos_done ON todos(done);
+CREATE INDEX idx_todos_due ON todos(due_ms);
+
+UPDATE meta SET value = '46' WHERE key = 'schema_version';

--- a/src-tauri/src/reminders.rs
+++ b/src-tauri/src/reminders.rs
@@ -1,0 +1,87 @@
+//! Background reminder ticker for due todos (#166).
+//!
+//! Re-introduces the reminders ticker that was removed with the
+//! note-derived actions feature (#162) — now driven by the standalone
+//! `todos` table. Mirrors `connectors/runner.rs`: one
+//! `tauri::async_runtime::spawn` task ticking on a fixed interval,
+//! errors logged but never fatal.
+//!
+//! Each tick finds incomplete, dated todos that are due and haven't
+//! been notified, fires a native OS notification, and stamps
+//! `notified_ms` so the same todo never re-fires (rescheduling the due
+//! date re-arms it — see `todos::update`). A `todos-changed` event is
+//! emitted after a batch so the UI refreshes.
+
+use std::sync::Mutex;
+use std::time::Duration;
+
+use rusqlite::Connection;
+use tauri::{AppHandle, Emitter, Manager};
+use tauri_plugin_notification::NotificationExt;
+
+/// How often to check for due todos. Fine enough that a reminder fires
+/// within ~30s of its due time without busy-polling.
+const TICK_SECS: u64 = 30;
+
+/// Spawn the reminder ticker. Call once at app boot (in `lib.rs::setup`).
+pub fn start(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let mut tick = tokio::time::interval(Duration::from_secs(TICK_SECS));
+        // Skip the immediate tick so boot settles before any prompt.
+        tick.tick().await;
+        loop {
+            tick.tick().await;
+            if let Err(e) = tick_once(&app) {
+                eprintln!("[reminders] tick failed: {e}");
+            }
+        }
+    });
+}
+
+fn tick_once(app: &AppHandle) -> Result<(), String> {
+    let now = current_unix_ms();
+    let conn_state = app.state::<Mutex<Connection>>();
+
+    let due = {
+        let c = conn_state.lock().map_err(|e| e.to_string())?;
+        crate::todos::due_unnotified(&c, now).map_err(|e| e.to_string())?
+    };
+    if due.is_empty() {
+        return Ok(());
+    }
+
+    let mut any = false;
+    for todo in &due {
+        // `.show()` is synchronous; no lock is held across it.
+        let result = app
+            .notification()
+            .builder()
+            .title("Todo due")
+            .body(&todo.text)
+            .show();
+        if let Err(e) = result {
+            // Leave notified_ms unset so the next tick retries.
+            eprintln!("[reminders] notification failed: {e}");
+            continue;
+        }
+        let c = conn_state.lock().map_err(|e| e.to_string())?;
+        if let Err(e) = crate::todos::mark_notified(&c, &todo.id, now) {
+            eprintln!("[reminders] mark_notified failed: {e}");
+        }
+        any = true;
+    }
+
+    if any {
+        // Nudge the UI so overdue badges / the page refresh.
+        let _ = app.emit("todos-changed", ());
+    }
+    Ok(())
+}
+
+fn current_unix_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}

--- a/src-tauri/src/todos.rs
+++ b/src-tauri/src/todos.rs
@@ -1,0 +1,333 @@
+//! Standalone todo list (#166).
+//!
+//! A fresh, self-contained to-do feature — deliberately NOT the
+//! note-derived "actions" system removed in #162. Items are created
+//! directly (on the Todos page or via the command palette, by text or
+//! voice), carry an optional due date, and a background ticker
+//! (`reminders.rs`) fires an OS notification when one comes due.
+//!
+//! All write commands emit a `todos-changed` event so the page, the
+//! palette, and the notification bell stay in sync without polling.
+
+use std::sync::Mutex;
+
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Todo {
+    pub id: String,
+    pub text: String,
+    pub done: bool,
+    pub due_ms: Option<i64>,
+    pub created_ms: i64,
+    pub modified_ms: i64,
+    pub completed_ms: Option<i64>,
+}
+
+const SELECT_COLS: &str =
+    "id, text, done, due_ms, created_ms, modified_ms, completed_ms";
+
+fn row_to_todo(r: &rusqlite::Row<'_>) -> rusqlite::Result<Todo> {
+    Ok(Todo {
+        id: r.get(0)?,
+        text: r.get(1)?,
+        done: r.get::<_, i64>(2)? != 0,
+        due_ms: r.get(3)?,
+        created_ms: r.get(4)?,
+        modified_ms: r.get(5)?,
+        completed_ms: r.get(6)?,
+    })
+}
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+// ----- DB layer (also reused by the reminder ticker) ---------------------
+
+/// List todos for `scope`: "active" (incomplete), "completed", or "all".
+/// Active items sort by due date (soonest first, undated last), then
+/// newest-created; completed items sort by completion time, newest first.
+pub fn list(conn: &Connection, scope: &str) -> rusqlite::Result<Vec<Todo>> {
+    let sql = match scope {
+        "completed" => format!(
+            "SELECT {SELECT_COLS} FROM todos WHERE done = 1 \
+             ORDER BY completed_ms DESC LIMIT 500"
+        ),
+        "all" => format!(
+            "SELECT {SELECT_COLS} FROM todos \
+             ORDER BY done ASC, (due_ms IS NULL) ASC, due_ms ASC, created_ms DESC"
+        ),
+        // default "active"
+        _ => format!(
+            "SELECT {SELECT_COLS} FROM todos WHERE done = 0 \
+             ORDER BY (due_ms IS NULL) ASC, due_ms ASC, created_ms DESC"
+        ),
+    };
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], row_to_todo)?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+pub fn insert(
+    conn: &Connection,
+    text: &str,
+    due_ms: Option<i64>,
+    source: &str,
+) -> rusqlite::Result<Todo> {
+    let id = uuid::Uuid::new_v4().to_string();
+    let now = now_ms();
+    conn.execute(
+        "INSERT INTO todos(id, text, done, due_ms, created_ms, modified_ms, completed_ms, notified_ms, source) \
+         VALUES (?1, ?2, 0, ?3, ?4, ?4, NULL, NULL, ?5)",
+        params![id, text, due_ms, now, source],
+    )?;
+    Ok(Todo {
+        id,
+        text: text.to_string(),
+        done: false,
+        due_ms,
+        created_ms: now,
+        modified_ms: now,
+        completed_ms: None,
+    })
+}
+
+pub fn get(conn: &Connection, id: &str) -> rusqlite::Result<Option<Todo>> {
+    let sql = format!("SELECT {SELECT_COLS} FROM todos WHERE id = ?1");
+    conn.query_row(&sql, params![id], row_to_todo).optional()
+}
+
+/// Update the editable fields. Moving the due date clears `notified_ms`
+/// so a rescheduled item can notify again at its new time.
+pub fn update(
+    conn: &Connection,
+    id: &str,
+    text: &str,
+    due_ms: Option<i64>,
+) -> rusqlite::Result<Option<Todo>> {
+    conn.execute(
+        "UPDATE todos SET text = ?2, due_ms = ?3, modified_ms = ?4, \
+            notified_ms = CASE WHEN COALESCE(due_ms, -1) IS ?3 THEN notified_ms ELSE NULL END \
+         WHERE id = ?1",
+        params![id, text, due_ms, now_ms()],
+    )?;
+    get(conn, id)
+}
+
+pub fn set_done(conn: &Connection, id: &str, done: bool) -> rusqlite::Result<Option<Todo>> {
+    let now = now_ms();
+    conn.execute(
+        "UPDATE todos SET done = ?2, completed_ms = ?3, modified_ms = ?4 WHERE id = ?1",
+        params![id, done as i64, if done { Some(now) } else { None }, now],
+    )?;
+    get(conn, id)
+}
+
+pub fn delete(conn: &Connection, id: &str) -> rusqlite::Result<()> {
+    conn.execute("DELETE FROM todos WHERE id = ?1", params![id])?;
+    Ok(())
+}
+
+/// Incomplete, dated todos that are due now and haven't been notified.
+/// Drives the reminder ticker.
+pub fn due_unnotified(conn: &Connection, now: i64) -> rusqlite::Result<Vec<Todo>> {
+    let sql = format!(
+        "SELECT {SELECT_COLS} FROM todos \
+         WHERE done = 0 AND due_ms IS NOT NULL AND due_ms <= ?1 AND notified_ms IS NULL \
+         ORDER BY due_ms ASC"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params![now], row_to_todo)?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(row?);
+    }
+    Ok(out)
+}
+
+pub fn mark_notified(conn: &Connection, id: &str, now: i64) -> rusqlite::Result<()> {
+    conn.execute(
+        "UPDATE todos SET notified_ms = ?2 WHERE id = ?1",
+        params![id, now],
+    )?;
+    Ok(())
+}
+
+/// Count of incomplete todos that are overdue (past due as of `now`).
+/// Used for the sidebar / bell badge.
+pub fn overdue_count(conn: &Connection, now: i64) -> rusqlite::Result<i64> {
+    conn.query_row(
+        "SELECT COUNT(*) FROM todos WHERE done = 0 AND due_ms IS NOT NULL AND due_ms <= ?1",
+        params![now],
+        |r| r.get(0),
+    )
+}
+
+// ----- Tauri commands -----------------------------------------------------
+
+#[tauri::command]
+pub fn list_todos(
+    scope: Option<String>,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<Vec<Todo>, String> {
+    let c = conn.lock().map_err(|e| e.to_string())?;
+    list(&c, scope.as_deref().unwrap_or("active")).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn create_todo(
+    text: String,
+    due_ms: Option<i64>,
+    source: Option<String>,
+    app: AppHandle,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<Todo, String> {
+    let text = text.trim().to_string();
+    if text.is_empty() {
+        return Err("Todo text is empty.".to_string());
+    }
+    let todo = {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        insert(&c, &text, due_ms, source.as_deref().unwrap_or("page")).map_err(|e| e.to_string())?
+    };
+    let _ = app.emit("todos-changed", ());
+    Ok(todo)
+}
+
+#[tauri::command]
+pub fn update_todo(
+    id: String,
+    text: String,
+    due_ms: Option<i64>,
+    app: AppHandle,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<Option<Todo>, String> {
+    let text = text.trim().to_string();
+    if text.is_empty() {
+        return Err("Todo text is empty.".to_string());
+    }
+    let todo = {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        update(&c, &id, &text, due_ms).map_err(|e| e.to_string())?
+    };
+    let _ = app.emit("todos-changed", ());
+    Ok(todo)
+}
+
+#[tauri::command]
+pub fn set_todo_done(
+    id: String,
+    done: bool,
+    app: AppHandle,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<Option<Todo>, String> {
+    let todo = {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        set_done(&c, &id, done).map_err(|e| e.to_string())?
+    };
+    let _ = app.emit("todos-changed", ());
+    Ok(todo)
+}
+
+#[tauri::command]
+pub fn delete_todo(
+    id: String,
+    app: AppHandle,
+    conn: tauri::State<'_, Mutex<Connection>>,
+) -> Result<(), String> {
+    {
+        let c = conn.lock().map_err(|e| e.to_string())?;
+        delete(&c, &id).map_err(|e| e.to_string())?;
+    }
+    let _ = app.emit("todos-changed", ());
+    Ok(())
+}
+
+// ----- Tests --------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::index::apply_migrations(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn insert_list_and_complete() {
+        let conn = open_db();
+        let a = insert(&conn, "buy milk", None, "page").unwrap();
+        insert(&conn, "ship release", Some(1_000), "palette").unwrap();
+
+        let active = list(&conn, "active").unwrap();
+        assert_eq!(active.len(), 2);
+        // Dated item sorts before the undated one.
+        assert_eq!(active[0].text, "ship release");
+        assert_eq!(active[1].text, "buy milk");
+
+        set_done(&conn, &a.id, true).unwrap();
+        assert_eq!(list(&conn, "active").unwrap().len(), 1);
+        let done = list(&conn, "completed").unwrap();
+        assert_eq!(done.len(), 1);
+        assert!(done[0].completed_ms.is_some());
+    }
+
+    #[test]
+    fn due_notification_lifecycle() {
+        let conn = open_db();
+        let t = insert(&conn, "call dentist", Some(500), "page").unwrap();
+        // Not yet due at t=400.
+        assert!(due_unnotified(&conn, 400).unwrap().is_empty());
+        // Due at t=600.
+        let due = due_unnotified(&conn, 600).unwrap();
+        assert_eq!(due.len(), 1);
+        mark_notified(&conn, &t.id, 600).unwrap();
+        // Won't fire again.
+        assert!(due_unnotified(&conn, 999).unwrap().is_empty());
+    }
+
+    #[test]
+    fn rescheduling_due_clears_notified() {
+        let conn = open_db();
+        let t = insert(&conn, "x", Some(500), "page").unwrap();
+        mark_notified(&conn, &t.id, 600).unwrap();
+        assert!(due_unnotified(&conn, 999).unwrap().is_empty());
+        // Move the due date out — notified_ms should clear so it can
+        // fire again at the new time.
+        update(&conn, &t.id, "x", Some(5_000)).unwrap();
+        assert!(due_unnotified(&conn, 6_000).unwrap().len() == 1);
+    }
+
+    #[test]
+    fn editing_text_keeps_notified_flag() {
+        let conn = open_db();
+        let t = insert(&conn, "x", Some(500), "page").unwrap();
+        mark_notified(&conn, &t.id, 600).unwrap();
+        // Same due date, just a text edit — must NOT re-arm the reminder.
+        update(&conn, &t.id, "x edited", Some(500)).unwrap();
+        assert!(due_unnotified(&conn, 999).unwrap().is_empty());
+    }
+
+    #[test]
+    fn overdue_count_counts_incomplete_past_due() {
+        let conn = open_db();
+        insert(&conn, "a", Some(100), "page").unwrap();
+        insert(&conn, "b", Some(100_000), "page").unwrap();
+        let done = insert(&conn, "c", Some(100), "page").unwrap();
+        set_done(&conn, &done.id, true).unwrap();
+        assert_eq!(overdue_count(&conn, 1_000).unwrap(), 1);
+    }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -7729,3 +7729,312 @@ button.workstream-external-chip:hover {
   color: var(--fg);
 }
 
+/* ---------- Todos (#166) --------------------------------------------- */
+.todo-view {
+  padding: 22px 32px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 760px;
+}
+
+.todo-composer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 0.5px solid var(--home-line);
+  border-radius: 10px;
+  background: var(--home-card);
+}
+.todo-composer-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--fg);
+  font-size: 14px;
+  outline: none;
+}
+.todo-composer-due {
+  border: 0.5px solid var(--home-line);
+  border-radius: 7px;
+  background: var(--bg);
+  color: var(--fg-muted);
+  font-size: 12px;
+  padding: 4px 6px;
+  font-family: inherit;
+}
+.todo-composer-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 12px;
+  border-radius: 7px;
+  border: 0.5px solid var(--home-accent-border);
+  background: var(--home-accent-soft);
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 550;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.todo-composer-add:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.todo-composer-add:not(:disabled):hover {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.todo-tabs {
+  display: flex;
+  gap: 6px;
+}
+.todo-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 11px;
+  border-radius: 999px;
+  border: 0.5px solid var(--home-line);
+  background: var(--bg);
+  color: var(--fg-muted);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.todo-tab:hover {
+  background: var(--home-chip);
+  color: var(--fg);
+}
+.todo-tab.active {
+  background: var(--home-accent-soft);
+  border-color: var(--home-accent-border);
+  color: var(--accent);
+}
+.todo-tab-count {
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  opacity: 0.75;
+}
+
+.todo-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.todo-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.todo-group-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  padding-left: 2px;
+}
+.todo-group-head.todo-group-overdue {
+  color: #c44a1f;
+}
+[data-theme="dark"] .todo-group-head.todo-group-overdue {
+  color: #e8825b;
+}
+.todo-group-count {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.7;
+}
+
+.todo-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.todo-row {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 9px 12px;
+  border-radius: 9px;
+  border: 0.5px solid transparent;
+  background: var(--home-card);
+}
+.todo-row:hover {
+  background: var(--home-card-hover);
+  border-color: var(--home-line);
+}
+.todo-row:hover .todo-delete {
+  opacity: 1;
+}
+.todo-row.done {
+  opacity: 0.62;
+}
+
+.todo-check {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border);
+  background: transparent;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.todo-check:hover {
+  border-color: var(--accent);
+}
+.todo-check.checked {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.todo-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.todo-text {
+  border: none;
+  background: transparent;
+  color: var(--fg);
+  font-size: 14px;
+  text-align: left;
+  cursor: text;
+  padding: 0;
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.todo-row.done .todo-text {
+  text-decoration: line-through;
+}
+.todo-edit-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  border-bottom: 1px solid var(--accent);
+  background: transparent;
+  color: var(--fg);
+  font-size: 14px;
+  outline: none;
+  padding: 0 0 1px;
+}
+
+.todo-due-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+.todo-due {
+  border: 0.5px solid var(--home-line);
+  border-radius: 6px;
+  background: var(--home-chip);
+  color: var(--fg-muted);
+  font-size: 11.5px;
+  padding: 2px 8px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.todo-due:hover {
+  color: var(--fg);
+}
+.todo-due.overdue {
+  color: #c44a1f;
+  background: color-mix(in srgb, #c44a1f 12%, transparent);
+  border-color: color-mix(in srgb, #c44a1f 28%, transparent);
+  font-weight: 550;
+}
+[data-theme="dark"] .todo-due.overdue {
+  color: #e8825b;
+}
+.todo-due-clear {
+  border: none;
+  background: transparent;
+  color: var(--fg-muted);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 2px;
+  opacity: 0.6;
+}
+.todo-due-clear:hover {
+  opacity: 1;
+  color: #c44a1f;
+}
+.todo-due-add {
+  border: 0.5px dashed var(--home-line);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--fg-muted);
+  font-size: 11.5px;
+  padding: 2px 8px;
+  cursor: pointer;
+  flex-shrink: 0;
+  opacity: 0.8;
+}
+.todo-due-add:hover {
+  opacity: 1;
+  color: var(--accent);
+  border-color: var(--home-accent-border);
+}
+.todo-due-input {
+  border: 0.5px solid var(--accent);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 11.5px;
+  padding: 2px 6px;
+  font-family: inherit;
+  flex-shrink: 0;
+}
+
+.todo-delete {
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 6px;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+.todo-delete:hover {
+  color: #c44a1f;
+  background: color-mix(in srgb, #c44a1f 10%, transparent);
+}
+
+/* command palette: the pinned "Create todo" row + added confirmation */
+.palette-result-todo .palette-result-icon {
+  color: var(--accent);
+}
+.palette-empty-inline {
+  padding: 8px 14px 4px;
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+.palette-added {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--accent);
+}
+

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -6,6 +6,7 @@ import {
   type ConnectorStatusEvent,
   listCalendarEvents,
   listConnectors,
+  listTodos,
   type NoteListItem,
   openOrCreateEventNote,
 } from "./file";
@@ -16,6 +17,7 @@ import { type NotificationRecord, unreadCount } from "./notifications";
 import { NotificationsPanel } from "./NotificationsPanel";
 import { ChatPage } from "./ChatPage";
 import { ChangelogView } from "./Changelog";
+import { TodosView } from "./Todos";
 import { SearchPalette } from "./SearchPalette";
 import { TeamView } from "./Team";
 import { WorkstreamsView } from "./Workstreams";
@@ -24,6 +26,7 @@ import {
   IconBell,
   IconBrand,
   IconBriefcase,
+  IconChecklist,
   IconChevRight,
   IconHome,
   IconMic,
@@ -84,6 +87,7 @@ type NavId =
   | "chat"
   | "workstreams"
   | "changelog"
+  | "todos"
   | "favorites"
   | "archive"
   | "team";
@@ -126,6 +130,43 @@ function useConnectorHealthAlert(): boolean {
     };
   }, []);
   return hasError;
+}
+
+/// Dot on the Todos nav item when any incomplete todo is overdue (#166).
+/// Refetches on every `todos-changed` event and re-checks once a minute
+/// so a todo crossing its due time lights up without a manual refresh.
+function useTodosOverdueAlert(): boolean {
+  const [overdue, setOverdue] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = async () => {
+      try {
+        const list = await listTodos("active");
+        if (cancelled) return;
+        const now = Date.now();
+        setOverdue(list.some((t) => t.due_ms != null && t.due_ms <= now));
+      } catch (e) {
+        if (!cancelled) console.error("[home] listTodos failed:", e);
+      }
+    };
+    void refresh();
+    let unlisten: UnlistenFn | null = null;
+    (async () => {
+      const fn = await listen("todos-changed", () => void refresh());
+      if (cancelled) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    })();
+    const tick = setInterval(() => void refresh(), 60_000);
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+      clearInterval(tick);
+    };
+  }, []);
+  return overdue;
 }
 
 /// Live calendar data hook (#62). Returns mapped `UpcomingEvent`s for
@@ -436,6 +477,7 @@ export function Home({
       "chat",
       "workstreams",
       "changelog",
+      "todos",
       "favorites",
       "archive",
       "team",
@@ -480,6 +522,7 @@ export function Home({
 
   const { upcoming, raw: rawEvents, nowMs: eventsNowMs } = useUpcomingEvents();
   const settingsAlert = useConnectorHealthAlert();
+  const todosAlert = useTodosOverdueAlert();
 
   // Today-bound count for the greeting subline. Counts events whose
   // start falls between today's midnight and tomorrow's, ignoring
@@ -557,6 +600,7 @@ export function Home({
           onTagSelect={(t) => setTagFilter(t === tagFilter ? null : t)}
           onOpenSettings={onOpenSettings}
           settingsAlert={settingsAlert}
+          todosAlert={todosAlert}
           onOpenPalette={() => setPaletteOpen(true)}
           onNewNote={onNewNote}
           onNewMeeting={onNewMeeting}
@@ -688,6 +732,8 @@ export function Home({
           />
         ) : nav === "changelog" ? (
           <ChangelogView onOpenSettings={onOpenSettings} />
+        ) : nav === "todos" ? (
+          <TodosView />
         ) : (
           <>
             <NotesFeed
@@ -724,6 +770,7 @@ function Sidebar({
   onTagSelect,
   onOpenSettings,
   settingsAlert,
+  todosAlert,
   onOpenPalette,
   onNewNote,
   onNewMeeting,
@@ -738,6 +785,8 @@ function Sidebar({
    *  is errored (#141). Lets the user notice broken sync from anywhere
    *  in the app, not just by visiting Settings → Connectors. */
   settingsAlert: boolean;
+  /** Dot on the Todos nav item when any incomplete todo is overdue. */
+  todosAlert: boolean;
   onOpenPalette: () => void;
   /** Global compose CTAs. The Greeting on Home renders these inline;
    *  on every other nav we surface them from the sidebar footer
@@ -788,6 +837,13 @@ function Sidebar({
           label="Changelog"
           active={active === "changelog"}
           onClick={() => onSelect("changelog")}
+        />
+        <NavItem
+          icon={<IconChecklist size={14} sw={1.7} />}
+          label="Todos"
+          active={active === "todos"}
+          alert={todosAlert}
+          onClick={() => onSelect("todos")}
         />
         <NavItem
           icon={<IconUser size={14} sw={1.7} />}
@@ -1028,6 +1084,7 @@ function renderScopedActions(
         </>
       );
     case "changelog":
+    case "todos":
     case "favorites":
     case "archive":
     case "home":
@@ -1042,6 +1099,8 @@ function pageHeaderTitle(nav: NavId): string {
       return "Workstreams";
     case "changelog":
       return "Changelog";
+    case "todos":
+      return "Todos";
     case "team":
       return "Team";
     case "favorites":

--- a/src/SearchPalette.tsx
+++ b/src/SearchPalette.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import {
+  createTodo,
   searchNotes,
   SEARCH_HIGHLIGHT_CLOSE,
   SEARCH_HIGHLIGHT_OPEN,
@@ -11,6 +12,7 @@ import {
 import { LevelMeter } from "./LevelMeter";
 import {
   IconArrowRight,
+  IconChecklist,
   IconFileText,
   IconMic,
   IconSearch,
@@ -58,6 +60,14 @@ export function SearchPalette({ open, onClose, onOpenNote, onOpenWorkstream }: P
   const [activeIdx, setActiveIdx] = useState(0);
   const [voiceState, setVoiceState] = useState<VoiceState>({ kind: "off" });
   const voiceModeActive = voiceState.kind !== "off";
+  // Brief "✓ Added …" confirmation after creating a todo from the palette.
+  const [justAdded, setJustAdded] = useState<string | null>(null);
+  // True for the one search pass right after a voice capture, so the
+  // "Create todo" row (not the first note hit) becomes the active row —
+  // dictating a todo then pressing Enter commits it.
+  const voiceCaptured = useRef(false);
+  // Where the current query text came from, stamped onto created todos.
+  const inputSource = useRef<"palette" | "voice">("palette");
 
   const { messages, isStreaming, sendMessage } = useChat();
 
@@ -101,7 +111,10 @@ export function SearchPalette({ open, onClose, onOpenNote, onOpenWorkstream }: P
         const results = await searchNotes(trimmed, 20);
         if (queryGen.current !== gen) return;
         setHits(results);
-        setActiveIdx(0);
+        // After a voice capture, jump to the "Create todo" row (which
+        // sits just past the note hits) so Enter commits the dictation.
+        setActiveIdx(voiceCaptured.current ? results.length : 0);
+        voiceCaptured.current = false;
       } catch (err) {
         if (queryGen.current !== gen) return;
         console.error("[search] failed:", err);
@@ -207,6 +220,12 @@ export function SearchPalette({ open, onClose, onOpenNote, onOpenWorkstream }: P
         setVoiceState({ kind: "didnt-catch", message: r.text });
         return;
       }
+      // A dictation in the palette is treated as a todo capture: the
+      // transcript lands in the box and the search pass promotes the
+      // "Create todo" row to active (see the debounce effect) so a
+      // single Enter commits it. The user can still arrow up to search.
+      voiceCaptured.current = true;
+      inputSource.current = "voice";
       setQuery((prev) => {
         const sep = prev.length > 0 && !prev.endsWith(" ") ? " " : "";
         return prev + sep + r.text;
@@ -246,6 +265,29 @@ export function SearchPalette({ open, onClose, onOpenNote, onOpenWorkstream }: P
     await sendMessage(trimmed);
   };
 
+  // Create a todo from the current query (typed or dictated). Keeps the
+  // palette open and clears the box so several can be captured in a row
+  // — handy for voice. A brief confirmation replaces the empty prompt.
+  const createTodoFromPalette = async (text: string) => {
+    const trimmed = text.trim();
+    if (trimmed.length === 0) return;
+    const source = inputSource.current;
+    try {
+      await createTodo(trimmed, null, source);
+      setJustAdded(trimmed);
+      setQuery("");
+      setHits([]);
+      setActiveIdx(0);
+      inputSource.current = "palette";
+      window.setTimeout(() => {
+        setJustAdded((cur) => (cur === trimmed ? null : cur));
+      }, 2600);
+      setTimeout(() => inputRef.current?.focus(), 0);
+    } catch (err) {
+      console.error("[palette] create todo failed:", err);
+    }
+  };
+
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Escape") {
       e.preventDefault();
@@ -265,15 +307,29 @@ export function SearchPalette({ open, onClose, onOpenNote, onOpenWorkstream }: P
         if (query.trim().length > 0) submitChatTurn(query);
         return;
       }
-      if (hits.length === 0) return;
+      const hasQuery = query.trim().length > 0;
+      // The "Create todo" row sits just past the note hits.
+      const todoIdx = hits.length;
+      // Shift+Enter: create a todo from the current query, no matter
+      // which row is active.
+      if (e.key === "Enter" && e.shiftKey) {
+        e.preventDefault();
+        if (hasQuery) void createTodoFromPalette(query);
+        return;
+      }
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        setActiveIdx((i) => Math.min(i + 1, hits.length - 1));
+        const max = hasQuery ? todoIdx : hits.length - 1;
+        setActiveIdx((i) => Math.min(i + 1, Math.max(max, 0)));
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
         setActiveIdx((i) => Math.max(i - 1, 0));
       } else if (e.key === "Enter") {
         e.preventDefault();
+        if (hasQuery && activeIdx === todoIdx) {
+          void createTodoFromPalette(query);
+          return;
+        }
         const hit = hits[activeIdx];
         if (hit) {
           onOpenNote(hit.note_path);
@@ -329,7 +385,10 @@ export function SearchPalette({ open, onClose, onOpenNote, onOpenWorkstream }: P
               className="palette-input"
               placeholder={placeholder}
               value={query}
-              onChange={(e) => setQuery(e.target.value)}
+              onChange={(e) => {
+                inputSource.current = "palette";
+                setQuery(e.target.value);
+              }}
               disabled={mode === "chat" && isStreaming}
               spellCheck={false}
               autoCorrect="off"
@@ -370,11 +429,13 @@ export function SearchPalette({ open, onClose, onOpenNote, onOpenWorkstream }: P
             hits={hits}
             loading={loading}
             activeIdx={activeIdx}
+            justAdded={justAdded}
             onHover={setActiveIdx}
             onPick={(path) => {
               onOpenNote(path);
               onClose();
             }}
+            onCreateTodo={() => void createTodoFromPalette(query)}
           />
         ) : (
           <Conversation
@@ -398,7 +459,8 @@ export function SearchPalette({ open, onClose, onOpenNote, onOpenWorkstream }: P
             </span>
           ) : (
             <span>
-              <kbd>↵</kbd> open · <kbd>⌘↵</kbd> ask AI · <kbd>esc</kbd> close
+              <kbd>↵</kbd> open · <kbd>⌘↵</kbd> ask · <kbd>⇧↵</kbd> todo ·{" "}
+              <kbd>esc</kbd> close
             </span>
           )}
         </div>
@@ -444,28 +506,46 @@ function SearchResults({
   hits,
   loading,
   activeIdx,
+  justAdded,
   onHover,
   onPick,
+  onCreateTodo,
 }: {
   ref: React.RefObject<HTMLDivElement | null>;
   query: string;
   hits: SearchHit[];
   loading: boolean;
   activeIdx: number;
+  justAdded: string | null;
   onHover: (idx: number) => void;
   onPick: (path: string) => void;
+  onCreateTodo: () => void;
 }) {
+  const q = query.trim();
+  if (q.length === 0) {
+    return (
+      <div className="palette-results" ref={ref} role="listbox">
+        {justAdded ? (
+          <div className="palette-empty palette-added">
+            <IconChecklist size={13} sw={1.8} /> Added “{justAdded}” to todos
+          </div>
+        ) : (
+          <div className="palette-empty">
+            Type to search across all your notes — titles, bodies, and meeting
+            transcripts. <kbd>⌘↵</kbd> asks AI · <kbd>⇧↵</kbd> creates a todo ·
+            hold <kbd>space</kbd> to dictate.
+          </div>
+        )}
+      </div>
+    );
+  }
+  const todoIdx = hits.length;
   return (
     <div className="palette-results" ref={ref} role="listbox">
-      {query.trim().length === 0 ? (
-        <div className="palette-empty">
-          Type to search across all your notes — titles, bodies, and meeting
-          transcripts. Press <kbd>⌘↵</kbd> to ask AI instead.
-        </div>
-      ) : loading && hits.length === 0 ? (
-        <div className="palette-empty">Searching…</div>
+      {loading && hits.length === 0 ? (
+        <div className="palette-empty-inline">Searching…</div>
       ) : hits.length === 0 ? (
-        <div className="palette-empty">No matches.</div>
+        <div className="palette-empty-inline">No note matches.</div>
       ) : (
         hits.map((hit, idx) => (
           <ResultRow
@@ -478,6 +558,22 @@ function SearchResults({
           />
         ))
       )}
+      <button
+        type="button"
+        className={"palette-result palette-result-todo" + (activeIdx === todoIdx ? " is-active" : "")}
+        data-row-idx={todoIdx}
+        onMouseEnter={() => onHover(todoIdx)}
+        onClick={onCreateTodo}
+      >
+        <span className="palette-result-icon" aria-hidden="true">
+          <IconChecklist size={14} sw={1.7} />
+        </span>
+        <span className="palette-result-body">
+          <span className="palette-result-title">Create todo</span>
+          <span className="palette-result-snippet">“{q}”</span>
+        </span>
+        <span className="palette-result-source">⇧↵</span>
+      </button>
     </div>
   );
 }

--- a/src/Todos.tsx
+++ b/src/Todos.tsx
@@ -1,0 +1,377 @@
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  createTodo,
+  deleteTodo,
+  listTodos,
+  setTodoDone,
+  type Todo,
+  updateTodo,
+} from "./file";
+import { IconCheck, IconPlus, IconTrash } from "./icons";
+
+// ---- date helpers --------------------------------------------------------
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/// ms → the value a <input type="datetime-local"> expects (local time).
+function msToLocalInput(ms: number): string {
+  const d = new Date(ms);
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
+    d.getHours(),
+  )}:${pad(d.getMinutes())}`;
+}
+
+function localInputToMs(v: string): number | null {
+  if (!v) return null;
+  const ms = new Date(v).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function sameDay(a: number, b: number): boolean {
+  const da = new Date(a);
+  const db = new Date(b);
+  return (
+    da.getFullYear() === db.getFullYear() &&
+    da.getMonth() === db.getMonth() &&
+    da.getDate() === db.getDate()
+  );
+}
+
+/// Friendly due label: "Today 3:00 PM", "Tomorrow 9:00 AM", "Mon, Jun 16".
+function dueLabel(ms: number): string {
+  const now = Date.now();
+  const d = new Date(ms);
+  const time = d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  if (sameDay(ms, now)) return `Today ${time}`;
+  if (sameDay(ms, tomorrow.getTime())) return `Tomorrow ${time}`;
+  const day = d.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: d.getFullYear() === new Date().getFullYear() ? undefined : "numeric",
+  });
+  return `${day}, ${time}`;
+}
+
+type GroupKey = "overdue" | "today" | "upcoming" | "someday";
+const GROUP_LABEL: Record<GroupKey, string> = {
+  overdue: "Overdue",
+  today: "Today",
+  upcoming: "Upcoming",
+  someday: "No date",
+};
+
+function groupActive(todos: Todo[], now: number): { key: GroupKey; items: Todo[] }[] {
+  const buckets: Record<GroupKey, Todo[]> = {
+    overdue: [],
+    today: [],
+    upcoming: [],
+    someday: [],
+  };
+  for (const t of todos) {
+    if (t.due_ms == null) buckets.someday.push(t);
+    else if (t.due_ms < now) buckets.overdue.push(t);
+    else if (sameDay(t.due_ms, now)) buckets.today.push(t);
+    else buckets.upcoming.push(t);
+  }
+  return (["overdue", "today", "upcoming", "someday"] as GroupKey[])
+    .filter((k) => buckets[k].length > 0)
+    .map((k) => ({ key: k, items: buckets[k] }));
+}
+
+// ---- composer ------------------------------------------------------------
+
+function TodoComposer({ onCreated }: { onCreated: () => void }) {
+  const [text, setText] = useState("");
+  const [due, setDue] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const add = async () => {
+    const t = text.trim();
+    if (!t || busy) return;
+    setBusy(true);
+    try {
+      await createTodo(t, localInputToMs(due), "page");
+      setText("");
+      setDue("");
+      onCreated();
+    } catch (e) {
+      console.error("[todos] create failed:", e);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="todo-composer">
+      <input
+        className="todo-composer-input"
+        placeholder="Add a todo…"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            void add();
+          }
+        }}
+        autoFocus
+      />
+      <input
+        type="datetime-local"
+        className="todo-composer-due"
+        value={due}
+        onChange={(e) => setDue(e.target.value)}
+        title="Due date (optional)"
+      />
+      <button
+        type="button"
+        className="todo-composer-add"
+        onClick={() => void add()}
+        disabled={!text.trim() || busy}
+      >
+        <IconPlus size={13} sw={2} />
+        Add
+      </button>
+    </div>
+  );
+}
+
+// ---- row -----------------------------------------------------------------
+
+function TodoRow({ todo, onChanged }: { todo: Todo; onChanged: () => void }) {
+  const [editing, setEditing] = useState(false);
+  const [text, setText] = useState(todo.text);
+  const [editingDue, setEditingDue] = useState(false);
+  const dueRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => setText(todo.text), [todo.text]);
+
+  const overdue = !todo.done && todo.due_ms != null && todo.due_ms < Date.now();
+
+  const saveText = async () => {
+    const t = text.trim();
+    setEditing(false);
+    if (!t || t === todo.text) {
+      setText(todo.text);
+      return;
+    }
+    try {
+      await updateTodo(todo.id, t, todo.due_ms);
+      onChanged();
+    } catch (e) {
+      console.error("[todos] update failed:", e);
+    }
+  };
+
+  const saveDue = async (ms: number | null) => {
+    setEditingDue(false);
+    try {
+      await updateTodo(todo.id, todo.text, ms);
+      onChanged();
+    } catch (e) {
+      console.error("[todos] set due failed:", e);
+    }
+  };
+
+  return (
+    <div className={"todo-row" + (todo.done ? " done" : "")}>
+      <button
+        type="button"
+        className={"todo-check" + (todo.done ? " checked" : "")}
+        onClick={() => void setTodoDone(todo.id, !todo.done).then(onChanged)}
+        aria-label={todo.done ? "Mark not done" : "Mark done"}
+      >
+        {todo.done && <IconCheck size={11} sw={2.4} />}
+      </button>
+
+      <div className="todo-main">
+        {editing ? (
+          <input
+            className="todo-edit-input"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void saveText();
+              if (e.key === "Escape") {
+                setText(todo.text);
+                setEditing(false);
+              }
+            }}
+            onBlur={() => void saveText()}
+            autoFocus
+          />
+        ) : (
+          <button
+            type="button"
+            className="todo-text"
+            onClick={() => !todo.done && setEditing(true)}
+            title={todo.done ? "" : "Click to edit"}
+          >
+            {todo.text}
+          </button>
+        )}
+
+        {editingDue ? (
+          <input
+            ref={dueRef}
+            type="datetime-local"
+            className="todo-due-input"
+            defaultValue={todo.due_ms != null ? msToLocalInput(todo.due_ms) : ""}
+            onChange={(e) => void saveDue(localInputToMs(e.target.value))}
+            onBlur={() => setEditingDue(false)}
+            autoFocus
+          />
+        ) : todo.due_ms != null ? (
+          <span className="todo-due-wrap">
+            <button
+              type="button"
+              className={"todo-due" + (overdue ? " overdue" : "")}
+              onClick={() => setEditingDue(true)}
+            >
+              {dueLabel(todo.due_ms)}
+            </button>
+            <button
+              type="button"
+              className="todo-due-clear"
+              title="Remove due date"
+              onClick={() => void saveDue(null)}
+            >
+              ×
+            </button>
+          </span>
+        ) : (
+          <button
+            type="button"
+            className="todo-due-add"
+            onClick={() => setEditingDue(true)}
+          >
+            + Due date
+          </button>
+        )}
+      </div>
+
+      <button
+        type="button"
+        className="todo-delete"
+        title="Delete"
+        onClick={() => void deleteTodo(todo.id).then(onChanged)}
+      >
+        <IconTrash size={13} sw={1.7} />
+      </button>
+    </div>
+  );
+}
+
+// ---- page ----------------------------------------------------------------
+
+export function TodosView() {
+  const [active, setActive] = useState<Todo[]>([]);
+  const [completed, setCompleted] = useState<Todo[]>([]);
+  const [tab, setTab] = useState<"active" | "completed">("active");
+  const [loading, setLoading] = useState(true);
+  const [now, setNow] = useState(() => Date.now());
+
+  const refresh = async () => {
+    try {
+      const [a, c] = await Promise.all([listTodos("active"), listTodos("completed")]);
+      setActive(a);
+      setCompleted(c);
+      setNow(Date.now());
+    } catch (e) {
+      console.error("[todos] refresh failed:", e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+    void (async () => {
+      const fn = await listen("todos-changed", () => void refresh());
+      if (cancelled) fn();
+      else unlisten = fn;
+    })();
+    // Re-evaluate overdue grouping each minute even without changes.
+    const tick = setInterval(() => setNow(Date.now()), 60_000);
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+      clearInterval(tick);
+    };
+  }, []);
+
+  const groups = useMemo(() => groupActive(active, now), [active, now]);
+
+  return (
+    <div className="todo-view">
+      <TodoComposer onCreated={() => void refresh()} />
+
+      <div className="todo-tabs">
+        <button
+          type="button"
+          className={"todo-tab" + (tab === "active" ? " active" : "")}
+          onClick={() => setTab("active")}
+        >
+          Active <span className="todo-tab-count">{active.length}</span>
+        </button>
+        <button
+          type="button"
+          className={"todo-tab" + (tab === "completed" ? " active" : "")}
+          onClick={() => setTab("completed")}
+        >
+          Completed <span className="todo-tab-count">{completed.length}</span>
+        </button>
+      </div>
+
+      {loading ? (
+        <p className="settings-placeholder">Loading…</p>
+      ) : tab === "active" ? (
+        active.length === 0 ? (
+          <div className="settings-empty">
+            <div className="settings-empty-title">No todos yet</div>
+            <div className="settings-empty-body">
+              Add one above, or capture it anywhere with the command palette
+              (⌘K) — by typing, or hold Space to dictate.
+            </div>
+          </div>
+        ) : (
+          <div className="todo-groups">
+            {groups.map((g) => (
+              <div key={g.key} className="todo-group">
+                <div className={"todo-group-head todo-group-" + g.key}>
+                  {GROUP_LABEL[g.key]}
+                  <span className="todo-group-count">{g.items.length}</span>
+                </div>
+                <div className="todo-list">
+                  {g.items.map((t) => (
+                    <TodoRow key={t.id} todo={t} onChanged={() => void refresh()} />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )
+      ) : completed.length === 0 ? (
+        <div className="settings-empty">
+          <div className="settings-empty-title">Nothing completed yet</div>
+          <div className="settings-empty-body">Finished todos land here.</div>
+        </div>
+      ) : (
+        <div className="todo-list">
+          {completed.map((t) => (
+            <TodoRow key={t.id} todo={t} onChanged={() => void refresh()} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/file.ts
+++ b/src/file.ts
@@ -760,6 +760,52 @@ export async function getContributionInsight(
   return invoke<ContributionInsight>("get_contribution_insight", { id, regenerate });
 }
 
+// --- Todos (#166) --------------------------------------------------------
+
+/** A standalone to-do item. `due_ms` is optional; a background ticker
+ *  fires an OS notification when an incomplete item comes due. */
+export type Todo = {
+  id: string;
+  text: string;
+  done: boolean;
+  due_ms: number | null;
+  created_ms: number;
+  modified_ms: number;
+  completed_ms: number | null;
+};
+
+export type TodoScope = "active" | "completed" | "all";
+
+export async function listTodos(scope: TodoScope = "active"): Promise<Todo[]> {
+  return invoke<Todo[]>("list_todos", { scope });
+}
+
+/** Create a todo. `source` records the entry point: "page" | "palette"
+ *  | "voice". */
+export async function createTodo(
+  text: string,
+  dueMs: number | null = null,
+  source = "page",
+): Promise<Todo> {
+  return invoke<Todo>("create_todo", { text, dueMs, source });
+}
+
+export async function updateTodo(
+  id: string,
+  text: string,
+  dueMs: number | null,
+): Promise<Todo | null> {
+  return invoke<Todo | null>("update_todo", { id, text, dueMs });
+}
+
+export async function setTodoDone(id: string, done: boolean): Promise<Todo | null> {
+  return invoke<Todo | null>("set_todo_done", { id, done });
+}
+
+export async function deleteTodo(id: string): Promise<void> {
+  return invoke<void>("delete_todo", { id });
+}
+
 // --- Calendar events (#63) -----------------------------------------------
 
 export type CalendarAttendee = {


### PR DESCRIPTION
## What

A standalone to-do feature — items carry an optional **due date**, and a background ticker fires a native **OS notification** when one comes due. Deliberately *not* the note-derived "actions" system removed in #162; these are first-class, directly-created todos.

## Create from anywhere
- **Todos page** (new sidebar nav): inline composer (text + datetime-local), Active/Completed tabs, due grouping (**Overdue / Today / Upcoming / No date**) with overdue styling, inline text/due editing, check + delete.
- **Command palette** (⌘K): by **typing** — a pinned "Create todo" row + **⇧↵** to commit; or by **voice** — hold Space to dictate, the transcript lands in the box and promotes the todo row so one Enter commits it. Created items keep the palette open with a confirmation for rapid capture.

## Notifications
`reminders.rs` re-introduces the reminder ticker (connector-runner style): every 30s it finds incomplete, dated, un-notified todos, fires `app.notification()…show()`, and stamps `notified_ms`. Rescheduling a due date re-arms it. A sidebar dot flags overdue items in-app.

## Backend
- migration `046`: `todos` table.
- `todos.rs`: CRUD + scoped lists + due-notify helpers as Tauri commands; each write emits `todos-changed`.

## Verification
- `cargo test --lib`: **467 passed, 0 failed** (incl. the full reminder lifecycle: finds due, stamps notified, reschedule re-arms, text-edit doesn't).
- `tsc` + `vite build`: clean.
- Built + installed to `/Applications`; live DB migrated to **schema v46**; a live smoke test confirmed the installed app's ticker fires a due notification end-to-end.